### PR TITLE
fix: icon position when has contentRight 

### DIFF
--- a/packages/nextui/src/input/input-icon-clear.tsx
+++ b/packages/nextui/src/input/input-icon-clear.tsx
@@ -64,7 +64,7 @@ const InputIconClear: React.FC<Props> = ({
           margin: 0;
           display: inline-flex;
           align-items: center;
-          height: 100%;
+          height: auto;
           padding: 0 ${theme.layout.gapHalf};
           cursor: ${disabled ? 'not-allowed' : 'pointer'};
           box-sizing: border-box;
@@ -76,6 +76,7 @@ const InputIconClear: React.FC<Props> = ({
         }
         .has-content-right {
           padding: 0;
+          position: relative;
           transform: translateX(30%);
         }
         .visible {

--- a/packages/nextui/src/input/input.tsx
+++ b/packages/nextui/src/input/input.tsx
@@ -12,8 +12,8 @@ import { ContentPosition } from '../utils/prop-types';
 import InputLabel from './input-label';
 import InputBlockLabel from './input-block-label';
 import InputContent from './input-content';
-import InputClearIcon from './input-icon-clear';
-import Textarea from '../textarea/textarea';
+import InputIconClear from './input-icon-clear';
+import Textarea from '../textarea';
 import InputPassword from './input-password';
 import { getSizes, getColors } from './styles';
 import { getId } from '../utils/collections';
@@ -283,7 +283,7 @@ const Input = React.forwardRef<
               {...inputProps}
             />
             {clearable && (
-              <InputClearIcon
+              <InputIconClear
                 status={status}
                 visible={Boolean(selfValue)}
                 hasContentRight={!!contentRight}


### PR DESCRIPTION
#61

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Position `relative` added when input has content at right, also the height was changed to `auto`

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->


### Screenshots - Animations
![Screenshot 2021-10-02 at 22 05 45](https://user-images.githubusercontent.com/30373425/135735941-e40bf9fc-777a-4ff6-a0f2-68bbe5776c17.png)