### PR TITLE
fix: options buttons only shows up when the live editor is open

### DIFF
--- a/packages/docs/src/components/playground/editor.tsx
+++ b/packages/docs/src/components/playground/editor.tsx
@@ -45,13 +45,13 @@ const Editor: React.FC = () => {
   return (
     <div className="editor">
       <details open={visible}>
-        <summary>
+        <summary onClick={clickHandler}>
           <Row
             justify="space-between"
             align="center"
             style={{ height: '100%', width: '100%' }}
           >
-            <Col className="action" onClick={clickHandler}>
+            <Col className="action left-side">
               <span className="arrow">
                 <RightIcon size={16} fill={theme.palette.accents_6} />
               </span>
@@ -109,13 +109,14 @@ const Editor: React.FC = () => {
           overflow: hidden;
           border-radius: ${theme.layout.radius};
         }
-        :global(.right-side) {
-          opacity: 0;
-          transition: opacity 0.25s ease;
-        }
         details[open] :global(.right-side) {
-          opacity: 1;
+          display: inline-flex !important;
         }
+
+        :global(.right-side) {
+          display: none !important;
+        }
+
         summary {
           display: flex;
           justify-content: space-between;


### PR DESCRIPTION
## [docs]/[live-editor]

#64 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context

Display mode changed to `none` when live-editor is not open and `flex-inline` when it is

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations

![Screenshot 2021-10-03 at 16 51 07](https://user-images.githubusercontent.com/30373425/135769343-be7b4531-ea18-42b1-b2de-b28b1704e88f.png)

<!-- Adding images or gif animations of your changes improves the understanding of your changes -->