### PR TITLE
Fix 38/button aria attributes

### DIFF
--- a/packages/docs/content/docs/components/button.mdx
+++ b/packages/docs/content/docs/components/button.mdx
@@ -427,27 +427,28 @@ import { Button } from '@nextui-org/react';
 
 #### Button Props
 
-| Attribute        | Type                                            | Accepted values                  | Description                               | Default   |
-| ---------------- | ----------------------------------------------- | -------------------------------- | ----------------------------------------- | --------- |
-| **color**        | `NormalColors` `string`                         | [NormalColors](#normal-colors)   | Change button color                       | `default` |
-| **size**         | `NormalSizes`                                   | [NormalSizes](#normal-sizes)     | Change button size                        | `medium`  |
-| **disabled**     | `boolean`                                       | `true/false`                     | Disable button                            | `false`   |
-| **bordered**     | `boolean`                                       | `true/false`                     | Bodered button                            | `false`   |
-| **flat**         | `boolean`                                       | `true/false`                     | Flat button                               | `false`   |
-| **rounded**      | `boolean`                                       | `true/false`                     | Rounded button                            | `false`   |
-| **ghost**        | `boolean`                                       | `true/false`                     | The opposite color                        | `false`   |
-| **shadow**       | `boolean`                                       | `true/false`                     | Display shadow effect                     | `false`   |
-| **loading**      | `boolean`                                       | `true/false`                     | Display loading indicator                 | `false`   |
-| **loaderType**   | `NormalLoaders`                                 | [NormalLoaders](#normal-loaders) | Change loader indicator                   | `default` |
-| **auto**         | `boolean`                                       | `true/false`                     | Autoscale button width                    | `false`   |
-| **animated**     | `boolean`                                       | `true/false`                     | Display drip and scale animation          | `true`    |
-| **borderWeight** | `NormalWeights`                                 | [NormalWeights](#normal-weights) | Border weight for `bordered` button       | `normal`  |
-| **onClick**      | `MouseEventHandler`                             | -                                | Button click handler                      | -         |
-| **icon**         | `ReactNode`                                     | -                                | Show icon in button                       | -         |
-| **iconRight**    | `ReactNode`                                     | -                                | Show icon on the other side of the button | -         |
-| **htmlType**     | `ButtonHTMLAttributes.type`                     | -                                | Native type of button element             | `button`  |
-| **ref**          | <Code>Ref<HTMLButtonElement &#124; null></Code> | -                                | forwardRef                                | -         |
-| ...              | `ButtonHTMLAttributes`                          | `'id', 'className', ...`         | Button native props                       | -         |
+| Attribute        | Type                                            | Accepted values                    | Description                               | Default   |
+| ---------------- | ----------------------------------------------- | ---------------------------------- | ----------------------------------------- | --------- |
+| **color**        | `NormalColors` `string`                         | [NormalColors](#normal-colors)     | Change button color                       | `default` |
+| **size**         | `NormalSizes`                                   | [NormalSizes](#normal-sizes)       | Change button size                        | `medium`  |
+| **disabled**     | `boolean`                                       | `true/false`                       | Disable button                            | `false`   |
+| **bordered**     | `boolean`                                       | `true/false`                       | Bodered button                            | `false`   |
+| **flat**         | `boolean`                                       | `true/false`                       | Flat button                               | `false`   |
+| **rounded**      | `boolean`                                       | `true/false`                       | Rounded button                            | `false`   |
+| **ghost**        | `boolean`                                       | `true/false`                       | The opposite color                        | `false`   |
+| **shadow**       | `boolean`                                       | `true/false`                       | Display shadow effect                     | `false`   |
+| **loading**      | `boolean`                                       | `true/false`                       | Display loading indicator                 | `false`   |
+| **loaderType**   | `NormalLoaders`                                 | [NormalLoaders](#normal-loaders)   | Change loader indicator                   | `default` |
+| **auto**         | `boolean`                                       | `true/false`                       | Autoscale button width                    | `false`   |
+| **animated**     | `boolean`                                       | `true/false`                       | Display drip and scale animation          | `true`    |
+| **borderWeight** | `NormalWeights`                                 | [NormalWeights](#normal-weights)   | Border weight for `bordered` button       | `normal`  |
+| **onClick**      | `MouseEventHandler`                             | -                                  | Button click handler                      | -         |
+| **icon**         | `ReactNode`                                     | -                                  | Show icon in button                       | -         |
+| **iconRight**    | `ReactNode`                                     | -                                  | Show icon on the other side of the button | -         |
+| **htmlType**     | `ButtonHTMLAttributes.type`                     | -                                  | Native type of button element             | `button`  |
+| **ref**          | <Code>Ref<HTMLButtonElement &#124; null></Code> | -                                  | forwardRef                                | -         |
+| ...              | `ButtonHTMLAttributes`                          | `'id', 'className', ...`           | Button native props                       | -         |
+| aria-...         | `AriaAttributes`                                | `'aria-label', 'aria-hidden', ...` | Aria attributes                           | -         |
 
 <Spacer y={2} />
 

--- a/packages/nextui/src/button/button.tsx
+++ b/packages/nextui/src/button/button.tsx
@@ -85,7 +85,7 @@ const Button = React.forwardRef<
   useImperativeHandle(ref, () => buttonRef.current);
   const groupConfig = useButtonGroupContext();
   const filteredProps = filterPropsWithGroup(btnProps, groupConfig);
-  /* eslint-disable @typescript-eslint/no-unused-vars */
+
   const {
     children,
     disabled,
@@ -105,6 +105,7 @@ const Button = React.forwardRef<
     loaderType,
     bordered,
     ghost,
+    tabIndex,
     style: buttonStyle,
     ...props
   } = filteredProps;
@@ -115,6 +116,7 @@ const Button = React.forwardRef<
     );
   }
   const hasIcon = icon || iconRight;
+  const onlyIcon = hasIcon && React.Children.count(children) === 0;
   const isRight = Boolean(iconRight);
 
   const { bg, color, loaderBg, border, style, hover } = useMemo(
@@ -188,6 +190,9 @@ const Button = React.forwardRef<
       className={`button ${className}`}
       disabled={disabled}
       onClick={clickHandler}
+      aria-label={typeof children === 'string' ? children : undefined}
+      role={onlyIcon ? 'presentation' : undefined}
+      tabIndex={!disabled ? tabIndex ?? 0 : -1}
       style={{
         ...style,
         ...buttonStyle
@@ -202,7 +207,7 @@ const Button = React.forwardRef<
           background={loaderBg}
         />
       )}
-      {React.Children.count(children) === 0 ? (
+      {onlyIcon ? (
         <ButtonIcon isRight={isRight} isSingle>
           {hasIcon}
         </ButtonIcon>


### PR DESCRIPTION
## [fix]/[button]
**TASK**: [Fix 38 - Add aria attributes to button](https://github.com/nextui-org/nextui/issues/38)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Add `aria-label` attribute to button with the value of its children
Add `role="presentation"` when there is only icon
Add `tabIndex=-1' if disabled or 0 is not passed as prop

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->