### PR TITLE
Fix 104/avatar resize img

### DIFF
--- a/packages/nextui/src/avatar/avatar.tsx
+++ b/packages/nextui/src/avatar/avatar.tsx
@@ -176,6 +176,9 @@ const Avatar: React.FC<AvatarProps> = ({
           background: ${theme.palette.background};
           border-radius: ${radius};
           transition: transform 250ms ease 0ms, opacity 200ms ease-in 0ms;
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
         }
         .avatar-ready {
           opacity: 1;

--- a/packages/nextui/src/avatar/avatar.tsx
+++ b/packages/nextui/src/avatar/avatar.tsx
@@ -145,7 +145,6 @@ const Avatar: React.FC<AvatarProps> = ({
           justify-content: center;
           align-items: center;
           box-sizing: border-box;
-          position: relative;
           overflow: hidden;
           border-radius: ${radius};
           vertical-align: top;
@@ -174,7 +173,6 @@ const Avatar: React.FC<AvatarProps> = ({
           z-index: 99;
           opacity: 0;
           display: flex;
-          border-radius: 50%;
           background: ${theme.palette.background};
           border-radius: ${radius};
           transition: transform 250ms ease 0ms, opacity 200ms ease-in 0ms;


### PR DESCRIPTION
## [fix]/[avatar]
**TASK**: [Fix avatar image resize](https://github.com/nextui-org/nextui/issues/104)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Resize large images to cover the avatar

### Screenshots - Animation
![Captura de pantalla 2021-11-01 a las 14 45 49](https://user-images.githubusercontent.com/9528363/139681744-2ca4b1ba-09df-4f5a-a709-f820080109bc.png)
![Captura de pantalla 2021-11-01 a las 14 45 59](https://user-images.githubusercontent.com/9528363/139681762-8a603267-468d-4e53-8351-44e62aa536cb.png)


