### PR TITLE
Fix #141

### DIFF
--- a/apps/docs/src/components/nav-link/index.tsx
+++ b/apps/docs/src/components/nav-link/index.tsx
@@ -47,7 +47,9 @@ const NavLink: React.FC<NavLinkProps> = ({
           </Link>
         ) : (
           <NextLink href={pathname || href}>
-            <Link onClick={() => !comingSoon && onClick}>{title}</Link>
+            <Link onClick={(e) => !comingSoon && onClick && onClick(e)}>
+              {title}
+            </Link>
           </NextLink>
         )
       }

--- a/apps/docs/src/layouts/navbar.tsx
+++ b/apps/docs/src/layouts/navbar.tsx
@@ -77,6 +77,12 @@ const Navbar: React.FC<Props> = ({ isHome, routes }) => {
     }
   }, [isMobile]);
 
+  useEffect(() => {
+    if (expanded) {
+      onToggleNavigation();
+    }
+  }, [router.asPath]);
+
   const onToggleNavigation = () => {
     setExpanded(!expanded);
     isMobile && setBodyHidden(!expanded);

--- a/apps/docs/src/layouts/navbar.tsx
+++ b/apps/docs/src/layouts/navbar.tsx
@@ -77,12 +77,6 @@ const Navbar: React.FC<Props> = ({ isHome, routes }) => {
     }
   }, [isMobile]);
 
-  useEffect(() => {
-    if (expanded) {
-      onToggleNavigation();
-    }
-  }, [router.asPath]);
-
   const onToggleNavigation = () => {
     setExpanded(!expanded);
     isMobile && setBodyHidden(!expanded);


### PR DESCRIPTION
## Docs/navbar
**TASK**: [Mobile navigation does not close when changing routes](https://github.com/nextui-org/nextui/issues/151)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Closing the drawer automatically when the route changes (if it is already expanded).
<!--- Why is this change required? What problem does it solve? -->
This change would be nice because when navigating on mobile is kinda annoying to keep closing manually the drawer.
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
To reproduce: check the issue.

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

https://user-images.githubusercontent.com/73541683/150659488-68422982-a679-4219-ad30-60c9a954f17d.mp4


