### PR TITLE
Fix #149

### DIFF
--- a/apps/docs/src/components/fixed/index.tsx
+++ b/apps/docs/src/components/fixed/index.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 import withDefaults from '@utils/with-defaults';
 import { styled, CSS } from '@nextui-org/react';
 
-export interface StickyProps {
+export interface FixedProps {
   offset?: number;
   shadow?: boolean;
   className?: string;
@@ -16,7 +16,7 @@ const defaultProps = {
   className: ''
 };
 
-const StyledSticky = styled('div', {
+const StyledFixed = styled('div', {
   background: 'transparent',
   position: 'fixed',
   zIndex: '$max',
@@ -29,7 +29,7 @@ const StyledSticky = styled('div', {
   }
 });
 
-const Sticky: React.FC<React.PropsWithChildren<StickyProps>> = ({
+const Fixed: React.FC<React.PropsWithChildren<FixedProps>> = ({
   offset,
   children,
   shadow,
@@ -37,16 +37,16 @@ const Sticky: React.FC<React.PropsWithChildren<StickyProps>> = ({
   css
 }) => {
   return (
-    <StyledSticky
+    <StyledFixed
       css={{ ...(css as any), top: offset || 0 }}
       className={cn(className, { shadow })}
       shadow={shadow}
     >
       {children}
-    </StyledSticky>
+    </StyledFixed>
   );
 };
 
-const MemoSticky = React.memo(Sticky);
+const MemoFixed = React.memo(Fixed);
 
-export default withDefaults(MemoSticky, defaultProps);
+export default withDefaults(MemoFixed, defaultProps);

--- a/apps/docs/src/components/index.ts
+++ b/apps/docs/src/components/index.ts
@@ -14,7 +14,7 @@ export { default as Playground } from './playground';
 export { default as Anchor } from './anchor';
 export { default as MDXComponents } from './mdx';
 export { default as TableOfContent } from './table-of-content';
-export { default as Sticky } from './fixed';
+export { default as Fixed } from './fixed';
 export { default as PageNav } from './page-nav';
 export { default as DotsContainer } from './dots-container';
 export { default as Palette } from './palette';

--- a/apps/docs/src/components/index.ts
+++ b/apps/docs/src/components/index.ts
@@ -14,7 +14,7 @@ export { default as Playground } from './playground';
 export { default as Anchor } from './anchor';
 export { default as MDXComponents } from './mdx';
 export { default as TableOfContent } from './table-of-content';
-export { default as Sticky } from './sticky';
+export { default as Sticky } from './fixed';
 export { default as PageNav } from './page-nav';
 export { default as DotsContainer } from './dots-container';
 export { default as Palette } from './palette';

--- a/apps/docs/src/components/sticky/index.tsx
+++ b/apps/docs/src/components/sticky/index.tsx
@@ -18,7 +18,7 @@ const defaultProps = {
 
 const StyledSticky = styled('div', {
   background: 'transparent',
-  position: 'sticky',
+  position: 'fixed',
   zIndex: '$max',
   variants: {
     shadow: {

--- a/apps/docs/src/layouts/docs.tsx
+++ b/apps/docs/src/layouts/docs.tsx
@@ -64,24 +64,25 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
             }
           }}
         >
-          <Sticky
-            offset={84}
-            className="docs__left-sidebar"
-            css={{
-              width: '28%',
-              maxHeight: 'calc(100vh - 4rem)',
-              overflow: 'auto',
-              display: 'none',
-              '::-webkit-scrollbar': {
-                width: '0px'
-              },
-              '@md': {
-                display: 'block'
-              }
-            }}
-          >
-            <Sidebar routes={routes} tag={tag} slug={slug} />
-          </Sticky>
+          <Col css={{ width: '28%' }}>
+            <Sticky
+              offset={84}
+              className="docs__left-sidebar"
+              css={{
+                maxHeight: 'calc(100vh - 4rem)',
+                overflow: 'auto',
+                display: 'none',
+                '::-webkit-scrollbar': {
+                  width: '0px'
+                },
+                '@md': {
+                  display: 'block'
+                }
+              }}
+            >
+              <Sidebar routes={routes} tag={tag} slug={slug} />
+            </Sticky>
+          </Col>
           <Col
             className="docs__center"
             css={{
@@ -107,19 +108,21 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
               )}
             </footer>
           </Col>
-          <Sticky
-            offset={84}
-            className="docs__right-sidebar"
-            css={{
-              width: '28%',
-              display: 'none',
-              '@lg': {
-                display: 'block'
-              }
-            }}
-          >
-            <TableOfContent headings={headings} />
-          </Sticky>
+          <Col css={{ width: '28%' }}>
+            <Sticky
+              offset={84}
+              className="docs__right-sidebar"
+              css={{
+                width: '28%',
+                display: 'none',
+                '@lg': {
+                  display: 'block'
+                }
+              }}
+            >
+              <TableOfContent headings={headings} />
+            </Sticky>
+          </Col>
           <StyledImg
             className="docs__gradient-blue"
             src="/gradient-left-dark.svg"

--- a/apps/docs/src/layouts/docs.tsx
+++ b/apps/docs/src/layouts/docs.tsx
@@ -9,7 +9,7 @@ import { Link } from '@nextui-org/react';
 import { Heading, getHeadings } from '@utils/get-headings';
 import { MetaProps } from '@lib/docs/meta';
 import Header from '@layouts/header';
-import { Sticky, PageNav } from '@components';
+import { Fixed, PageNav } from '@components';
 import { REPO_NAME, GITHUB_URL } from '@lib/github/constants';
 import { TAG, CONTENT_PATH } from '@lib/docs/config';
 import { StyledImg } from '@primitives';
@@ -65,7 +65,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
           }}
         >
           <Col css={{ width: '28%' }}>
-            <Sticky
+            <Fixed
               offset={92}
               className="docs__left-sidebar"
               css={{
@@ -81,7 +81,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
               }}
             >
               <Sidebar routes={routes} tag={tag} slug={slug} />
-            </Sticky>
+            </Fixed>
           </Col>
           <Col
             className="docs__center"
@@ -109,7 +109,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
             </footer>
           </Col>
           <Col css={{ width: '28%' }}>
-            <Sticky
+            <Fixed
               offset={92}
               className="docs__right-sidebar"
               css={{
@@ -121,7 +121,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
               }}
             >
               <TableOfContent headings={headings} />
-            </Sticky>
+            </Fixed>
           </Col>
           <StyledImg
             className="docs__gradient-blue"

--- a/apps/docs/src/layouts/docs.tsx
+++ b/apps/docs/src/layouts/docs.tsx
@@ -66,7 +66,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
         >
           <Col css={{ width: '28%' }}>
             <Sticky
-              offset={84}
+              offset={92}
               className="docs__left-sidebar"
               css={{
                 maxHeight: 'calc(100vh - 4rem)',
@@ -110,7 +110,7 @@ const DocsLayout: React.FC<React.PropsWithChildren<Props>> = ({
           </Col>
           <Col css={{ width: '28%' }}>
             <Sticky
-              offset={84}
+              offset={92}
               className="docs__right-sidebar"
               css={{
                 width: '28%',


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: [New docs UI sidebar glitches (overlays the navbar) when scrolling down](https://github.com/nextui-org/nextui/issues/149)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Changed from `position: sticky` to `position:fixed`.  The issue was happening because the sticky positioning is treated as relative in normal context and as fixed when scrolling. Once the parent container would reach its end of height, it would just push all the content upwards.

Corrected offset to match the previous position.

Renamed `Sticky` to `Fixed`.

### Screenshots - Animations
The **before** can be seen in Issue #149 .

**After:**

https://user-images.githubusercontent.com/73541683/150660378-b7338a66-150e-4f06-8a3c-2d819c95709d.mp4


Please let me know if there is anything that needs to be corrected/adjusted.

PS: The video is cropped because of the file size limit.


