### PR TITLE
fix(docs): space added to layout section top

### DIFF
--- a/apps/docs/content/docs/layout/container.mdx
+++ b/apps/docs/content/docs/layout/container.mdx
@@ -14,6 +14,8 @@ import { Container, Row, Col } from '@nextui-org/react';
 
 <CarbonAd />
 
+<Spacer y={2} />
+
 <Playground
   title="Default"
   desc="Container which sets a `max-width` and a default `gap` at each responsive breakpoint"

--- a/apps/docs/content/docs/layout/grid.mdx
+++ b/apps/docs/content/docs/layout/grid.mdx
@@ -14,6 +14,8 @@ import { Grid } from '@nextui-org/react';
 
 <CarbonAd />
 
+<Spacer y={2} />
+
 <Playground
   title="Default"
   desc="Dynamically scale container width while maintaining spacing."

--- a/apps/docs/content/docs/layout/spacer.mdx
+++ b/apps/docs/content/docs/layout/spacer.mdx
@@ -14,6 +14,8 @@ import { Spacer } from '@nextui-org/react';
 
 <CarbonAd />
 
+<Spacer y={2} />
+
 <Playground
   title="Vertical"
   code={`


### PR DESCRIPTION
Nice work folks! I'm already starting a project using this lib

I got a small layout bug, just an extra space to match everything else.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Just a  ```<Spacer y={2} />``` component was added under the  ```<CarbonAd />``` to follow the pattern of the other pages.

### Screenshots - Animations
![Screen Shot 2022-01-28 at 20 51 22](https://user-images.githubusercontent.com/3044907/151636833-f8548c9d-1015-47b1-8325-34595d4c9ce4.png)