### PR TITLE
fix responsive for ipad-h on home page

### DIFF
--- a/apps/docs/src/components/templates/shop-card/styles.ts
+++ b/apps/docs/src/components/templates/shop-card/styles.ts
@@ -70,7 +70,8 @@ export const TabText = styled('p', {
 
 export const ProductImageContainer = styled('div', {
   d: 'flex',
-  minSize: '200px',
+  minHeight: '200px',
+  width: '200px',
   br: '32px',
   position: 'relative',
   background: 'linear-gradient(135deg, #010187 0%,#18000E 100%)',


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]

NO TASK


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Fix responsive for the card demo on the home page. 

### Screenshots - Animations

#### Before
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/197471/151706916-4fd6e60a-f7c8-4b4b-bef1-1e8bf11a0594.png">

#### After 

<img width="1374" alt="image" src="https://user-images.githubusercontent.com/197471/151706882-1cd6cb80-9796-4bab-b6b9-a08c2c071f98.png">