### PR TITLE
Fixed Invisible Gradient Component When Highlighting it

### DIFF
--- a/apps/docs/src/components/hero/styles.ts
+++ b/apps/docs/src/components/hero/styles.ts
@@ -15,6 +15,9 @@ export const StyledTitle = styled('h1', {
 });
 
 export const StyledGradientTitle = styled(StyledTitle, {
+  '&::selection': {
+    WebkitTextFillColor: '$colors$text',
+  },
   textGradient: '180deg, #FF1CF7 25%, #b249f8 100%'
 });
 

--- a/apps/docs/src/components/primitives/index.ts
+++ b/apps/docs/src/components/primitives/index.ts
@@ -2,6 +2,9 @@ import { styled, Link } from '@nextui-org/react';
 import { lightTheme } from '@theme/shared';
 
 export const Title = styled('h1', {
+  '&::selection': {
+    WebkitTextFillColor: '$colors$text',
+  },
   display: 'inline',
   fontWeight: '$bold',
   color: '$text',

--- a/packages/react/src/theme/common.ts
+++ b/packages/react/src/theme/common.ts
@@ -455,10 +455,7 @@ export const defaultUtils = {
   textGradient: (value: Stitches.PropertyValue<'backgroundImage'>) => ({
     backgroundImage: `linear-gradient(${value})`,
     WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent',
-    '&::selection': {
-      WebkitTextFillColor: 'white',
-    }
+    WebkitTextFillColor: 'transparent'
   })
 };
 

--- a/packages/react/src/theme/common.ts
+++ b/packages/react/src/theme/common.ts
@@ -455,7 +455,10 @@ export const defaultUtils = {
   textGradient: (value: Stitches.PropertyValue<'backgroundImage'>) => ({
     backgroundImage: `linear-gradient(${value})`,
     WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent'
+    WebkitTextFillColor: 'transparent',
+    '&::selection': {
+      WebkitTextFillColor: 'white',
+    }
   })
 };
 


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: This PR Fixes #215 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
The Root Cause of this issue was that Gradient Component By Default Class was Set as Transparent which was causing Highlighted Part to Go Transparent too with Background Gradient . ~~This was NextUI Component Based Issue hence this PR Fixes on PR on fixing every Gradient Component~~

Latest Commit :- After the Latest Commit Changes are only applied to main website

### Screenshots - 


Before :-

![before](https://user-images.githubusercontent.com/47073516/152173321-1b9ad1ea-a77e-4c42-9894-21952b434c48.PNG)


After :- 


![after](https://user-images.githubusercontent.com/47073516/152173399-8d1844ac-bee1-474c-a8ed-3731c3348988.PNG)
 