### PR TITLE
Using Next Link component instead of router.push

### DIFF
--- a/apps/docs/src/components/features-grid/features-grid.tsx
+++ b/apps/docs/src/components/features-grid/features-grid.tsx
@@ -39,9 +39,9 @@ const FeaturesGrid: React.FC<FeaturesGridProps> = ({
   ...props
 }) => {
   const router = useRouter();
-  const handleClick = (href: string) => {
+  /*const handleClick = (href: string) => {
     router.push(href);
-  };
+  };*/
 
   return (
     <Grid.Container gap={2} css={{ px: 0, ...(css as any) }} {...props}>

--- a/apps/docs/src/components/features-grid/features-grid.tsx
+++ b/apps/docs/src/components/features-grid/features-grid.tsx
@@ -3,6 +3,7 @@ import { Grid, GridProps, Text, Row, CSS } from '@nextui-org/react';
 import { FeatureItem } from './styles';
 import withDefaults from '@utils/with-defaults';
 import { useRouter } from 'next/router';
+import Link from 'next/link'
 
 export interface Feature {
   title: string;
@@ -46,34 +47,38 @@ const FeaturesGrid: React.FC<FeaturesGridProps> = ({
     <Grid.Container gap={2} css={{ px: 0, ...(css as any) }} {...props}>
       {features.map((feat, index) => (
         <Grid key={`${feat.title}_${index}`} xs={xs} sm={sm} lg={lg}>
-          <FeatureItem
-            clickable={!!feat.href}
-            css={itemCss}
-            onClick={() => (feat.href ? handleClick(feat.href) : undefined)}
-          >
-            <Row align="center">
-              <div className="icon-wrapper">{feat.icon}</div>
-              <Text
-                className="feature-title"
-                css={{
-                  my: 0,
-                  fontSize: '1.1rem',
-                  fontWeight: '$semibold',
-                  ml: '$4'
-                }}
+          <Link href={feat.href}>
+            <a>
+              <FeatureItem
+                clickable={!!feat.href}
+                css={itemCss}
+                {/* onClick={() => (feat.href ? handleClick(feat.href) : undefined)}*/ }
               >
-                {feat.title}
-              </Text>
-            </Row>
-            <Row align="center" css={{ px: '$2', pt: '$4', pb: '$2' }}>
-              <Text
-                className="feature-description"
-                css={{ color: '$accents7' }}
-              >
-                {feat.description}
-              </Text>
-            </Row>
-          </FeatureItem>
+                <Row align="center">
+                  <div className="icon-wrapper">{feat.icon}</div>
+                  <Text
+                    className="feature-title"
+                    css={{
+                      my: 0,
+                      fontSize: '1.1rem',
+                      fontWeight: '$semibold',
+                      ml: '$4'
+                    }}
+                  >
+                    {feat.title}
+                  </Text>
+                </Row>
+                <Row align="center" css={{ px: '$2', pt: '$4', pb: '$2' }}>
+                  <Text
+                    className="feature-description"
+                    css={{ color: '$accents7' }}
+                  >
+                    {feat.description}
+                  </Text>
+                </Row>
+              </FeatureItem>
+            </a>
+          </Link>
         </Grid>
       ))}
     </Grid.Container>


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: Using the `router` by Next.js and `onClick`  handler defeats the whole purpose of links and removes all the accessibility. This PR replaces all `router.push` uses to the `Link` component by Nextjs which provides the accessibility like **Open in New Tab/Window**, etc. And showing where the link will go when clicked.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
If we compare the current behaviour with the Next link, it changes a lot of things

One of those differences is the right-click. Right now if we right click this is what shows up 👇. 
![image](https://user-images.githubusercontent.com/51731966/152176675-86b7c8b8-eefd-4caf-b2d6-688687ff7eed.png)

But actually, we want this 👇
![image](https://user-images.githubusercontent.com/51731966/152176890-5b8cf4bc-2d72-4553-b875-ede73724801d.png)