### PR TITLE
Fix - Make the titles of the card components under "Primary Action" r…

### DIFF
--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -19,7 +19,7 @@ import { Card } from '@nextui-org/react';
 <Playground
   title="Default"
   desc="NextUI will wrap your content in a `Card.Body` component."
-  code={` 
+  code={`
 <Card css={{ mw: "400px" }}>
   <p>A basic card.</p>
 </Card>`}
@@ -28,7 +28,7 @@ import { Card } from '@nextui-org/react';
 <Playground
   title="Bordered"
   desc="You can change the full style towards a bodered `Card` with the `bordered` property."
-  code={` 
+  code={`
 <Card bordered shadow={false} css={{ mw: "400px" }}>
   <p>A bordered card.</p>
 </Card>`}
@@ -37,7 +37,7 @@ import { Card } from '@nextui-org/react';
 <Playground
   title="Hoverable"
   desc="You can apply a fancy hover animation with the `hoverable` property."
-  code={` 
+  code={`
 <Card bordered shadow={false} hoverable css={{ mw: "400px" }}>
   <p>A hoverable card.</p>
 </Card>`}
@@ -45,9 +45,9 @@ import { Card } from '@nextui-org/react';
 
 <Playground
   title="Clickable"
-  desc="You can use the `clickable` property to allow users to interact with the entirety of its surface 
+  desc="You can use the `clickable` property to allow users to interact with the entirety of its surface
   to trigger its main action, be it an expansion, a link to another screen or some other behavior."
-  code={` 
+  code={`
 <Card clickable bordered css={{ mw: "400px" }}>
   <p>A clickable card.</p>
 </Card>`}
@@ -79,17 +79,17 @@ return (
       </Grid>
     ))}
   </Grid.Container>
-);    
+);
 }`}
 />
 
 <Playground
   title="With divider"
   desc="You can use the `Divider` component to split the `Card` sections."
-  code={` 
-<Grid.Container gap={2}> 
-  <Grid>  
-    <Card css={{ w: "330px" }}>
+  code={`
+<Grid.Container gap={2}>
+  <Grid css={{w:"100%"}}>
+    <Card css={{ mw: "330px" }}>
         <Card.Header>
           <Text b>Card Title</Text>
         </Card.Header>
@@ -107,9 +107,9 @@ return (
           </Row>
         </Card.Footer>
     </Card>
-  </Grid>  
-  <Grid>  
-    <Card css={{ w: "330px" }}>
+  </Grid>
+  <Grid css={{w:"100%"}}>
+    <Card css={{ mw: "330px" }}>
         <Card.Header>
           <Text b>Card Title</Text>
         </Card.Header>
@@ -127,7 +127,7 @@ return (
           </Row>
         </Card.Footer>
     </Card>
-  </Grid> 
+  </Grid>
 </Grid.Container>
 `}
 />
@@ -135,10 +135,10 @@ return (
 <Playground
   title="With Footer"
   desc="You can use the `Card.Footer` component to add actions, details or another information to the `Card`."
-  code={` 
+  code={`
 <Grid.Container gap={2}>
-    <Grid>
-      <Card css={{ w: "330px" }}>
+    <Grid css={{w:"100%"}}>
+      <Card css={{ mw: "330px" }}>
         <Text h4>Next UI</Text>
         <Text>🚀  Beautiful and modern React UI library.</Text>
         <Card.Footer>
@@ -147,9 +147,9 @@ return (
           </Link>
         </Card.Footer>
       </Card>
-    </Grid>  
-    <Grid> 
-        <Card css={{ w: "330px" }} color="primary">
+    </Grid>
+    <Grid css={{w:"100%"}}>
+        <Card css={{ mw: "330px" }} color="primary">
           <Text h4 color="white">Next UI</Text>
           <Text color="white">🚀  Beautiful and modern React UI library.</Text>
           <Card.Footer>
@@ -158,7 +158,7 @@ return (
             </Link>
           </Card.Footer>
         </Card>
-    </Grid>  
+    </Grid>
 </Grid.Container>`}
 />
 
@@ -166,7 +166,7 @@ return (
   title="Cover Image"
   desc="You can use the `cover` prop and `Card.Image` component to add a coverred image to the `Card.Body`. NextUI automatically
   applies `object-fit: cover` to the inner image."
-  code={` 
+  code={`
 <Grid.Container gap={2} justify="center">
     <Grid xs={12} sm={4}>
       <Card cover>
@@ -242,7 +242,7 @@ return (
           alt="Card image background"
         />
       </Card>
-    </Grid>  
+    </Grid>
     <Grid xs={12} sm={5}>
       <Card cover css={{ w: '100%' }}>
         <Card.Header css={{ position: 'absolute', zIndex: 1, top: 5 }}>
@@ -268,7 +268,7 @@ return (
             alt="Card example background"
           />
         </Card.Body>
-        <Card.Footer             
+        <Card.Footer
           blur
           css={{
             position: 'absolute',
@@ -295,7 +295,7 @@ return (
           </Row>
         </Card.Footer>
       </Card>
-    </Grid>    
+    </Grid>
     <Grid xs={12} sm={7}>
       <Card cover css={{ w: '100%', p: 0 }}>
         <Card.Header css={{ position: 'absolute', zIndex: 1, top: 5 }}>
@@ -431,14 +431,14 @@ return (
           />
         </Card.Body>
         <Card.Footer justify="flex-start">
-          <Row justify="space-between">
+          <Row wrap='wrap' justify="space-between">
             <Text b>
               {item.title}
             </Text>
             <Text css={{ color: "$accents4", fontWeight: "$semibold" }}>
               {item.price}
             </Text>
-          </Row>        
+          </Row>
         </Card.Footer>
       </Card>
     </Grid>

--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -88,7 +88,7 @@ return (
   desc="You can use the `Divider` component to split the `Card` sections."
   code={`
 <Grid.Container gap={2}>
-  <Grid css={{w:"100%"}}>
+  <Grid sm={12} md={5}>
     <Card css={{ mw: "330px" }}>
         <Card.Header>
           <Text b>Card Title</Text>
@@ -108,7 +108,7 @@ return (
         </Card.Footer>
     </Card>
   </Grid>
-  <Grid css={{w:"100%"}}>
+  <Grid sm={12} md={5}>
     <Card css={{ mw: "330px" }}>
         <Card.Header>
           <Text b>Card Title</Text>
@@ -137,7 +137,7 @@ return (
   desc="You can use the `Card.Footer` component to add actions, details or another information to the `Card`."
   code={`
 <Grid.Container gap={2}>
-    <Grid css={{w:"100%"}}>
+    <Grid sm={12} md={5}>
       <Card css={{ mw: "330px" }}>
         <Text h4>Next UI</Text>
         <Text>🚀  Beautiful and modern React UI library.</Text>
@@ -148,7 +148,7 @@ return (
         </Card.Footer>
       </Card>
     </Grid>
-    <Grid css={{w:"100%"}}>
+    <Grid sm={12} md={5}>
         <Card css={{ mw: "330px" }} color="primary">
           <Text h4 color="white">Next UI</Text>
           <Text color="white">🚀  Beautiful and modern React UI library.</Text>


### PR DESCRIPTION
Card component examples in docs.

Fixes: https://github.com/nextui-org/nextui/issues/217

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context

I made changes to the example Card components on the website.
The titles of the cards under the "Primary Action" section were not responsive on moible. I added flex-wrap to break it on a new line when viewing on mobile.

The cards under the section "With Footer" and "With Divider" were also not responsive on mobile. I made the width responsive so that it scales with the screen size.
 
### Screenshots - Animations

**Before:**
![image](https://user-images.githubusercontent.com/25207023/152340353-f27d0dd8-1769-4c68-9be0-a23c431415d6.png)

**After:**
![image](https://user-images.githubusercontent.com/25207023/152340399-4556e3b4-29b7-4c34-91aa-c060d941b591.png)

 **Before:**
 
![image](https://user-images.githubusercontent.com/25207023/152340194-e8b9bc64-1682-49bd-b1c3-80c607b7dcda.png)

**After:**
![image](https://user-images.githubusercontent.com/25207023/152340268-c182e4ec-cead-4e03-8d41-ec8b275ba336.png)

 **Before:**
 
![image](https://user-images.githubusercontent.com/25207023/152341109-7c6ff9a2-7725-40b2-a07a-b6b4df5ebb03.png)

**After:**
![image](https://user-images.githubusercontent.com/25207023/152340639-45edb4c5-8441-4adf-9279-c31f0c46e6ba.png)

 