### PR TITLE
Full width prop for Button component.

### DIFF
--- a/apps/docs/content/docs/components/button.mdx
+++ b/apps/docs/content/docs/components/button.mdx
@@ -48,6 +48,8 @@ import { Button } from '@nextui-org/react';
     <Button size="xl">xlarge</Button>
     <Spacer y={0.5}/>
     <Button auto>auto width</Button>
+    <Spacer y={0.5}/>
+    <Button fullWidth>full width</Button>
 </>
 `}
 />

--- a/packages/react/src/button/__tests__/index.test.tsx
+++ b/packages/react/src/button/__tests__/index.test.tsx
@@ -97,6 +97,7 @@ describe('Button', () => {
         {/* <Button ghost>button</Button>
         <Button bordered>button</Button> */}
         <Button auto>button</Button>
+        <Button fullWidth>button</Button>
         <Button animated={false}>button</Button>
       </div>
     );

--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -44,6 +44,10 @@ export const Sizes = () => (
       Extra Large
     </Button>
     <Spacer y={0.5} />
+    <Button fullWidth color="gradient">
+      Full width
+    </Button>
+    <Spacer y={0.5} />
     <Button auto color="gradient">
       Auto width
     </Button>

--- a/packages/react/src/button/button.styles.ts
+++ b/packages/react/src/button/button.styles.ts
@@ -219,7 +219,15 @@ export const StyledButton = styled(
         true: {
           br: '$pill'
         }
-      }
+      },
+      fullWidth: {
+        true: {
+          width: '100%'
+        },
+        false: {
+          width: 'auto'
+        }
+      },
     },
     compoundVariants: [
       // size / auto
@@ -773,7 +781,8 @@ export const StyledButton = styled(
       color: 'default',
       borderWeight: 'normal',
       animated: true,
-      size: 'md'
+      size: 'md',
+      fullWidth: false,
     }
   },
   sharedFocus

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -35,6 +35,7 @@ export interface Props {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   as?: keyof JSX.IntrinsicElements;
   className?: string;
+  fullWidth?: boolean;
 }
 
 const defaultProps = {
@@ -44,7 +45,8 @@ const defaultProps = {
   ripple: true,
   animated: true,
   disabled: false,
-  className: ''
+  className: '',
+  fullWidth: false
 };
 
 type NativeAttrs = Omit<React.ButtonHTMLAttributes<unknown>, keyof Props>;
@@ -77,6 +79,7 @@ const Button = React.forwardRef<
     ghost,
     clickable,
     className,
+    fullWidth,
     ...props
   } = filteredProps;
   /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -119,6 +122,7 @@ const Button = React.forwardRef<
       animated={animated}
       onClick={clickHandler}
       className={clsx('nextui-button', `nextui-button--${getState}`, className)}
+      fullWidth={fullWidth}
       {...props}
     >
       {React.Children.count(children) === 0 ? (


### PR DESCRIPTION
## [react]/[Button]
**TASK**:

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Added the prop ``fullWidth`` to the Button component.
Updated Components documentation to include an example of a button with the ``fullWidth`` prop.
<!--- Why is this change required? What problem does it solve? -->
This allows the user to make the button full width of its container without needing ``css={{ width: "100%" }}`` whilst also being able to use the ``size`` prop for height and font size.
<!--- If it is solving an issue... How can it be reproduced in order to compare both behaviors? -->

### Screenshots - Animations

### Storybook preview:
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
<img width="322" alt="fullWidthExample" src="https://user-images.githubusercontent.com/54292974/152366382-4e2daa07-35d4-4c06-b2ca-44d1c99c3a71.png">

### Documentation preview:
<img width="841" alt="fullWidth-Documentation-Example" src="https://user-images.githubusercontent.com/54292974/152370408-d6f9e3c0-df30-48ab-ad95-c4fc3b047e59.png">

