### PR TITLE
fix(button): Change the default of Button type props

### DIFF
--- a/apps/docs/content/docs/components/button.mdx
+++ b/apps/docs/content/docs/components/button.mdx
@@ -408,7 +408,7 @@ import { Button } from '@nextui-org/react';
 | **onClick**      | `MouseEventHandler`                             | -                                | Button click handler                      | -         |
 | **icon**         | `ReactNode`                                     | -                                | Show icon in button                       | -         |
 | **iconRight**    | `ReactNode`                                     | -                                | Show icon on the other side of the button | -         |
-| **type**         | `ButtonHTMLAttributes.type`                     | `button` `reset` `submit`        | Native type of button element             | -         |
+| **type**         | `ButtonHTMLAttributes.type`                     | `button` `reset` `submit`        | Native type of button element             | `button`  |
 | **ref**          | <Code>Ref<HTMLButtonElement &#124; null></Code> | -                                | forwardRef                                | -         |
 | ...              | `ButtonHTMLAttributes`                          | `'id', 'className', ...`         | Button native props                       | -         |
 

--- a/apps/docs/content/docs/components/button.mdx
+++ b/apps/docs/content/docs/components/button.mdx
@@ -408,7 +408,7 @@ import { Button } from '@nextui-org/react';
 | **onClick**      | `MouseEventHandler`                             | -                                | Button click handler                      | -         |
 | **icon**         | `ReactNode`                                     | -                                | Show icon in button                       | -         |
 | **iconRight**    | `ReactNode`                                     | -                                | Show icon on the other side of the button | -         |
-| **type**         | `ButtonHTMLAttributes.type`                     | `button` `reset` `submit`        | Native type of button element             | `submit`  |
+| **type**         | `ButtonHTMLAttributes.type`                     | `button` `reset` `submit`        | Native type of button element             | -         |
 | **ref**          | <Code>Ref<HTMLButtonElement &#124; null></Code> | -                                | forwardRef                                | -         |
 | ...              | `ButtonHTMLAttributes`                          | `'id', 'className', ...`         | Button native props                       | -         |
 

--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -37,6 +37,7 @@ export interface Props {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   as?: keyof JSX.IntrinsicElements;
   className?: string;
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 const defaultProps = {
@@ -47,7 +48,8 @@ const defaultProps = {
   animated: true,
   disabled: false,
   auto: false,
-  className: ''
+  className: '',
+  type: 'button'
 };
 
 type NativeAttrs = Omit<React.ButtonHTMLAttributes<unknown>, keyof Props>;


### PR DESCRIPTION
## [nextui]/[button]
**TASK**: <!--- [Github ISSUE](Issue Link) -->https://github.com/nextui-org/nextui/issues/274



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
Add type to defaultProps of Button component
Change the default of type props in the Button component documentation to `button`
<!--- Why is this change required? What problem does it solve? -->

<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->

