### PR TITLE
NextUI users can now set borderRadius:0 for card.Body and card.image

### DIFF
--- a/packages/react/src/card/card.styles.ts
+++ b/packages/react/src/card/card.styles.ts
@@ -2,6 +2,7 @@ import { styled, VariantProps } from '../theme/stitches.config';
 import { StyledDrip } from '../utils/drip';
 
 export const StyledCardBody = styled('div', {
+  borderRadius: "0",
   d: 'flex',
   w: '100%',
   h: 'auto',

--- a/packages/react/src/image/image.styles.ts
+++ b/packages/react/src/image/image.styles.ts
@@ -13,7 +13,6 @@ export const StyledImageContainer = styled('div', {
   opacity: 0,
   margin: '0 auto',
   position: 'relative',
-  br: '$lg',
   overflow: 'hidden',
   maxWidth: '100%',
   transition: 'transform 250ms ease 0ms, opacity 200ms ease-in 0ms',
@@ -34,7 +33,9 @@ export const StyledImageContainer = styled('div', {
 
 export const StyledImage = styled('img', {
   size: '100%',
-  display: 'block'
+  display: 'block',
+  borderRadius: "$lg"
+  
 });
 
 export const StyledImageSkeleton = styled('div', {


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: This PR fixes #301 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [x] Refactor

### Description, Motivation and Context

borderRadius: 0 is now available to use for Card.Body and Card.Image

### Screenshots - Animations


![Capture](https://user-images.githubusercontent.com/47073516/155711341-687fec60-4ef4-4160-afeb-124209879768.PNG)

