### PR TITLE
fix: changeTheme function to avoid empty strings

### DIFF
--- a/packages/react/src/theme/utils.ts
+++ b/packages/react/src/theme/utils.ts
@@ -114,7 +114,7 @@ export const changeTheme = (theme: ThemeType | string) => {
     el
       ?.getAttribute('style')
       ?.split(';')
-      .filter((stl) => !stl.includes('color-scheme'))
+      .filter((stl) => !stl.includes('color-scheme') && stl.length)
       .map((el) => `${el};`) || [];
 
   el?.setAttribute('class', clsx(prevClasses, `${getThemeName(theme)}-theme`));


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: [308](https://github.com/nextui-org/nextui/issues/308)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
<!--- Describe your changes in detail -->
I added an extra condition to avoid empty strings in this case the next map wouldn't add the semicolon when string is empty.
<!--- Why is this change required? What problem does it solve? -->
It avoid to add unnecessary semicolons in document style tag.
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->
![Screenshot 2022-02-28 at 05 18 33](https://user-images.githubusercontent.com/40375118/155927159-d0e27cfc-33a6-4327-9caa-588a795e85ab.png)

