### PR TITLE
Fix ( Tooltip) Text invert's color error

### DIFF
--- a/packages/react/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/tooltip/tooltip.stories.tsx
@@ -58,6 +58,12 @@ export const Colors = () => {
           </Button>
         </Tooltip>
         <Spacer inline x={1.5} />
+        <Tooltip content="Developers love Next.js" color="invert">
+          <Button flat auto>
+            Invert
+          </Button>
+        </Tooltip>
+        <Spacer inline x={1.5} />
         <Tooltip content="Developers love Next.js" color="primary">
           <Button flat auto>
             Primary
@@ -99,6 +105,12 @@ export const TextColors = () => {
         <Tooltip content="Developers love Next.js">
           <Button light auto>
             Default
+          </Button>
+        </Tooltip>
+        <Spacer inline x={1.5} />
+        <Tooltip content="Developers love Next.js" color="invert">
+          <Button flat auto>
+            Invert
           </Button>
         </Tooltip>
         <Spacer inline x={1.5} />

--- a/packages/react/src/tooltip/tooltip.styles.ts
+++ b/packages/react/src/tooltip/tooltip.styles.ts
@@ -68,7 +68,6 @@ export const StyledTooltipContent = styled('div', {
       },
       invert: {
         $$tooltipColor: '$colors$foreground',
-        $$tooltipTextColor: '$colors$background',
         bg: '$$tooltipColor'
       }
     },
@@ -96,6 +95,10 @@ export const StyledTooltipContent = styled('div', {
       error: {
         $$tooltipTextColor: '$colors$error',
         color: '$$tooltipTextColor'
+      }
+      invert: {
+       $$tooltipTextColor: '$colors$background',
+       color:'$$tooltipTextColor'
       }
     },
     rounded: {

--- a/packages/react/src/tooltip/tooltip.styles.ts
+++ b/packages/react/src/tooltip/tooltip.styles.ts
@@ -95,10 +95,10 @@ export const StyledTooltipContent = styled('div', {
       error: {
         $$tooltipTextColor: '$colors$error',
         color: '$$tooltipTextColor'
-      }
+      },
       invert: {
-       $$tooltipTextColor: '$colors$background',
-       color:'$$tooltipTextColor'
+        $$tooltipTextColor: '$colors$background',
+        color: '$$tooltipTextColor'
       }
     },
     rounded: {

--- a/packages/react/src/tooltip/tooltip.styles.ts
+++ b/packages/react/src/tooltip/tooltip.styles.ts
@@ -97,7 +97,7 @@ export const StyledTooltipContent = styled('div', {
         color: '$$tooltipTextColor'
       },
       invert: {
-        $$tooltipTextColor: '$colors$background',
+        $$tooltipTextColor: '$colors$invert',
         color: '$$tooltipTextColor'
       }
     },
@@ -151,6 +151,14 @@ export const StyledTooltipContent = styled('div', {
       contentColor: 'default',
       css: {
         $$tooltipTextColor: '$colors$white'
+      }
+    },
+    // color='invert' && contentColor='default'
+    {
+      color: 'invert',
+      contentColor: 'default',
+      css: {
+        $$tooltipTextColor: "$colors$background"
       }
     }
   ],


### PR DESCRIPTION
## [LEVEL]/[COMPONENT]
**TASK**: #322 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Tooltip content don't have define invert

### Screenshots - Animations
Previous 
![image](https://user-images.githubusercontent.com/72869479/156568006-c12fb3fd-ed68-474c-bd65-e6b27bee0265.png)
Now
![image](https://user-images.githubusercontent.com/72869479/156568134-71c70823-5466-47c9-8f2c-8b39ee5fe948.png)


