### PR TITLE
[docs] fix some `text` & `link` types/props headings

### DIFF
--- a/apps/docs/content/docs/components/link.mdx
+++ b/apps/docs/content/docs/components/link.mdx
@@ -147,7 +147,7 @@ return (
 
 <Spacer y={1} />
 
-#### Simple Colors
+#### Link Colors
 
 ```ts
 type LinkColors =

--- a/apps/docs/content/docs/components/text.mdx
+++ b/apps/docs/content/docs/components/text.mdx
@@ -204,7 +204,7 @@ import { Text } from '@nextui-org/react';
 | **transform**  | `TextTransform`                 | [TextTransforms](#text-transforms) | text-transform prop                   | `none`    |
 | **size**       | `string` `number`               | -                                  | Text size                             | `inherit` |
 | **margin**     | `string` `number`               | -                                  | Text margin                           | `inherit` |
-| **color**      | `SimpleColors` `string`         | [SimpleColors](#normal-colors)     | Text color                            | `default` |
+| **color**      | `SimpleColors` `string`         | [SimpleColors](#simple-colors)     | Text color                            | `default` |
 | **weight**     | `TextWeights`                   | [TextWeights](#text-weights)       | Text weight                           | `noset`   |
 | **css**        | `Stitches.CSS`                  | -                                  | Override Default CSS style            | -         |
 | **as**         | `keyof JSX.IntrinsicElements`   | -                                  | Changes which tag component outputs   | `p`       |
@@ -216,7 +216,7 @@ import { Text } from '@nextui-org/react';
 
 <Spacer y={1} />
 
-#### Text Transform
+#### Text Transforms
 
 ```ts
 type TextTransforms =


### PR DESCRIPTION
## docs/[text.mdx | link.mdx]
**TASK**: `null`


### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Just found some new heading issues.
I'm not sure if I used the correct heading names or not, so please check them before merging.
Thanks <3