### PR TITLE
fix[react](collapse): wrong close when the content includes a input/t…

### DIFF
--- a/packages/react/src/collapse/collapse.stories.tsx
+++ b/packages/react/src/collapse/collapse.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { Grid, Text } from '../index';
+import { Grid, Text, Input } from '../index';
 import Collapse from './index';
 import useTheme from '../use-theme';
 import { Minus, Plus, User, Mail, Activity } from '../utils/icons';
@@ -28,6 +28,38 @@ export const Default = () => (
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
         commodo consequat.
       </Text>
+    </Collapse>
+    <Collapse title="Option B">
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Text>
+    </Collapse>
+    <Collapse title="Option C">
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Text>
+    </Collapse>
+    <Collapse title="Option D">
+      <Text>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Text>
+    </Collapse>
+  </Collapse.Group>
+);
+
+export const WithInput = () => (
+  <Collapse.Group onChange={(index, value) => console.log({ index, value })}>
+    <Collapse title={<h3>Option 1</h3>}>
+      <Input />
     </Collapse>
     <Collapse title="Option B">
       <Text>

--- a/packages/react/src/collapse/collapse.styles.ts
+++ b/packages/react/src/collapse/collapse.styles.ts
@@ -1,4 +1,9 @@
-import { styled, sharedFocus, VariantProps } from '../theme/stitches.config';
+import {
+  styled,
+  sharedFocus,
+  VariantProps,
+  cssFocusVisible
+} from '../theme/stitches.config';
 
 export const StyledCollapse = styled(
   'div',
@@ -130,26 +135,30 @@ export const StyledCollapse = styled(
   sharedFocus
 );
 
-export const StyledCollapseView = styled('div', {
-  w: '100%',
-  d: 'block',
-  ta: 'left',
-  bg: 'transparent',
-  border: 'none',
-  cursor: 'pointer',
-  outline: 'none',
-  padding: '$lg 0',
-  variants: {
-    disabled: {
-      true: {
-        cursor: 'not-allowed',
-        '.nextui-collapse-title, .nextui-collapse-subtitle': {
-          opacity: 0.5
+export const StyledCollapseView = styled(
+  'div',
+  {
+    w: '100%',
+    d: 'block',
+    ta: 'left',
+    bg: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    outline: 'none',
+    padding: '$lg 0',
+    variants: {
+      disabled: {
+        true: {
+          cursor: 'not-allowed',
+          '.nextui-collapse-title, .nextui-collapse-subtitle': {
+            opacity: 0.5
+          }
         }
       }
     }
-  }
-});
+  },
+  cssFocusVisible
+);
 
 export const StyledCollapseContent = styled('div', {
   fontSize: '$base',

--- a/packages/react/src/collapse/collapse.tsx
+++ b/packages/react/src/collapse/collapse.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
+import { useFocusRing } from '@react-aria/focus';
 import CollapseIcon from './collapse-icon';
 import Expand from '../utils/expand';
 import { useCollapseContext } from './collapse-context';
@@ -91,6 +92,17 @@ const Collapse: React.FC<React.PropsWithChildren<CollapseProps>> = ({
     updateValues
   } = useCollapseContext();
 
+  const {
+    isFocusVisible,
+    focusProps
+  }: {
+    isFocusVisible: boolean;
+    focusProps: Omit<
+      React.HTMLAttributes<HTMLButtonElement>,
+      keyof CollapseProps
+    >;
+  } = useFocusRing();
+
   if (!title) {
     useWarning('"title" is required.', 'Collapse');
   }
@@ -148,7 +160,7 @@ const Collapse: React.FC<React.PropsWithChildren<CollapseProps>> = ({
 
   return (
     <StyledCollapse
-      tabIndex={disabled ? -1 : 0}
+      tabIndex={-1}
       shadow={shadow}
       bordered={bordered}
       animated={animated}
@@ -159,11 +171,10 @@ const Collapse: React.FC<React.PropsWithChildren<CollapseProps>> = ({
       className={clsx(className, preClass, `${preClass}--${getState}`)}
       isDark={isDark}
       {...props}
-      {...bindings}
     >
       <StyledCollapseView
         role="button"
-        tabIndex={-1}
+        tabIndex={disabled ? -1 : 0}
         id={ariaLabelledById}
         className={`${preClass}-view`}
         data-state={getState}
@@ -171,7 +182,10 @@ const Collapse: React.FC<React.PropsWithChildren<CollapseProps>> = ({
         aria-disabled={disabled}
         aria-expanded={visible}
         aria-controls={ariaControlId}
+        isFocusVisible={isFocusVisible}
         onClick={handleChange}
+        {...focusProps}
+        {...bindings}
       >
         <div className={clsx(`${preClass}-title-container`)}>
           {contentLeft && (


### PR DESCRIPTION
## [react]/[collapse]
## Closing: #336 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context

Wrong close/open when the content includes a `input/textarea` component fixed

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->

### Screenshots - Animations
<!-- Adding images or gif animations of your changes improves the understanding of your changes -->