### PR TITLE
Fix #288 modal animation behavior

### DIFF
--- a/packages/react/src/backdrop/backdrop.styles.ts
+++ b/packages/react/src/backdrop/backdrop.styles.ts
@@ -1,4 +1,16 @@
-import { styled, VariantProps } from '../theme/stitches.config';
+import { styled, keyframes, VariantProps } from '../theme/stitches.config';
+
+const appearanceIn = keyframes({
+  '0%': {
+    opacity: 0
+  },
+  '60%': {
+    opacity: 0.75
+  },
+  '100%': {
+    opacity: 1
+  }
+});
 
 export const StyledBackdropContent = styled('div', {
   position: 'relative',
@@ -11,6 +23,21 @@ export const StyledBackdropContent = styled('div', {
   '@sm': {
     width: '90%',
     maxWidth: '90%'
+  },
+  variants: {
+    animated: {
+      true: {
+        '&': {
+          animationName: appearanceIn,
+          animationDuration: '200ms',
+          animationTimingFunction: 'ease-in',
+          animationDirection: 'normal'
+        }
+      },
+      false: {
+        transition: 'none'
+      }
+    }
   }
 });
 

--- a/packages/react/src/backdrop/backdrop.tsx
+++ b/packages/react/src/backdrop/backdrop.tsx
@@ -123,6 +123,7 @@ const Backdrop: React.FC<React.PropsWithChildren<BackdropProps>> = React.memo(
             blur={blur}
           />
           <StyledBackdropContent
+            animated={animated}
             className={`${preClass}-content`}
             onClick={childrenClickHandler}
             css={{


### PR DESCRIPTION
## [react]/[backdrop]
**TASK**: https://github.com/nextui-org/nextui/issues/288


### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Add the same opacity animation to `BackdropContent` as the `Modal`

### Screenshots - Animations

https://user-images.githubusercontent.com/32772271/160436312-eb261bcf-21cf-48df-8c9e-5a1b528a83d8.mov


