### PR TITLE
added text-shadow to docs mobile navigation text

### DIFF
--- a/apps/docs/src/components/mobile-navigation/index.tsx
+++ b/apps/docs/src/components/mobile-navigation/index.tsx
@@ -83,6 +83,7 @@ const MobileNavigation: React.FC<Props> = ({
             .mobile-navigation__list {
               margin: 0;
               padding: 16px 0 16px 16px;
+              text-shadow: 0 0 black;
             }
             .mobile-navigation__container.opened {
               top: 63px;


### PR DESCRIPTION
## [DOCS]/[MOBILE-NAVIGATION]

### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Only
- [ ] Refactor

### Description, Motivation and Context
Added text-shadow property to the mobile navigation in the documentation.
In light-mode, the mobile navigation text is hard to read.
Accessibility is still not optimal, but a little better.

### Screenshots
Before:
![before](https://user-images.githubusercontent.com/54767886/164554338-104c844d-1695-435f-909e-1c9bd740e361.png)

After:
![after](https://user-images.githubusercontent.com/54767886/164554352-41f00e88-7acd-427b-be5b-1abc79a7f444.png)


