### PR TITLE
fix: #291 stitches compatability with typescript

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,7 +77,7 @@
     "@react-types/grid": "3.0.1",
     "@react-types/overlays": "3.5.4",
     "@react-types/shared": "3.11.0",
-    "@stitches/react": "1.2.7"
+    "@stitches/react": "1.2.8"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4228,10 +4228,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stitches/react@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.7.tgz#aea2403fac726db66d1740d29557e3910b1a1dc7"
-  integrity sha512-6AxpUag7OW55ANzRnuy7R15FEyQeZ66fytVo3BBilFIU0mfo3t49CAMcEAL/A1SbhSj/FCdWkn/XrbjGBTJTzg==
+"@stitches/react@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.8.tgz#954f8008be8d9c65c4e58efa0937f32388ce3a38"
+  integrity sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==
 
 "@storybook/addon-a11y@^6.3.9":
   version "6.4.19"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/291

## 📝 Description

Fix the `length is declared here` issue by upgrading stitches to version [1.2.8](https://github.com/modulz/stitches/releases/tag/v1.2.8)

## ⛳️ Current behavior (updates)

```diff
- "@stitches/react": "1.2.7"
+ "@stitches/react": "1.2.8"
```
<!---
## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
-->
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

Screenshot of code completion with latest typescript **`CSS property`**

![Auto Completion Screenshot](https://user-images.githubusercontent.com/32772271/165183001-4848d2b5-a81b-4aa8-9607-60572c85ec71.png)

Screenshot of code completion with latest typescript **`Stitches utils`**

![Auto Completion Screenshot Utils](https://user-images.githubusercontent.com/32772271/165187394-822c2493-c7f2-47a7-8002-c12e702a5806.png)
