### PR TITLE
fix(react-link): wrap it into a single child

### DIFF
--- a/packages/react/src/link/link.tsx
+++ b/packages/react/src/link/link.tsx
@@ -24,8 +24,10 @@ export type LinkProps = Props &
 const Link = React.forwardRef<React.ElementRef<typeof StyledLink>, LinkProps>(
   ({ children, icon, ...props }, forwardedRef) => (
     <StyledLink {...props} ref={forwardedRef}>
-      {children}
-      {icon && <LinkIcon />}
+      <>
+        {children}
+        {icon && <LinkIcon />}
+      </>
     </StyledLink>
   )
 );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Due to [next/link](https://nextjs.org/docs/api-reference/next/link) doesn't support multiple children we have to wrap the NextUI children into a fragment

## ⛳️ Current behavior (updates)

It's not possible to use the NextUI link as a next/link thought the `as` prop

## 🚀 New behaviour

NextUI children were wrapped into a React Fragment in order to support [next/link](https://nextjs.org/docs/api-reference/next/link), NextUI will be able to use it as follows:

```js
import NextLink from "next/link";
import { Link } from "@nextui-org/react"

export default function App() {
  return (
    <Link href="#" as={NextLink}>
      "First solve the problem. Then, write the code." - Jon Johnson.
    </Link>
  );
}



```

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->


