### PR TITLE
Fix 426/button onclick keyboard

### DIFF
--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -33,6 +33,7 @@ export interface Props extends PressEvents, FocusableProps, AriaButtonProps {
   ripple?: boolean;
   icon?: React.ReactNode;
   iconRight?: React.ReactNode;
+  // @deprecated
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   as?: keyof JSX.IntrinsicElements;
   className?: string;
@@ -101,6 +102,8 @@ const Button = React.forwardRef(
     const handlePress = (e: PressEvent) => {
       if (e.pointerType === 'keyboard' || e.pointerType === 'virtual') {
         handleDrip(e);
+        // TODO: take this out and deprecate onClick function for next release (only use the @react-aria/button impl)
+        onClick?.(e as any);
       }
       onPress?.(e);
     };
@@ -109,6 +112,7 @@ const Button = React.forwardRef(
     const { buttonProps, isPressed } = useButton(
       {
         ...btnProps,
+        onClick: handleClick,
         isDisabled: disabled,
         elementType: as,
         onPress: handlePress
@@ -134,9 +138,6 @@ const Button = React.forwardRef(
       false,
       buttonRef
     );
-
-    // TODO: remove this when we can use the new onPress(e) => e.clientX && e.clientY API
-    buttonProps.onClick = handleClick;
 
     /* eslint-enable @typescript-eslint/no-unused-vars */
     if (__DEV__ && filteredProps.color === 'gradient' && (flat || light)) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #426 

## 📝 Description

The button component is not dispatching the `onClick` event, a temporal solution was implemented until we fully migrate to the `useButton` props

## ⛳️ Current behavior (updates)

The button component is not dispatching the `onClick` event

## 🚀 New behavior

A temporal solution was implemented until we fully migrate to the`useButton` props

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
