### PR TITLE
Fix 431/checkbox initial checked

### DIFF
--- a/packages/react/src/checkbox/checkbox.tsx
+++ b/packages/react/src/checkbox/checkbox.tsx
@@ -22,6 +22,7 @@ import {
   StyledCheckboxText
 } from './checkbox.styles';
 import { mapPropsToReactAriaAttr } from './utils';
+import { __DEV__ } from '../utils/assertion';
 import clsx from '../utils/clsx';
 
 interface Props
@@ -91,6 +92,8 @@ const Checkbox = React.forwardRef<HTMLLabelElement, CheckboxProps>(
       labelColor,
       animated,
       autoFocus,
+      // @ts-ignore
+      initialChecked,
       ...props
     } = checkboxProps;
 
@@ -205,7 +208,10 @@ const Checkbox = React.forwardRef<HTMLLabelElement, CheckboxProps>(
 
 Checkbox.defaultProps = defaultProps;
 
-Checkbox.displayName = 'NextUI.Checkbox';
+if (__DEV__) {
+  Checkbox.displayName = 'NextUI.Checkbox';
+}
+
 Checkbox.toString = () => '.nextui-checkbox';
 
 type CheckboxComponent<T, P = {}> = React.ForwardRefExoticComponent<


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #431 

## 📝 Description

Checkbox's `initialChecked` prop was being passed to the html

## ⛳️ Current behavior (updates)

React doesn't recognize the `initialChecked` prop on a DOM element

## 🚀 New behavior

The `initialChecked` prop was taken out from the checkboxProps, this prop will be renamed to `defaultSelected` in a near future

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

 The `initialChecked`  will be renamed to `defaultSelected` in a near future to have a better `@react-aria` integration