### PR TITLE
Updated _document.tsx code to remove errors

### DIFF
--- a/apps/docs/content/docs/guide/getting-started.mdx
+++ b/apps/docs/content/docs/guide/getting-started.mdx
@@ -79,7 +79,7 @@ import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { CssBaseline } from '@nextui-org/react';
 
 class MyDocument extends Document {
-  static async getInitialProps(ctx) {
+  static async getInitialProps(ctx: any) {
     const initialProps = await Document.getInitialProps(ctx);
     return {
       ...initialProps,


### PR DESCRIPTION
Original Discussion: https://github.com/nextui-org/nextui/issues/441
and my original code: https://github.com/nextui-org/nextui/issues/441#issuecomment-1116955466

I posted the correct code but I suppose the PR by anoushk1234 forgot to include `ctx: any` at line 82.   
 Without `ctx: any`, the editor would throw an error because ctx requires a type.   
Explained here: https://stackoverflow.com/a/50414836/18995569