### PR TITLE
fix(react-user): prop and link warnings

### DIFF
--- a/packages/react/src/user/index.ts
+++ b/packages/react/src/user/index.ts
@@ -10,8 +10,7 @@ export {
   StyledUser,
   StyledUserInfo,
   StyledUserName,
-  StyledUserDesc,
-  StyledUserLink
+  StyledUserDesc
 } from './user.styles';
 
 export default User;

--- a/packages/react/src/user/user-link.tsx
+++ b/packages/react/src/user/user-link.tsx
@@ -1,35 +1,37 @@
 import React from 'react';
 import Link from '../link';
-import { StyledUserLink } from './user.styles';
-import { CSS } from '../theme/stitches.config';
+import clsx from '../utils/clsx';
 import { __DEV__ } from '../utils/assertion';
+import type { LinkProps } from '../link';
 
 interface Props {
-  href?: string;
+  children?: React.ReactNode;
 }
-type NativeAttrs = Omit<React.AnchorHTMLAttributes<unknown>, keyof Props>;
-export type UserLinkProps = Props & NativeAttrs & { css?: CSS };
 
-const UserLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.PropsWithChildren<UserLinkProps>
->(
-  (
-    { href, className, children, ...props },
-    ref: React.Ref<HTMLAnchorElement>
-  ) => {
+export type UserLinkProps = Props & Omit<LinkProps, 'icon'>;
+
+const UserLink = React.forwardRef<HTMLAnchorElement, UserLinkProps>(
+  (props: UserLinkProps, ref: React.Ref<HTMLAnchorElement>) => {
+    const {
+      rel = 'noopener',
+      color = 'primary',
+      target = '_blank',
+      className,
+      children,
+      ...otherProps
+    } = props;
+
     return (
-      <StyledUserLink {...props}>
-        <Link
-          ref={ref}
-          href={href}
-          color="primary"
-          target="_blank"
-          rel="noopener"
-        >
-          {children}
-        </Link>
-      </StyledUserLink>
+      <Link
+        ref={ref}
+        rel={rel}
+        color={color}
+        target={target}
+        className={clsx('nextui-user-link', className)}
+        {...otherProps}
+      >
+        {children}
+      </Link>
     );
   }
 );

--- a/packages/react/src/user/user.styles.ts
+++ b/packages/react/src/user/user.styles.ts
@@ -38,7 +38,7 @@ export const StyledUserDesc = styled('span', {
   }
 });
 
-export const StyledUserLink = styled('a', {
+export const StyledUserLink = styled('span', {
   a: {
     '&:hover': {
       opacity: 0.7

--- a/packages/react/src/user/user.styles.ts
+++ b/packages/react/src/user/user.styles.ts
@@ -37,11 +37,3 @@ export const StyledUserDesc = styled('span', {
     mb: 0
   }
 });
-
-export const StyledUserLink = styled('span', {
-  a: {
-    '&:hover': {
-      opacity: 0.7
-    }
-  }
-});

--- a/packages/react/src/user/user.tsx
+++ b/packages/react/src/user/user.tsx
@@ -55,6 +55,8 @@ export const User = React.forwardRef(
       bordered,
       size,
       description,
+      zoomed,
+      pointer,
       ...otherProps
     } = props;
 
@@ -67,8 +69,8 @@ export const User = React.forwardRef(
           src={src}
           color={color}
           squared={squared}
-          zoomed={props.zoomed}
-          pointer={props.pointer}
+          zoomed={zoomed}
+          pointer={pointer}
           bordered={bordered}
           text={text}
           size={size}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/474

## 📝 Description

- passed unnecessary props to `StyledUser`
> `Warning: Received true for a non-boolean attribute zoomed`
> `Warning: Received true for a non-boolean attribute pointer`

- `StyledUserLink` and `Link` both use the `a` tag
> `Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>`

## ⛳️ Current behavior (updates)

- structure `props` in order to pass the correct `otherProps`

- change the `a` tag of `StyledUserLink` to `span`

<!-- 
## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users.

## 📝 Additional Information
 -->