### PR TITLE
feat(avatar): allow to pass custom ref to img

### DIFF
--- a/packages/react/src/avatar/__tests__/index.test.tsx
+++ b/packages/react/src/avatar/__tests__/index.test.tsx
@@ -95,7 +95,7 @@ describe('Avatar', () => {
     expect(avatar).toMatchSnapshot();
   });
 
-  it.only('should populate imgRef', () => {
+  it('should populate imgRef', () => {
     const imgRef = createRef<HTMLImageElement>();
     const wrapper = mount(
       <Avatar

--- a/packages/react/src/avatar/__tests__/index.test.tsx
+++ b/packages/react/src/avatar/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { mount, render, shallow } from 'enzyme';
 import Avatar from '../index';
 
@@ -93,5 +93,17 @@ describe('Avatar', () => {
   it('should render component of a specified size', () => {
     const avatar = render(<Avatar css={{ size: 20 }} />);
     expect(avatar).toMatchSnapshot();
+  });
+
+  it.only('should populate imgRef', () => {
+    const imgRef = createRef<HTMLImageElement>();
+    const wrapper = mount(
+      <Avatar
+        imgRef={imgRef}
+        src="https://i.pravatar.cc/300?u=a042581f4e29026705d"
+      />
+    );
+    expect(imgRef.current).not.toBeNull();
+    expect(() => wrapper.unmount()).not.toThrow();
   });
 });

--- a/packages/react/src/avatar/avatar.tsx
+++ b/packages/react/src/avatar/avatar.tsx
@@ -6,6 +6,7 @@ import { useDOMRef } from '../utils/dom';
 import { __DEV__ } from '../utils/assertion';
 import StyledAvatar, { AvatarVariantsProps } from './avatar.styles';
 import clsx from '../utils/clsx';
+import useForkRef from '../use-fork-ref';
 
 interface Props {
   text?: string;
@@ -13,6 +14,7 @@ interface Props {
   icon?: React.ReactNode;
   alt?: string;
   className?: string;
+  imgRef?: ReactRef<HTMLImageElement>;
   as?: keyof JSX.IntrinsicElements;
 }
 
@@ -32,7 +34,15 @@ const safeText = (text: string): string => {
 
 export const Avatar = React.forwardRef(
   (props: AvatarProps, ref: ReactRef<HTMLSpanElement>) => {
-    const { src, text, icon, alt, className, ...otherProps } = props;
+    const {
+      src,
+      text,
+      icon,
+      alt,
+      className,
+      imgRef: imgRefProp,
+      ...otherProps
+    } = props;
 
     const domRef = useDOMRef(ref);
 
@@ -40,6 +50,10 @@ export const Avatar = React.forwardRef(
     const [ready, setReady] = useState(false);
 
     const imgRef = useRef<HTMLImageElement>(null);
+    const handleImgRef = useForkRef<HTMLImageElement, HTMLImageElement>(
+      imgRefProp,
+      imgRef
+    );
 
     useEffect(() => {
       imgRef?.current?.complete && setReady(true);
@@ -64,7 +78,7 @@ export const Avatar = React.forwardRef(
         <span className="nextui-avatar-bg" />
         {!showText && (
           <img
-            ref={imgRef}
+            ref={handleImgRef}
             className={clsx('nextui-avatar-img', `nextui-avatar--${getState}`, {
               'nextui-avatar-ready': ready
             })}

--- a/packages/react/src/use-fork-ref/index.ts
+++ b/packages/react/src/use-fork-ref/index.ts
@@ -1,0 +1,3 @@
+import useForkRef from './use-fork-ref';
+
+export default useForkRef;

--- a/packages/react/src/use-fork-ref/use-fork-ref.ts
+++ b/packages/react/src/use-fork-ref/use-fork-ref.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import type { Ref, MutableRefObject } from 'react';
+
+const setRef = <T>(
+  ref:
+    | MutableRefObject<T | null>
+    | ((instance: T | null) => void)
+    | null
+    | undefined,
+  value: T | null
+): void => {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+};
+
+const useForkRef = <InstanceA, InstanceB>(
+  refA: Ref<InstanceA> | null | undefined,
+  refB: Ref<InstanceB> | null | undefined
+): Ref<InstanceA & InstanceB> | null => {
+  /**
+   * This will create a new function if the ref props change and are defined.
+   * This means react will call the old forkRef with `null` and the new forkRef
+   * with the ref. Cleanup naturally emerges from this behavior.
+   */
+  return useMemo(() => {
+    if (refA == null && refB == null) {
+      return null;
+    }
+
+    return (refValue) => {
+      setRef(refA, refValue);
+      setRef(refB, refValue);
+    };
+  }, [refA, refB]);
+};
+
+export default useForkRef;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #476  <!-- Github issue # here -->

## 📝 Description

I have a use case where I need access to the underlying `img` element. At the moment, it's not possible to send own ref object.

## ⛳️ Current behavior (updates)

There is no way to use own ref to get access to the `img` element.

## 🚀 New behavior

I used `useForkRef` hook from `@mui/utils` that allows to combine two refs into one. That enables components to use internal ref as well as ref passed from props.

## 💣 Is this a breaking change (Yes/No):

No
