### PR TITLE
feat(storybook): theme toggle with nextui

### DIFF
--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -5,12 +5,12 @@ import { createTheme, NextUIProvider, styled } from '@nextui-org/react';
 
 const lightTheme = createTheme({
   type: 'light',
-  className: 'light-mode'
+  className: 'light-theme'
 });
 
 const darkTheme = createTheme({
   type: 'dark',
-  className: 'dark-mode'
+  className: 'dark-theme'
 });
 
 const Box = styled('div', {
@@ -22,7 +22,7 @@ const Box = styled('div', {
   alignItems: 'center',
   flexWrap: 'wrap',
   width: '100vw',
-  height: 'calc(100vh - 60px)'
+  height: '100vh'
 });
 
 export const decorators = [
@@ -36,11 +36,32 @@ export const decorators = [
 ];
 
 export const parameters = {
+  layout: 'fullscreen',
   actions: { argTypesRegex: '^on[A-Z].*' },
   darkMode: {
     stylePreview: true,
-    dark: { ...themes.dark, appBg: 'black' },
-    light: { ...themes.normal, appBg: 'white' }
+    darkClass: 'dark-theme',
+    lightClass: 'light-theme',
+    dark: {
+      ...themes.dark,
+      // accent0, accent1
+      appBg: '#161616',
+      barBg: '#262626',
+      background: '#161616',
+      appContentBg: '#161616',
+      // radii xs
+      appBorderRadius: 7
+    },
+    light: {
+      ...themes.normal,
+      // accent0, accent1
+      appBg: '#F5F5F5',
+      barBg: '#EDEDED',
+      background: '#F5F5F5',
+      appContentBg: '#F5F5F5',
+      // radii xs
+      appBorderRadius: 7
+    }
   },
   backgrounds: {
     default: 'light'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- Closes # Github issue # here -->

## 📝 Description

Storybook theme switching with NextUI.

## ⛳️ Current behavior (updates)

- Fullscreen canvas
- Correct the theme class
- Use NextUI radii `xs`
- Use NextUI color `accents`

<!--  ## 🚀 New behavior

> Please describe the behavior or changes this PR adds
 -->

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Screenshot of light theme

![light](https://user-images.githubusercontent.com/32772271/170454907-6da30cfe-dab0-4dc1-91dd-33fd2cbe9ef4.png)

Screenshot of dark theme

![dark](https://user-images.githubusercontent.com/32772271/170454832-4dc125e9-c799-444c-9ca2-d87be8753a2f.png)
