### PR TITLE
Prevent anchor links from hiding behind navbar

### DIFF
--- a/apps/docs/src/styles/globalStyles.ts
+++ b/apps/docs/src/styles/globalStyles.ts
@@ -1,6 +1,9 @@
 import { globalCss } from '@nextui-org/react';
 
 export default globalCss({
+  html: {
+    scrollPaddingTop: '80px'
+  },
   // css baseline overrides
   blockquote: {
     mb: '$14 !important',


### PR DESCRIPTION
## 📝 Description

When clicking any section title (rendered by `LinkedHeading()`) in doc, the page jump to where a part of the section is hiding behind the navbar.

This is a common problem caused by sticky navbar, which can be solved by CSS scroll snap module.

## ⛳️ Current behavior (updates)

![Current behavior](https://us1.myximage.com/2022/05/29/fb49dc13bf585df20d23cf4355e25c22.png)

Note that Size section actually hides behind navbar.

## 🚀 New behavior

![New behavior](https://us1.myximage.com/2022/05/29/d0025e4adfc7353dd6bfa40d55135c12.png)

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
