### PR TITLE
fix(react-table): safari row jitters on hover

### DIFF
--- a/packages/react/src/table/table.styles.ts
+++ b/packages/react/src/table/table.styles.ts
@@ -127,7 +127,9 @@ export const StyledTableCell = styled(
       size: '100%',
       top: 0,
       left: 0,
-      opacity: 0
+      opacity: 0,
+      transform: 'translateZ(0)',
+      backfaceVisibility: 'hidden'
     },
     variants: {
       align: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #509 

## 📝 Description
Table row jitters when mouse enters it on Safari

## ⛳️ Current behavior (updates)

Looks like safari has a slight flicker on transforms animations https://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform

## 🚀 New behavior

The issue has been fixed by adding:
```js
      transform: 'translateZ(0)',
      backfaceVisibility: 'hidden'
```

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
https://stackoverflow.com/questions/3461441/prevent-flicker-on-webkit-transition-of-webkit-transform