### PR TITLE
fix: card text selection

### DIFF
--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -55,7 +55,9 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         isHovered={isHovered}
         tabIndex={isPressable ? 0 : -1}
         isFocusVisible={isFocusVisible}
-        {...mergeProps(pressProps, focusProps, hoverProps, otherProps)}
+        {...(isPressable
+          ? mergeProps(pressProps, focusProps, hoverProps, otherProps)
+          : mergeProps(focusProps, hoverProps, otherProps))}
       >
         {isPressable && !disableAnimation && !disableRipple && (
           <Drip {...dripBindings} />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Texts on card components can not be selected by mouse when they are not pressable.

## ⛳️ Current behavior (updates)

Texts can not be selected nor copied.

## 🚀 New behavior

Texts can be selected and copied.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

This is a bug invoked by react-aria `usePress`. According to the author of `usePress()` ([explained here](https://github.com/adobe/react-spectrum/issues/2956#issuecomment-1069655946), which also involved the card implementation), we should avoid it when the card is not pressable. Correct me if I'm wrong 😂 not a pro of react-aria
