### PR TITLE
fix(react-card): internal components hover and text copy

### DIFF
--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -2,11 +2,23 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import Card from './index';
 import { styled } from '../theme/stitches.config';
-import { Row, Col, Link, Text, Code, Button, Grid } from '../index';
+import {
+  Row,
+  Col,
+  Link,
+  Text,
+  Code,
+  Button,
+  Grid,
+  Checkbox,
+  Spacer,
+  Input
+} from '../index';
 import AppleEvent from '../../assets/apple-event.jpeg';
 import Homepods from '../../assets/homepod.jpeg';
 import Relaxing from '../../assets/relaxing.jpeg';
 import BreathingApp from '../../assets/breathing-app-icon.jpeg';
+import { Mail, Password } from '../utils/icons';
 
 export default {
   title: 'Surfaces/Card',
@@ -667,5 +679,64 @@ export const Shadows = () => {
         </Grid>
       ))}
     </Grid.Container>
+  );
+};
+
+export const withForm = () => {
+  return (
+    <Card css={{ mw: '400px' }}>
+      <Card.Header css={{ justifyContent: 'center' }}>
+        <Text size={18}>
+          Welcome to&nbsp;
+          <Text b size={18}>
+            NextUI
+          </Text>
+        </Text>
+      </Card.Header>
+      <Card.Body css={{ px: '$10', pt: '$1', ov: 'visible' }}>
+        <Input
+          clearable
+          bordered
+          fullWidth
+          size="lg"
+          color="primary"
+          placeholder="Email"
+          contentLeft={<Mail fill="currentColor" />}
+        />
+        <Spacer y={0.5} />
+        <Input
+          clearable
+          bordered
+          fullWidth
+          size="lg"
+          color="primary"
+          placeholder="Password"
+          contentLeft={<Password />}
+        />
+        <Spacer y={0.5} />
+        <Row justify="space-between" align="center">
+          <Checkbox>
+            <Text size={14} css={{ color: '$accents8' }}>
+              Remember me
+            </Text>
+          </Checkbox>
+          <Link href="#" css={{ color: '$link', fontSize: '$sm' }}>
+            Forgot password?
+          </Link>
+        </Row>
+      </Card.Body>
+      <Card.Footer css={{ pt: 0 }}>
+        <Grid.Container justify="flex-end" gap={1}>
+          <Grid>
+            <Button auto flat>
+              Sign Up
+            </Button>
+          </Grid>
+          <Grid>
+            <Button auto>Login</Button>
+          </Grid>
+        </Grid.Container>
+      </Card.Footer>
+    </Card>
   );
 };

--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithoutRef, RefAttributes } from 'react';
 import type { ReactNode } from 'react';
-import { mergeProps } from '@react-aria/utils';
 import Drip from '../utils/drip';
 import { CSS } from '../theme/stitches.config';
 import { useCard } from './use-card';
@@ -35,9 +34,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
       disableRipple,
       borderWeight,
       isHovered,
-      pressProps,
-      focusProps,
-      hoverProps,
+      getCardProps,
       dripBindings
     } = useCard({ ...otherProps, ref });
 
@@ -55,9 +52,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         isHovered={isHovered}
         tabIndex={isPressable ? 0 : -1}
         isFocusVisible={isFocusVisible}
-        {...(isPressable
-          ? mergeProps(pressProps, focusProps, hoverProps, otherProps)
-          : mergeProps(focusProps, hoverProps, otherProps))}
+        {...getCardProps()}
       >
         {isPressable && !disableAnimation && !disableRipple && (
           <Drip {...dripBindings} />

--- a/packages/react/src/card/use-card.ts
+++ b/packages/react/src/card/use-card.ts
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useFocusRing } from '@react-aria/focus';
 import type {
   PressEvents,
   PressEvent,
   FocusableProps
 } from '@react-types/shared';
+import { mergeProps } from '@react-aria/utils';
 import type { FocusRingAria } from '@react-aria/focus';
 import { usePress } from '@react-aria/interactions';
 import { useHover } from '@react-aria/interactions';
@@ -96,6 +97,20 @@ export const useCard = (props: UseCardProps) => {
 
   pressProps.onClick = handleClick;
 
+  const getCardProps = useCallback(
+    (props = {}) => {
+      return {
+        ...mergeProps(
+          isPressable ? { ...pressProps, ...focusProps } : {},
+          isHoverable ? hoverProps : {},
+          otherProps,
+          props
+        )
+      };
+    },
+    [isPressable, isHoverable, pressProps, focusProps, hoverProps, otherProps]
+  );
+
   return {
     cardRef,
     variant,
@@ -105,13 +120,10 @@ export const useCard = (props: UseCardProps) => {
     isPressed,
     disableAnimation,
     disableRipple,
-    pressProps,
-    hoverProps,
     dripBindings,
-    focusProps,
     onDripClickHandler,
     isFocusVisible,
-    ...otherProps
+    getCardProps
   };
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

This PR solve the card internal components hover/focus/click issue.

## ⛳️ Current behavior (updates)

Currently users can't hover/focus/click the card internal components.

## 🚀 New behavior

`pressProps`, `focusProps` and `hoverProps` are now being conditionally applied to the card depending on whether the `isPressable` and `isHoverable` props are set to `true`.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
