### PR TITLE
Need Import React in Example

### DIFF
--- a/apps/docs/content/docs/guide/nextui-plus-nextjs.mdx
+++ b/apps/docs/content/docs/guide/nextui-plus-nextjs.mdx
@@ -50,6 +50,7 @@ to create file `_document.js`.
 Then we add the following code to the file:
 
 ```jsx
+import React from 'react';
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { CssBaseline } from '@nextui-org/react';
 


### PR DESCRIPTION
When trying to replicate the example it will fail since in the example the React instance is being requested in:

```jsx
     return {
                ...initialProps,
                styles: React.Children.toArray([initialProps.styles])
     //                  ^
};
  }
```

and this at no time matters

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> When trying to replicate the example it will fail since in the example the React instance is being requested and this at no time matters


## ⛳️ Current behavior (updates)

> I add the line import React from 'react'

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

At the time of following the steps and copying and pasting the example, this error will stop appearing
![image](https://user-images.githubusercontent.com/68222436/173219415-146d0c1a-cac0-4d55-9029-39b58bf7467a.png)


## 💣 Is this a breaking change (Yes/No):  No 

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->



## 📝 Additional Information

It's something simple that users can add, but for novice programmers it can be a headache to understand what is going wrong, and the idea that the learning curve or creating your project can be as simple as copy and paste.
