### PR TITLE
fix(react-table): Table.Pagination component doesn't update with Table.Body

### DIFF
--- a/packages/react/src/table/table-context.tsx
+++ b/packages/react/src/table/table-context.tsx
@@ -62,6 +62,7 @@ const Provider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
 
   useEffect(() => {
     setCollection(defaultValues?.collection);
+    setCurrentPage(defaultContext.currentPage);
   }, [defaultValues?.collection]);
 
   const providerValue = React.useMemo<TableConfig>(

--- a/packages/react/src/table/table-context.tsx
+++ b/packages/react/src/table/table-context.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { TableCollection } from '@react-types/table';
 import { NormalAlignment } from '../utils/prop-types';
 import { TableVariantsProps } from './table.styles';
@@ -59,6 +59,10 @@ const Provider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
   const [color, setColor] = React.useState<TableVariantsProps['color']>(
     defaultValues?.color
   );
+
+  useEffect(() => {
+    setCollection(defaultValues?.collection);
+  }, [defaultValues?.collection]);
 
   const providerValue = React.useMemo<TableConfig>(
     () => ({

--- a/packages/react/src/table/table-context.tsx
+++ b/packages/react/src/table/table-context.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { TableCollection } from '@react-types/table';
 import { NormalAlignment } from '../utils/prop-types';
 import { TableVariantsProps } from './table.styles';
@@ -60,7 +60,7 @@ const Provider: React.FC<React.PropsWithChildren<ProviderProps>> = ({
     defaultValues?.color
   );
 
-  useEffect(() => {
+  React.useEffect(() => {
     setCollection(defaultValues?.collection);
     setCurrentPage(defaultContext.currentPage);
   }, [defaultValues?.collection]);

--- a/packages/react/src/table/table-pagination.tsx
+++ b/packages/react/src/table/table-pagination.tsx
@@ -30,6 +30,7 @@ const TablePagination: React.FC<TablePaginationProps> = ({
     collection,
     footerAlign,
     rowsPerPage,
+    currentPage,
     setFooterAlign,
     setRowsPerPage,
     setCurrentPage
@@ -64,6 +65,7 @@ const TablePagination: React.FC<TablePaginationProps> = ({
       total={totalPagination}
       animated={animated}
       onChange={handlePageChanged}
+      page={currentPage}
       color={props.color || (color as PaginationProps['color'])}
       className={clsx('nextui-table-pagination', props.className)}
       {...props}

--- a/packages/react/src/table/table.stories.tsx
+++ b/packages/react/src/table/table.stories.tsx
@@ -453,7 +453,7 @@ export const SwitchPagination = () => {
             </Table.Column>
           )}
         </Table.Header>
-        <Table.Body items={moreRows ? rows : paginatedRows}>
+        <Table.Body items={moreRows ? paginatedRows : rows}>
           {(item) => (
             <Table.Row>
               {(columnKey) => (

--- a/packages/react/src/table/table.stories.tsx
+++ b/packages/react/src/table/table.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import Table, { TableProps, SortDescriptor } from './index';
 import { getKeyValue } from '../utils/object';
@@ -10,7 +10,9 @@ import {
   Tooltip,
   styled,
   useAsyncList,
-  useCollator
+  useCollator,
+  Button,
+  Spacer
 } from '../index';
 import { Eye, Edit, Delete } from '../utils/icons';
 
@@ -412,6 +414,63 @@ export const Pagination = () => {
         onPageChange={(page) => console.log({ page })}
       />
     </Table>
+  );
+};
+
+export const SwitchPagination = () => {
+  const [moreRows, setMoreRows] = useState(true);
+  return (
+    <>
+      <Button
+        onPress={() => {
+          setMoreRows(!moreRows);
+        }}
+      >
+        Switch
+      </Button>
+      <Spacer />
+      <Table
+        bordered
+        shadow={false}
+        aria-label="Example table with dynamic content"
+        css={{
+          minWidth: '620px',
+          height: 'auto',
+          '@xsMax': {
+            minWidth: '100%'
+          }
+        }}
+        selectionMode="multiple"
+        color="secondary"
+      >
+        <Table.Header columns={columns}>
+          {(column) => (
+            <Table.Column
+              key={column.uid}
+              align={column.uid === 'date' ? 'end' : 'start'}
+            >
+              {column.name}
+            </Table.Column>
+          )}
+        </Table.Header>
+        <Table.Body items={moreRows ? rows : paginatedRows}>
+          {(item) => (
+            <Table.Row>
+              {(columnKey) => (
+                <Table.Cell>{getKeyValue(item, columnKey)}</Table.Cell>
+              )}
+            </Table.Row>
+          )}
+        </Table.Body>
+        <Table.Pagination
+          shadow
+          noMargin
+          align="center"
+          rowsPerPage={3}
+          onPageChange={(page) => console.log({ page })}
+        />
+      </Table>
+    </>
   );
 };
 

--- a/packages/react/src/table/table.stories.tsx
+++ b/packages/react/src/table/table.stories.tsx
@@ -440,7 +440,6 @@ export const SwitchPagination = () => {
             minWidth: '100%'
           }
         }}
-        selectionMode="multiple"
         color="secondary"
       >
         <Table.Header columns={columns}>

--- a/packages/react/src/table/table.stories.tsx
+++ b/packages/react/src/table/table.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Meta } from '@storybook/react';
 import Table, { TableProps, SortDescriptor } from './index';
 import { getKeyValue } from '../utils/object';
@@ -418,7 +418,7 @@ export const Pagination = () => {
 };
 
 export const SwitchPagination = () => {
-  const [moreRows, setMoreRows] = useState(true);
+  const [moreRows, setMoreRows] = React.useState(true);
   return (
     <>
       <Button


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #543

## 📝 Description

Updating `<Table />` component can be a usual action, as mentioned in #543. However, `<Table.Pagination>` does not update synchronically with `<Table.Body />`, which results in two bugs:

1. `<Table.Pagination />` length doesn't change. So when rows number is larger after the update, some pages can not be selected via `<Table.Pagination />`.
2. When rows number is smaller comparing to the previous table, the original page of `<Table.Pagination />` is automatically selected and a blank table is showed.3. 

This is because:

1. The table context `collection` never updates when rows data change.
2. `<Pagination />` is not properly controlled as it does not receive the `page` prop.

## ⛳️ Current behavior (updates)

#543 described it thoroughly. I've added a new story here so it would be clearer to test.

![before](https://us1.myximage.com/2022/06/17/a32c959b2cb1bee040ddec5009d6c6f9.gif)

## 🚀 New behavior

![after](https://us1.myximage.com/2022/06/17/c539838cd0cfee528d98a917c464f657.gif)

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
