### PR TITLE
fix(docs):default value of animated props in avatar group

### DIFF
--- a/apps/docs/content/docs/components/avatar.mdx
+++ b/apps/docs/content/docs/components/avatar.mdx
@@ -100,7 +100,7 @@ import { Avatar } from '@nextui-org/react';
 | Attribute    | Type                          | Accepted values                  | Description                             | Default |
 | ------------ | ----------------------------- | -------------------------------- | --------------------------------------- | ------- |
 | **count**    | `number`                      | -                                | Total count of avatars                  | -       |
-| **animated** | `boolean`                     | -                                | Display translations animation on hover | `false` |
+| **animated** | `boolean`                     | -                                | Display translations animation on hover | `true` |
 | **css**      | `Stitches.CSS`                | -                                | Override Default CSS style              | -       |
 | **as**       | `keyof JSX.IntrinsicElements` | -                                | Changes which tag component outputs     | `div`   |
 | ...          | `HTMLAttributes`              | `'id', 'name', 'className', ...` | Native props                            | -       |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Fix the docs from `false` to `true` because it is `animated: true` in avatar-group

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
Fix the avatar-group.styles.ts file if the default value assumes false