### PR TITLE
fix(react-table): react-stately props

### DIFF
--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -1,12 +1,20 @@
-import React, {useImperativeHandle, useRef, RefAttributes, PropsWithoutRef} from "react";
-import {useTable} from "@react-aria/table";
-import {useTableState, TableStateProps} from "@react-stately/table";
-import {SelectionMode, SelectionBehavior, CollectionChildren} from "@react-types/shared";
+import React, {
+  useImperativeHandle,
+  useRef,
+  RefAttributes,
+  PropsWithoutRef,
+} from "react";
+import { useTable } from "@react-aria/table";
+import { useTableState, TableStateProps } from "@react-stately/table";
+import {
+  SelectionMode,
+  SelectionBehavior,
+  CollectionChildren,
+} from "@react-types/shared";
 
-import {Spacer} from "../index";
-import {CSS} from "../theme/stitches.config";
-import {pickSingleChild} from "../utils/collections";
-import {excludedTableProps} from "../utils/prop-types";
+import { Spacer } from "../index";
+import { CSS } from "../theme/stitches.config";
+import { pickSingleChild } from "../utils/collections";
 import withDefaults from "../utils/with-defaults";
 import clsx from "../utils/clsx";
 
@@ -30,8 +38,8 @@ import {
   TableVariantsProps,
   TableContainerVariantsProps,
 } from "./table.styles";
-import TableContext, {TableConfig} from "./table-context";
-import {isInfinityScroll, hasPaginationChild} from "./utils";
+import TableContext, { TableConfig } from "./table-context";
+import { isInfinityScroll, hasPaginationChild } from "./utils";
 
 interface Props<T> extends TableStateProps<T> {
   selectionMode?: SelectionMode;
@@ -41,12 +49,15 @@ interface Props<T> extends TableStateProps<T> {
   as?: keyof JSX.IntrinsicElements;
 }
 
-type NativeAttrs = Omit<React.TableHTMLAttributes<unknown>, keyof Props<object>>;
+type NativeAttrs = Omit<
+  React.TableHTMLAttributes<unknown>,
+  keyof Props<object>
+>;
 
 export type TableProps<T = object> = Props<T> &
   NativeAttrs &
   Omit<TableVariantsProps, "isMultiple" | "shadow" | "hasPagination"> &
-  TableContainerVariantsProps & {css?: CSS; containerCss?: CSS};
+  TableContainerVariantsProps & { css?: CSS; containerCss?: CSS };
 
 const defaultProps = {
   animated: true,
@@ -58,6 +69,7 @@ const defaultProps = {
 const Table = React.forwardRef<HTMLTableElement, TableProps>(
   (tableProps, ref: React.Ref<HTMLTableElement | null>) => {
     const {
+      css,
       selectionMode,
       selectionBehavior,
       hideLoading,
@@ -67,22 +79,23 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
       animated,
       borderWeight,
       bordered,
+      hoverable,
+      sticked,
       containerCss,
-      onSelectionChange,
-      onSortChange,
-      ...props
+      className,
     } = tableProps;
 
     const [withoutPaginationChildren, paginationChildren] = pickSingleChild<
       CollectionChildren<any>
     >(children, TablePagination);
 
-    const {hasPagination, rowsPerPage} = hasPaginationChild(children, TablePagination);
+    const { hasPagination, rowsPerPage } = hasPaginationChild(
+      children,
+      TablePagination
+    );
 
     const state = useTableState({
       ...tableProps,
-      onSelectionChange,
-      onSortChange,
       children: withoutPaginationChildren,
       showSelectionCheckboxes:
         tableProps.showSelectionCheckboxes !== undefined
@@ -90,19 +103,11 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
           : selectionMode === "multiple" && selectionBehavior !== "replace",
     });
 
-    // clean table props
-    Object.keys(props).forEach((propNameKey: any) => {
-      if (excludedTableProps.indexOf(propNameKey) > -1) {
-        // @ts-ignored
-        delete props[propNameKey];
-      }
-    });
-
     const tableRef = useRef<HTMLTableElement | null>(null);
 
     useImperativeHandle(ref, () => tableRef?.current);
 
-    const {collection} = state;
+    const { collection } = state;
     const {
       gridProps,
     }: {
@@ -124,24 +129,28 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
           borderWeight={borderWeight}
           bordered={bordered}
           className="nextui-table-container"
-          css={{...(containerCss as any)}}
+          css={{ ...(containerCss as any) }}
           shadow={shadow}
         >
           <StyledTable
             ref={tableRef}
             animated={animated}
-            className={clsx("nextui-table", props.className)}
+            className={clsx("nextui-table", className)}
             color={color}
+            css={css}
             hasPagination={hasPagination}
-            hoverable={selectionMode !== "none" || props.hoverable}
+            hoverable={selectionMode !== "none" || hoverable}
             isMultiple={selectionMode === "multiple"}
             shadow={shadow}
             {...gridProps}
-            {...props}
           >
             <TableRowGroup as="thead" isFixed={isInfinityScroll(collection)}>
               {collection.headerRows.map((headerRow) => (
-                <TableHeaderRow key={headerRow?.key} item={headerRow} state={state}>
+                <TableHeaderRow
+                  key={headerRow?.key}
+                  item={headerRow}
+                  state={state}
+                >
                   {[...headerRow.childNodes].map((column) =>
                     column?.props?.isSelectionCell ? (
                       <TableSelectAllCheckbox
@@ -158,11 +167,13 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
                         column={column}
                         state={state}
                       />
-                    ),
+                    )
                   )}
                 </TableHeaderRow>
               ))}
-              {!props.sticked && <Spacer as="tr" className="nextui-table-hidden-row" y={0.4} />}
+              {!sticked && (
+                <Spacer as="tr" className="nextui-table-hidden-row" y={0.4} />
+              )}
             </TableRowGroup>
             <TableBody
               animated={animated}
@@ -177,7 +188,11 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
               <TableFooter>
                 <Spacer as="tr" className="nextui-table-hidden-row" y={0.6} />
                 <tr role="row">
-                  <th colSpan={collection.columnCount} role="columnheader" tabIndex={-1}>
+                  <th
+                    colSpan={collection.columnCount}
+                    role="columnheader"
+                    tabIndex={-1}
+                  >
                     {paginationChildren}
                   </th>
                 </tr>
@@ -187,7 +202,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
         </StyledTableContainer>
       </TableContext.Provider>
     );
-  },
+  }
 );
 
 type TableComponent<T, P = {}> = React.ForwardRefExoticComponent<
@@ -204,4 +219,7 @@ type TableComponent<T, P = {}> = React.ForwardRefExoticComponent<
 Table.displayName = "NextUI.Table";
 Table.toString = () => ".nextui-table";
 
-export default withDefaults(Table, defaultProps) as TableComponent<HTMLTableElement, TableProps>;
+export default withDefaults(Table, defaultProps) as TableComponent<
+  HTMLTableElement,
+  TableProps
+>;

--- a/packages/react/src/table/table.tsx
+++ b/packages/react/src/table/table.tsx
@@ -68,6 +68,8 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
       borderWeight,
       bordered,
       containerCss,
+      onSelectionChange,
+      onSortChange,
       ...props
     } = tableProps;
 
@@ -79,6 +81,8 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     const state = useTableState({
       ...tableProps,
+      onSelectionChange,
+      onSortChange,
       children: withoutPaginationChildren,
       showSelectionCheckboxes:
         tableProps.showSelectionCheckboxes !== undefined

--- a/packages/react/src/utils/prop-types.ts
+++ b/packages/react/src/utils/prop-types.ts
@@ -1,4 +1,4 @@
-import {ElementType} from "react";
+import { ElementType } from "react";
 
 export const tuple = <T extends string[]>(...args: T) => args;
 
@@ -11,10 +11,17 @@ export const normalColors = tuple(
   "success",
   "warning",
   "error",
-  "gradient",
+  "gradient"
 );
 
-export const simpleColors = tuple("default", "primary", "secondary", "success", "warning", "error");
+export const simpleColors = tuple(
+  "default",
+  "primary",
+  "secondary",
+  "success",
+  "warning",
+  "error"
+);
 
 export const extendedColors = tuple(
   "default",
@@ -24,7 +31,7 @@ export const extendedColors = tuple(
   "warning",
   "error",
   "invert",
-  "gradient",
+  "gradient"
 );
 
 export const extendedColorsNoGradient = tuple(
@@ -34,7 +41,7 @@ export const extendedColorsNoGradient = tuple(
   "success",
   "warning",
   "error",
-  "invert",
+  "invert"
 );
 
 export const extraColors = tuple(
@@ -50,12 +57,24 @@ export const extraColors = tuple(
   "purple",
   "violet",
   "gradient",
-  "cyan",
+  "cyan"
 );
 
-export const normalLoaders = tuple("default", "points", "points-opacity", "gradient", "spinner");
+export const normalLoaders = tuple(
+  "default",
+  "points",
+  "points-opacity",
+  "gradient",
+  "spinner"
+);
 
-export const normalWeights = tuple("light", "normal", "bold", "extrabold", "black");
+export const normalWeights = tuple(
+  "light",
+  "normal",
+  "bold",
+  "extrabold",
+  "black"
+);
 
 export const textWeights = tuple(
   /* Keyword values */
@@ -68,7 +87,7 @@ export const textWeights = tuple(
   "inherit",
   "initial",
   "revert",
-  "unset",
+  "unset"
 );
 
 export const textTransforms = tuple(
@@ -83,7 +102,7 @@ export const textTransforms = tuple(
   "inherit",
   "initial",
   "revert",
-  "unset",
+  "unset"
 );
 
 const copyTypes = tuple("default", "slient", "prevent");
@@ -102,7 +121,7 @@ const placement = tuple(
   "bottomEnd",
   "right",
   "rightStart",
-  "rightEnd",
+  "rightEnd"
 );
 
 const position = tuple(
@@ -115,7 +134,7 @@ const position = tuple(
   "inherit",
   "initial",
   "revert",
-  "unset",
+  "unset"
 );
 
 const objectFit = tuple(
@@ -128,7 +147,7 @@ const objectFit = tuple(
   "inherit",
   "initial",
   "revert",
-  "unset",
+  "unset"
 );
 
 const dividerAlign = tuple("start", "center", "end", "left", "right");
@@ -139,10 +158,16 @@ const justify = tuple(
   "flex-end",
   "space-between",
   "space-around",
-  "space-evenly",
+  "space-evenly"
 );
 
-const alignItems = tuple("flex-start", "flex-end", "center", "stretch", "baseline");
+const alignItems = tuple(
+  "flex-start",
+  "flex-end",
+  "center",
+  "stretch",
+  "baseline"
+);
 
 const alignContent = tuple(
   "stretch",
@@ -150,7 +175,7 @@ const alignContent = tuple(
   "flex-start",
   "flex-end",
   "space-between",
-  "space-around",
+  "space-around"
 );
 
 const direction = tuple("row", "row-reverse", "column", "column-reverse");
@@ -164,7 +189,7 @@ const display = tuple(
   "inline",
   "inline-block",
   "inline-flex",
-  "inline-grid",
+  "inline-grid"
 );
 
 const contentPosition = tuple("left", "right");
@@ -184,17 +209,7 @@ export const excludedInputPropsForTextarea = tuple(
   "contentRightStyling",
   "onContentClick",
   "onClearClick",
-  "css",
-);
-
-export const excludedTableProps = tuple(
-  "items",
-  "disabledKeys",
-  "allowDuplicateSelectionEvents",
-  "disallowEmptySelection",
-  "defaultSelectedKeys",
-  "sortDescriptor",
-  "onSortChange",
+  "css"
 );
 
 const selectionBehavior = tuple("toggle", "replace");


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes [#557  <!-- Github issue # here -->](https://github.com/nextui-org/nextui/issues/557)

## 📝 Description

It's not possible to replicate the same issue locally in storybook, but I noticed that some props from @react-stately/table hook `useTableState` were being wrongly spread into `StyledTable`. That's why the dom was complaining regarding the `onSelectionChange`, because that event does not exist natively.

## ⛳️ Current behavior (updates)

I'm not changing any behaviour, just strictly passing the correct props.

## 🚀 New behavior

No new behaviour.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Would be nice to understand why the storybook instance is suppressing this error.

@jrgarciadev, let me know if you agree with my commit text.
