### PR TITLE
fix(doc): remove unimplemented Dropdown API

### DIFF
--- a/apps/docs/content/docs/components/dropdown.mdx
+++ b/apps/docs/content/docs/components/dropdown.mdx
@@ -259,15 +259,6 @@ import { Dropdown } from '@nextui-org/react';
 | -------------- | -------- | ------------------------------------------------------ | ------- |
 | **aria-label** | `string` | A screen reader only label for the dropdown menu item. | -       |
 
-<Spacer y={1} />
-
-#### Dropdown.Item Events
-
-| Attribute    | Type                                                                            | Description                                                                | Default |
-| ------------ | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------- |
-| **onAction** | <Code>(key: [Key](https://reactjs.org/docs/lists-and-keys.html)) => void</Code> | Handler that is called when the user activates the item.                   | -       |
-| **onClose**  | <Code>() => void</Code>                                                         | Handler that is called when the menu should close after selecting an item. | -       |
-
 <Spacer y={2} />
 
 ---


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #585

## 📝 Description

`onAction` & `onClose` are currently not `Dropdown.Item` props and may lead to confusion.

## 💣 Is this a breaking change (Yes/No): No
