### PR TITLE
fix(react-card): box shadow applied intead of box shadow filter on sa…

### DIFF
--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -24,6 +24,14 @@ export const Default = () => (
   </Card>
 );
 
+export const Hoverable = () => (
+  <Card isHoverable css={{w: "400px"}} variant="bordered">
+    <Card.Body css={{py: "$lg"}}>
+      <Text>A basic card</Text>
+    </Card.Body>
+  </Card>
+);
+
 export const Variants = () => (
   <Grid.Container gap={2}>
     <Grid xs={4}>

--- a/packages/react/src/card/card.styles.ts
+++ b/packages/react/src/card/card.styles.ts
@@ -55,6 +55,10 @@ export const StyledCard = styled(
         },
         shadow: {
           dropShadow: "$lg",
+          "@safari": {
+            boxShadow: "$lg",
+            dropShadow: "none",
+          },
         },
         bordered: {
           borderStyle: "solid",
@@ -99,6 +103,10 @@ export const StyledCard = styled(
       isHovered: {
         true: {
           dropShadow: "$lg",
+          "@safari": {
+            boxShadow: "$lg",
+            dropShadow: "none",
+          },
         },
       },
     },
@@ -125,6 +133,10 @@ export const StyledCard = styled(
         variant: "shadow",
         css: {
           dropShadow: "$xl",
+          "@safari": {
+            boxShadow: "$xl",
+            dropShadow: "none",
+          },
         },
       },
     ],


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #578 

## 🚀 New behavior

Card's shadows are working on safari, it looks like safari doesn't support really well the `drop-shadow` filter, we use it because it's useful to not lose the `outline` of the card when in pressed/navigated by the keyboard


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
