### PR TITLE
docs: fix typo in the Table docs

### DIFF
--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -112,7 +112,7 @@ import { Table } from '@nextui-org/react';
 />
 
 <Playground
-  title="Infinty Pagination"
+  title="Infinity Pagination"
   desc="Table supports loading data asynchronously, and will display a progress loading set by the loadingState prop. 
   It also supports infinite scrolling to load more data on demand as the user scrolls, via the `onLoadMore` prop."
   highlightedLines="38-40"


### PR DESCRIPTION
Fixes a typo in the Table docs.


