### PR TITLE
fix(react-pagination): add active page to memoized callback deps

### DIFF
--- a/packages/react/src/use-pagination/index.ts
+++ b/packages/react/src/use-pagination/index.ts
@@ -46,7 +46,7 @@ const usePagination = ({
         onChangeActivePage(pageNumber);
       }
     },
-    [total],
+    [total, activePage],
   );
 
   const next = () => setPage(activePage + 1);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/619

## 📝 Description

Reading `state` in pagination's `onChange` will always return the initial value.

## ⛳️ Current behavior (updates)

Add `activePage` to the memoized callback deps.

## 🚀 New behavior

Update or changes if `total, activePage` (deps) has been changed.

Read more: [`usecallback`](https://reactjs.org/docs/hooks-reference.html#usecallback).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

> **Note** The branch based on `next`.
