### PR TITLE
Fix: isRequired radio component support

### DIFF
--- a/packages/react/src/radio/radio.stories.tsx
+++ b/packages/react/src/radio/radio.stories.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { FormEvent } from 'react';
 import { Meta } from '@storybook/react';
 import Radio from './index';
+
+const handleSubmit = (e: FormEvent) => {
+  e.preventDefault()
+  alert('Submitted!')
+}
 
 export default {
   title: 'Inputs/Radio',
@@ -16,6 +21,18 @@ export const Default = () => (
     <Radio value="D">Option D</Radio>
   </Radio.Group>
 );
+
+export const Required = () => (
+  <form onSubmit={handleSubmit}>
+    <Radio.Group label="Options" isRequired>
+      <Radio value="A">Option A</Radio>
+      <Radio value="B">Option B</Radio>
+      <Radio value="C">Option C</Radio>
+      <Radio value="D">Option D</Radio>
+    </Radio.Group>
+    <button type='submit'>Submit</button>
+  </form>
+)
 
 export const Disabled = () => (
   <Radio.Group label="Options" defaultValue="A" isDisabled>

--- a/packages/react/src/radio/radio.tsx
+++ b/packages/react/src/radio/radio.tsx
@@ -51,8 +51,10 @@ export const Radio = React.forwardRef(
       autoFocus,
       disableAnimation,
       hoverProps,
-      inputProps
+      inputProps,
+      required,
     } = useRadio({ ...otherProps, children: children ?? label });
+
 
     const domRef = useFocusableRef<HTMLLabelElement>(
       ref as FocusableRef<HTMLLabelElement>,
@@ -100,6 +102,7 @@ export const Radio = React.forwardRef(
               <input
                 ref={inputRef}
                 className="nextui-radio-input"
+                required={required}
                 {...mergeProps(inputProps, focusProps)}
               />
             </VisuallyHidden>

--- a/packages/react/src/radio/use-radio.ts
+++ b/packages/react/src/radio/use-radio.ts
@@ -67,6 +67,11 @@ export const useRadio = (props: UseRadioProps) => {
     [groupContext.validationState]
   );
 
+  const required = useMemo(
+    ()=> groupContext.isRequired ?? false,
+    [groupContext.isRequired]
+  )
+
   return {
     size,
     color,
@@ -79,7 +84,8 @@ export const useRadio = (props: UseRadioProps) => {
     isSquared,
     disableAnimation,
     inputProps,
-    hoverProps
+    hoverProps,
+    required
   };
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

Support for isRequired parameter in Radio.Group

## ⛳️ Current behavior (updates)

Currently isRequired does not work as intended, as it does not create "required" props for inner <input> radio tags

## 🚀 New behavior

Adds expected behavior for isRequired prop.

## 💣 Is this a breaking change (Yes/No):

No
