### PR TITLE
Pass input value to onContentClick handler

### DIFF
--- a/packages/react/src/input/input-props.ts
+++ b/packages/react/src/input/input-props.ts
@@ -48,7 +48,8 @@ export interface Props
   onBlur?: (e: React.FocusEvent<FormElement>) => void;
   onContentClick?: (
     key: ContentPosition,
-    e: React.MouseEvent<HTMLDivElement>
+    e: React.MouseEvent<HTMLDivElement>,
+    inputValue: string
   ) => void;
   autoComplete?: string;
 }

--- a/packages/react/src/input/input.tsx
+++ b/packages/react/src/input/input.tsx
@@ -169,7 +169,7 @@ const Input = React.forwardRef<FormElement, InputProps>(
       e: React.MouseEvent<HTMLDivElement>
     ) => {
       if (disabled) return;
-      onContentClick && onContentClick(key, e);
+      onContentClick && onContentClick(key, e, selfValue);
     };
 
     useEffect(() => {


### PR DESCRIPTION
I think it would be really convenient to pass the current value of an input field to the onContentClick handler for the use case that the content is a button that should submit the input value. I know there are other ways to solve this but directly passing the value in the handler seems by far the most simple version to me.