### PR TITLE
feat: Add isDisabled property to tooltip &  Fix abnormal props.content display #683

### DIFF
--- a/packages/react/src/tooltip/__test__/index.test.tsx
+++ b/packages/react/src/tooltip/__test__/index.test.tsx
@@ -147,4 +147,14 @@ describe("Tooltip", () => {
 
     expect(wrapper.find("#visible").length).toBe(0);
   });
+
+  it("should not render when props.isDisabled present", async () => {
+    const wrapper = mount(
+      <div>
+        <Tooltip isDisabled content={<p id="visible">custom-content</p>}>some tips</Tooltip>
+      </div>,
+    );
+
+    expect(wrapper.find("#visible").length).toBe(0);
+  });
 });

--- a/packages/react/src/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/tooltip/tooltip.stories.tsx
@@ -294,3 +294,16 @@ export const WithoutContent = () => {
     </Container>
   );
 };
+
+export const Disabled = () => {
+  return (
+    <Container>
+      <Tooltip isDisabled color="primary" content="Developers love Next.js">
+        <Button auto flat color="error">
+          Disabled
+        </Button>
+      </Tooltip>
+    </Container>
+  );
+};
+

--- a/packages/react/src/tooltip/tooltip.tsx
+++ b/packages/react/src/tooltip/tooltip.tsx
@@ -32,6 +32,7 @@ interface Props {
   onVisibleChange?: TooltipOnVisibleChange;
   as?: keyof JSX.IntrinsicElements;
   triggerCss?: CSS;
+  isDisabled?: boolean;
 }
 
 const defaultProps = {
@@ -80,6 +81,7 @@ const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
   onClick,
   keepMounted,
   visible: customVisible,
+  isDisabled,
   ...props
 }) => {
   const timer = useRef<number>();
@@ -155,7 +157,7 @@ const Tooltip: React.FC<React.PropsWithChildren<TooltipProps>> = ({
       {...props}
     >
       {children}
-      {content && <TooltipContent {...contentProps}>{content}</TooltipContent>}
+      {content && !isDisabled ? <TooltipContent {...contentProps}>{content}</TooltipContent> : null}
     </StyledTooltipTrigger>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #683

## 📝 Description

- feature: Add isDisabled property to tooltip. #683
- fix: props.content display errors


## ⛳️ Current behavior (updates)

- Test Code: 

```tsx
export const WithoutContent = () => {
  return (
    <Container>
      <Tooltip color="primary" content={0}>
        <Button auto flat>
          Do hover here
        </Button>
      </Tooltip>
    </Container>
  );
};
```

- Incorrect display
<img width="822" alt="image" src="https://user-images.githubusercontent.com/45115006/186713898-763cee7f-f055-4465-a4d5-0f3c4ad5ebda.png">

- Code

```tsx
{content && <TooltipContent {...contentProps}>{content}</TooltipContent>}
```

## 🚀 New behavior

Normal display and disable requirements.

![Kapture 2022-08-25 at 23 57 48](https://user-images.githubusercontent.com/45115006/186713370-0182be11-49bc-43a2-bb9a-2f0752f2bdd5.gif)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
