### PR TITLE
fix(react-radio): radio group isRequired prop passed directly to the …

### DIFF
--- a/packages/react/src/radio/use-radio-group.ts
+++ b/packages/react/src/radio/use-radio-group.ts
@@ -39,6 +39,7 @@ export const useRadioGroup = (props: UseRadioGroupProps) => {
   const otherPropsWithOrientation = useMemo<AriaRadioGroupProps>(() => {
     return {
       ...otherProps,
+      isRequired,
       orientation,
     };
   }, [otherProps]);


### PR DESCRIPTION
…useRadioGgoup hook

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #710 

## 📝 Description

The Radio.Group does not include the required parameter.


## 🚀 New behavior

The `isRequired` prop is now being passed directly to the `useRadioGroup` hook from `react-aria` 

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
