### PR TITLE
Fix 707/textarea input circular dependecy

### DIFF
--- a/apps/docs/content/components/navbar/common.ts
+++ b/apps/docs/content/components/navbar/common.ts
@@ -109,9 +109,7 @@ import { Box } from "./Box.js";
 export const Layout = ({ children }) => (
   <Box
     css={{
-      maxW: "100%",
-      position: "relative",
-      overflow: "visible scroll",
+      maxW: "100%"
     }}
   >
     {children}

--- a/packages/react/src/input/index.ts
+++ b/packages/react/src/input/index.ts
@@ -1,5 +1,3 @@
-import Textarea from "../textarea";
-
 import Input from "./input";
 import InputPassword from "./input-password";
 
@@ -29,7 +27,6 @@ export type {
   InputContentVariantsProps,
 } from "./input.styles";
 
-Input.Textarea = Textarea;
 Input.Password = InputPassword;
 
 export default Input;

--- a/packages/react/src/input/input.tsx
+++ b/packages/react/src/input/input.tsx
@@ -11,7 +11,6 @@ import {useLabel} from "@react-aria/label";
 
 import {ContentPosition} from "../utils/prop-types";
 import {CSS} from "../theme/stitches.config";
-import Textarea from "../textarea";
 import useTheme from "../use-theme";
 import {warn} from "../utils/console";
 import ClearIcon from "../utils/clear-icon";
@@ -376,7 +375,6 @@ const Input = React.forwardRef<FormElement, InputProps>(
 type InputComponent<T, P = {}> = React.ForwardRefExoticComponent<
   PropsWithoutRef<P> & RefAttributes<T>
 > & {
-  Textarea: typeof Textarea;
   Password: typeof InputPassword;
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #707 

## 📝 Description

Circular dependency between the `input` and `Textarea` components

## ⛳️ Current behavior (updates)

#707 

## 🚀 New behavior

`Textarea` import was removed from the `Input` files


## 💣 Is this a breaking change (Yes/No): Yes

If you are using the `Input.Textarea` compound component, you should migrate to `Textarea` 
