### PR TITLE
fix(react-dropdown): supports popover content custom css, safari anim…

### DIFF
--- a/apps/docs/content/docs/components/dropdown.mdx
+++ b/apps/docs/content/docs/components/dropdown.mdx
@@ -207,6 +207,7 @@ import { Dropdown } from "@nextui-org/react";
 | **autoFocus**              | `boolean` [FocusStrategyType](#focus-strategy-type)                                                          | Where the focus should be set.                                                                          | `false`   |
 | **shouldFocusWrap**        | `boolean`                                                                                                    | Whether keyboard navigation is circular.                                                                | `false`   |
 | **css**                    | `Stitches.CSS`                                                                                               | Override Default CSS style.                                                                             | -         |
+| **containerCss** `new`     | `Stitches.CSS`                                                                                               | Override the dropdown mmenu container (`Popover.Content`) CSS style.                                    | -         |
 | **as**                     | `keyof JSX.IntrinsicElements`                                                                                | Changes which tag component outputs.                                                                    | `ul`      |
 
 <Spacer y={1} />

--- a/apps/docs/src/pages/examples/navbar/with-dropdown-menu.tsx
+++ b/apps/docs/src/pages/examples/navbar/with-dropdown-menu.tsx
@@ -46,6 +46,10 @@ export default function NavbarWithDropdownMenuExample() {
             </Navbar.Item>
             <Dropdown.Menu
               aria-label="ACME features"
+              containerCss={{
+                position: "fixed",
+                top: "64px",
+              }}
               css={{
                 $$dropdownMenuWidth: "340px",
                 $$dropdownItemHeight: "70px",

--- a/packages/react/src/dropdown/dropdown-menu.tsx
+++ b/packages/react/src/dropdown/dropdown-menu.tsx
@@ -7,6 +7,7 @@ import {useMenu} from "@react-aria/menu";
 import {useTreeState} from "@react-stately/tree";
 import {mergeProps} from "@react-aria/utils";
 
+import Popover from "../popover";
 import {useDOMRef, useSyncRef} from "../utils/dom";
 import {CSS} from "../theme/stitches.config";
 import clsx from "../utils/clsx";
@@ -34,6 +35,7 @@ interface Props<T> extends AriaMenuProps<T>, DOMProps, AriaLabelingProps {
    * @default 'default'
    */
   textColor?: SimpleColors;
+  containerCss?: CSS;
 }
 
 type NativeAttrs = Omit<React.HTMLAttributes<unknown>, keyof Props<object>>;
@@ -48,6 +50,7 @@ const DropdownMenu = React.forwardRef(
       color = "default",
       textColor = "default",
       variant = "flat",
+      containerCss,
       ...otherProps
     } = props;
 
@@ -63,17 +66,30 @@ const DropdownMenu = React.forwardRef(
     useSyncRef(context, domRef);
 
     return (
-      <StyledDropdownMenu
-        ref={domRef}
-        as={as}
-        className={clsx("nextui-dropdown-menu", props.className)}
-        css={{...(css as any)}}
-        {...menuProps}
-      >
-        {[...state.collection].map((item) => {
-          if (item.type === "section") {
-            return (
-              <DropdownSection
+      <Popover.Content css={containerCss}>
+        <StyledDropdownMenu
+          ref={domRef}
+          as={as}
+          className={clsx("nextui-dropdown-menu", props.className)}
+          css={{...(css as any)}}
+          {...menuProps}
+        >
+          {[...state.collection].map((item) => {
+            if (item.type === "section") {
+              return (
+                <DropdownSection
+                  key={item.key}
+                  color={color}
+                  item={item}
+                  state={state}
+                  textColor={textColor}
+                  variant={variant}
+                  onAction={completeProps.onAction}
+                />
+              );
+            }
+            let dropdownItem = (
+              <DropdownItem
                 key={item.key}
                 color={color}
                 item={item}
@@ -83,26 +99,15 @@ const DropdownMenu = React.forwardRef(
                 onAction={completeProps.onAction}
               />
             );
-          }
-          let dropdownItem = (
-            <DropdownItem
-              key={item.key}
-              color={color}
-              item={item}
-              state={state}
-              textColor={textColor}
-              variant={variant}
-              onAction={completeProps.onAction}
-            />
-          );
 
-          if (item.wrapper) {
-            dropdownItem = item.wrapper(dropdownItem);
-          }
+            if (item.wrapper) {
+              dropdownItem = item.wrapper(dropdownItem);
+            }
 
-          return dropdownItem;
-        })}
-      </StyledDropdownMenu>
+            return dropdownItem;
+          })}
+        </StyledDropdownMenu>
+      </Popover.Content>
     );
   },
 );

--- a/packages/react/src/dropdown/dropdown.tsx
+++ b/packages/react/src/dropdown/dropdown.tsx
@@ -41,7 +41,7 @@ const Dropdown = (props: DropdownProps) => {
         onClose={context.state.close}
       >
         {menuTrigger}
-        <Popover.Content>{menu}</Popover.Content>
+        {menu}
       </Popover>
     </DropdownProvider>
   );

--- a/packages/react/src/popover/popover-content.tsx
+++ b/packages/react/src/popover/popover-content.tsx
@@ -51,6 +51,11 @@ const PopoverContent = React.forwardRef(
 
     const transformOrigin = getTransformOrigin(placement);
 
+    const popoverCss = {
+      transformOrigin,
+      ...css,
+    };
+
     // Hide content outside the modal from screen readers.
     const {modalProps} = useModal({isDisabled: true});
 
@@ -82,13 +87,10 @@ const PopoverContent = React.forwardRef(
         ref={mergeRefs(overlayRef, ref)}
         {...getPopoverProps(
           mergeProps(overlayProps, modalProps, dialogProps, focusProps, completeProps),
+          popoverCss,
         )}
         as={as}
         className={clsx("nextui-popover-content-container", className)}
-        css={{
-          transformOrigin,
-          ...(css as any),
-        }}
         isFocusVisible={isFocusVisible}
       >
         <DismissButton onDismiss={onClose} />

--- a/packages/react/src/popover/popover.styles.ts
+++ b/packages/react/src/popover/popover.styles.ts
@@ -4,7 +4,7 @@ import {cssFocusVisible} from "../theme/shared-css";
 export const appearanceIn = keyframes({
   "0%": {
     opacity: 0,
-    transform: "scale(0.95)",
+    transform: "translateZ(0)  scale(0.95)",
   },
   "60%": {
     opacity: 0.75,
@@ -15,6 +15,7 @@ export const appearanceIn = keyframes({
   },
   "100%": {
     opacity: 1,
+    transform: "translateZ(0) scale(1)",
   },
 });
 
@@ -67,7 +68,7 @@ export const StyledPopoverContentContainer = styled(
       animationName: appearanceIn,
       animationTimingFunction: "ease-out",
       animationDirection: "normal",
-      animationDuration: "250ms",
+      animationDuration: "300ms",
     },
 
     "&.nextui-popover-content-leave": {

--- a/packages/react/src/popover/use-popover.ts
+++ b/packages/react/src/popover/use-popover.ts
@@ -7,6 +7,7 @@ import {useOverlayPosition, useOverlayTrigger} from "@react-aria/overlays";
 import {useOverlayTriggerState} from "@react-stately/overlays";
 
 import {mergeRefs} from "../utils/refs";
+import {isObject} from "../utils/object";
 
 import {PopoverPlacement, getAriaPlacement} from "./utils";
 import {PopoverContentVariantsProps} from "./popover.styles";
@@ -152,11 +153,37 @@ export function usePopover(props: UsePopoverProps = {}) {
   );
 
   const getPopoverProps = useCallback(
-    (props = {}) => {
+    (props = {}, css = {}) => {
+      const positionKeys = positionProps.style ? Object.keys(positionProps.style) : [];
+      let positionCss = {};
+
+      positionKeys.forEach((key) => {
+        const value = isObject(css) && css[key];
+
+        if (value) {
+          positionCss = {
+            ...positionCss,
+            [key]: value,
+          };
+        }
+      });
+
+      const realPositionProps =
+        Object.keys(positionCss).length > 0
+          ? {
+              ...positionProps,
+              style: {
+                ...positionProps.style,
+                ...positionCss,
+              },
+            }
+          : positionProps;
+
       return {
+        css,
         ...props,
         ...overlayProps,
-        ...positionProps,
+        ...realPositionProps,
         "data-state": getState,
         "data-placement": placement,
       };


### PR DESCRIPTION
…ation fixed

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #730 

## 📝 Description

The navbar dropdown loses the position on scroll

## ⛳️ Current behavior (updates)

The navbar dropdown loses the position on scroll

## 🚀 New behavior

- Dropdown is now able to use the Popover.Content CSS prop to set the desired `position`
- Safari dropdown animation fixed

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

Dropdown new prop:

`containerCss`: Override the dropdown mmenu container (`Popover.Content`) CSS style.
