### PR TITLE
fix: Link icon example missing isExternal prop (fix #742)

### DIFF
--- a/apps/docs/content/components/link/icon.ts
+++ b/apps/docs/content/components/link/icon.ts
@@ -3,11 +3,11 @@ const App = `import { Link, Spacer } from "@nextui-org/react";
 export default function App() {
   return (
     <>
-      <Link href="#" icon>
+      <Link href="#">
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
       <Spacer />
-      <Link href="#" icon isExternal>
+      <Link href="#" isExternal>
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
     </>

--- a/apps/docs/content/components/link/icon.ts
+++ b/apps/docs/content/components/link/icon.ts
@@ -7,7 +7,7 @@ export default function App() {
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
       <Spacer />
-      <Link href="#" icon color>
+      <Link href="#" icon isExternal>
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
     </>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #742

## 📝 Description

https://nextui.org/docs/components/link#external-link miss `isExternal` prop.

## ⛳️ Current behavior (updates)

<img width="872" alt="image" src="https://user-images.githubusercontent.com/102238922/188681207-e224d744-6af6-4cb9-a992-c0a820c34b3b.png">



## 🚀 New behavior

<img width="865" alt="image" src="https://user-images.githubusercontent.com/102238922/188681476-e6e9b3ca-f995-4ffb-8726-6b404805efc9.png">




## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information

`Link` uses `isExternal` prop just to control whether to show `LinkIcon`. The literal meaning of `isExternal` is a bit obscure. Maybe naming it `icon` is better? When `icon` is set true, show default internal `LinkIcon`; When `icon` is set other icon component, then just show it. @jrgarciadev 
