### PR TITLE
fix(button): Button prop as in typescript

### DIFF
--- a/packages/react/src/button/button.tsx
+++ b/packages/react/src/button/button.tsx
@@ -64,7 +64,7 @@ interface IFocusRingAria extends FocusRingAria {
 type VariantProps = Omit<ButtonVariantsProps, "isPressed" | "isHovered" | "isChildLess">;
 
 export type ButtonProps = Props &
-  Omit<HTMLNextUIProps<"button">, keyof VariantProps> &
+  Omit<HTMLNextUIProps<button>, keyof VariantProps> &
   VariantProps;
 
 const Button = forwardRef<ButtonProps, "button">((props, ref) => {


### PR DESCRIPTION
## 📝 Description

> When we use button "as" in typescript ,the props will not extend.

## ⛳️ Current behavior (updates)

>pass the wrong type
`Omit<HTMLNextUIProps<"button">` 

## 🚀 New behavior

>change to type button
`Omit<HTMLNextUIProps<button>` 

## 💣 Is this a breaking change (Yes/No):

No

