### PR TITLE
Progress never full prop

### DIFF
--- a/apps/docs/content/docs/components/progress.mdx
+++ b/apps/docs/content/docs/components/progress.mdx
@@ -91,6 +91,7 @@ import { Progress } from '@nextui-org/react';
 | **shadow**         | `boolean`                       | `true/false`                   | Display shadow effect                           | `false`    |
 | **squared**        | `boolean`                       | `true/false`                   | Squared progress                                | `false`    | 
 | **animated**       | `boolean`                       | `true/false`                   | Enable or disable the progress animation        | `true`     |
+| **neverFull**      | `boolean`                       | `true/false`                   | Make percent max out at 98                      | `false`    |
 | **css**            | `Stitches.CSS`                  | -                              | Override Default CSS style                      | -          |
 | **as**             | `keyof JSX.IntrinsicElements`   | -                              | Changes which tag component outputs             | `div`      |
 | ...                | `ProgressHTMLAttributes`        | `'id', 'className', ...`       | Progress native props                           | -          |

--- a/packages/react/src/progress/progress.tsx
+++ b/packages/react/src/progress/progress.tsx
@@ -18,6 +18,7 @@ interface Props {
   max?: number;
   min?: number;
   css?: CSS;
+  neverFull?: boolean;
   as?: keyof JSX.IntrinsicElements;
 }
 
@@ -49,6 +50,7 @@ const Progress: React.FC<ProgressProps> = ({
   shadow,
   indeterminated,
   css,
+  neverFull,
   ...props
 }) => {
   const value = useMemo(
@@ -56,7 +58,9 @@ const Progress: React.FC<ProgressProps> = ({
     [valueProp, min, max],
   );
 
-  const percent = useMemo(() => valueToPercent(value, min, max), [value, min, max]);
+  let percent = useMemo(() => valueToPercent(value, min, max), [value, min, max]);
+  if (neverFull && percent == 100) percent = 98
+    
 
   return (
     <StyledProgress


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

> Added a prop that makes the progress bar never full. A use case would be when you set the max value to a really low number (say, 3), and you want to avoid the "why is it loading at 100%" response from users.

## 💣 Is this a breaking change (Yes/No): No
