### PR TITLE
fix(react): id mismatch during hydration

### DIFF
--- a/packages/react/src/checkbox/use-checkbox-group.ts
+++ b/packages/react/src/checkbox/use-checkbox-group.ts
@@ -5,7 +5,10 @@ import type {NormalSizes, NormalColors, SimpleColors} from "../utils/prop-types"
 
 import {useCheckboxGroup as useReactAriaCheckboxGroup} from "@react-aria/checkbox";
 import {useCheckboxGroupState} from "@react-stately/checkbox";
-import React from "react";
+import {mergeProps} from "@react-aria/utils";
+import React, {useMemo} from "react";
+
+import useId from "../use-id";
 
 interface Props extends AriaCheckboxGroupProps {
   size?: NormalSizes;
@@ -31,9 +34,20 @@ export const useCheckboxGroup = (props: UseCheckboxGroupProps = {}) => {
     ...otherProps
   } = props;
 
+  const labelId = useId();
+  const id = useId(props?.id);
+
   const groupState = useCheckboxGroupState(otherProps);
 
-  const {labelProps, groupProps} = useReactAriaCheckboxGroup(otherProps, groupState);
+  const checkboxGroup = useReactAriaCheckboxGroup(otherProps, groupState);
+
+  const groupProps = useMemo(() => {
+    return mergeProps(checkboxGroup.groupProps, {id, "aria-labelledby": labelId});
+  }, [checkboxGroup.groupProps, id, labelId]);
+
+  const labelProps = useMemo(() => {
+    return mergeProps(checkboxGroup.labelProps, {id: labelId});
+  }, [checkboxGroup.labelProps, labelId]);
 
   return {
     css,

--- a/packages/react/src/collapse/collapse.tsx
+++ b/packages/react/src/collapse/collapse.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useMemo} from "react";
 import {useFocusRing} from "@react-aria/focus";
-import {useId} from "@react-aria/utils";
 
 import {warn} from "../utils/console";
 import useCurrentState from "../use-current-state";
@@ -9,6 +8,7 @@ import {CSS} from "../theme/stitches.config";
 import useKeyboard, {KeyCode} from "../use-keyboard";
 import clsx from "../utils/clsx";
 import withDefaults from "../utils/with-defaults";
+import useId from "../use-id";
 
 import CollapseGroup from "./collapse-group";
 import {useCollapseContext} from "./collapse-context";

--- a/packages/react/src/dropdown/use-dropdown.ts
+++ b/packages/react/src/dropdown/use-dropdown.ts
@@ -1,9 +1,10 @@
-import {useRef, useCallback} from "react";
+import {useRef, useCallback, useMemo} from "react";
 import {mergeProps} from "@react-aria/utils";
 import {MenuTriggerType} from "@react-types/menu";
 import {useMenuTrigger} from "@react-aria/menu";
 import {useMenuTriggerState} from "@react-stately/menu";
 
+import useId from "../use-id";
 import {mergeRefs} from "../utils/refs";
 import {PopoverProps} from "../popover";
 
@@ -47,6 +48,8 @@ export function useDropdown(props: UseDropdownProps = {}) {
     ...popoverProps
   } = props;
 
+  const triggerId = useId();
+
   const triggerRef = useRef<HTMLElement>(null);
   const menuTriggerRef = triggerRefProp || triggerRef;
   const menuRef = useRef<HTMLUListElement>(null);
@@ -79,13 +82,21 @@ export function useDropdown(props: UseDropdownProps = {}) {
             }
           : css,
         ...realTriggerProps,
+        id: triggerId,
       };
     },
-    [triggerRef, triggerRefProp, menuTriggerProps, disableTriggerPressedAnimation],
+    [triggerRef, triggerRefProp, menuTriggerProps, disableTriggerPressedAnimation, triggerId],
   );
+
+  const ariaProps = useMemo(() => {
+    return {
+      "aria-labelledby": triggerId,
+    };
+  }, [triggerId]);
 
   return {
     ...menuProps,
+    ...ariaProps,
     popoverProps,
     state,
     ref: menuRef,

--- a/packages/react/src/input/input.tsx
+++ b/packages/react/src/input/input.tsx
@@ -16,6 +16,7 @@ import {warn} from "../utils/console";
 import ClearIcon from "../utils/clear-icon";
 import clsx from "../utils/clsx";
 import {__DEV__} from "../utils/assertion";
+import useId from "../use-id";
 
 import {
   StyledInput,
@@ -98,6 +99,8 @@ const Input = React.forwardRef<FormElement, InputProps>(
 
     useImperativeHandle(ref, () => inputRef.current);
 
+    const id = useId(props?.id);
+
     const [selfValue, setSelfValue] = useState<string>(initialValue);
     const [hover, setHover] = useState<boolean>(false);
 
@@ -176,6 +179,7 @@ const Input = React.forwardRef<FormElement, InputProps>(
     const inputProps = {
       ...props,
       ...controlledValue,
+      id,
     };
 
     const {labelProps, fieldProps} = useLabel({

--- a/packages/react/src/navbar/navbar-item.tsx
+++ b/packages/react/src/navbar/navbar-item.tsx
@@ -1,7 +1,6 @@
 import React, {useMemo, useEffect} from "react";
 import {useHover} from "@react-aria/interactions";
 import {mergeProps} from "@react-aria/utils";
-import {useId} from "@react-aria/utils";
 
 import {HTMLNextUIProps, forwardRef} from "../utils/system";
 import {useDOMRef} from "../utils/dom";
@@ -9,6 +8,7 @@ import {arrayToObject} from "../utils/object";
 import clsx from "../utils/clsx";
 import {Text} from "../index";
 import {__DEV__} from "../utils/assertion";
+import useId from "../use-id";
 
 import {useNavbarContentContext} from "./navbar-content-context";
 import {StyledNavbarItem, NavbarItemVariantsProps} from "./navbar.styles";

--- a/packages/react/src/popover/use-popover.ts
+++ b/packages/react/src/popover/use-popover.ts
@@ -6,6 +6,7 @@ import {mergeProps} from "@react-aria/utils";
 import {useOverlayPosition, useOverlayTrigger} from "@react-aria/overlays";
 import {useOverlayTriggerState} from "@react-stately/overlays";
 
+import useId from "../use-id";
 import {mergeRefs} from "../utils/refs";
 import {isObject} from "../utils/object";
 
@@ -91,6 +92,8 @@ export function usePopover(props: UsePopoverProps = {}) {
     shouldCloseOnInteractOutside,
   } = props;
 
+  const id = useId();
+
   const domRef = useRef<HTMLElement>(null);
   const domTriggerRef = useRef<HTMLElement>(null);
 
@@ -140,16 +143,18 @@ export function usePopover(props: UsePopoverProps = {}) {
 
   const getTriggerProps = useCallback(
     (props = {}, _ref = null) => {
+      const aria = {"aria-controls": id};
+
       const realTriggerProps = triggerRefProp?.current
-        ? mergeProps(triggerProps, props)
-        : mergeProps(props, triggerProps);
+        ? mergeProps(triggerProps, props, aria)
+        : mergeProps(props, triggerProps, aria);
 
       return {
         ...realTriggerProps,
         ref: mergeRefs(triggerRef, _ref),
       };
     },
-    [triggerRef, triggerRefProp, triggerProps],
+    [triggerRef, triggerRefProp, triggerProps, id],
   );
 
   const getPopoverProps = useCallback(
@@ -186,6 +191,7 @@ export function usePopover(props: UsePopoverProps = {}) {
         ...realPositionProps,
         "data-state": getState,
         "data-placement": placement,
+        id,
       };
     },
     [getState, positionProps, overlayProps, placement],

--- a/packages/react/src/radio/use-radio-group.ts
+++ b/packages/react/src/radio/use-radio-group.ts
@@ -2,8 +2,11 @@ import type {AriaRadioGroupProps} from "@react-types/radio";
 import type {NormalSizes, SimpleColors} from "../utils/prop-types";
 
 import React, {useMemo, HTMLAttributes} from "react";
+import {mergeProps} from "@react-aria/utils";
 import {useRadioGroupState} from "@react-stately/radio";
 import {useRadioGroup as useReactAriaRadioGroup} from "@react-aria/radio";
+
+import useId from "../use-id";
 
 interface Props extends AriaRadioGroupProps {
   size?: NormalSizes;
@@ -36,20 +39,32 @@ export const useRadioGroup = (props: UseRadioGroupProps) => {
     ...otherProps
   } = props;
 
+  const labelId = useId();
+  const id = useId(props?.id);
+  const name = useId(props?.name);
+
   const otherPropsWithOrientation = useMemo<AriaRadioGroupProps>(() => {
     return {
       ...otherProps,
       isRequired,
       orientation,
     };
-  }, [otherProps]);
+  }, [otherProps, isRequired, orientation]);
 
   const radioGroupState = useRadioGroupState(otherPropsWithOrientation);
 
-  const {radioGroupProps, labelProps}: IRadioGroupAria = useReactAriaRadioGroup(
+  const radioGroup: IRadioGroupAria = useReactAriaRadioGroup(
     otherPropsWithOrientation,
     radioGroupState,
   );
+
+  const radioGroupProps = useMemo(() => {
+    return mergeProps(radioGroup.radioGroupProps, {id, "aria-labelledby": labelId});
+  }, [radioGroup.radioGroupProps, id, labelId]);
+
+  const labelProps = useMemo(() => {
+    return mergeProps(radioGroup.labelProps, {id: labelId});
+  }, [radioGroup.labelProps, labelId]);
 
   return {
     size,
@@ -61,6 +76,7 @@ export const useRadioGroup = (props: UseRadioGroupProps) => {
     radioGroupState,
     radioGroupProps,
     labelProps,
+    name,
   };
 };
 

--- a/packages/react/src/radio/use-radio.ts
+++ b/packages/react/src/radio/use-radio.ts
@@ -50,7 +50,7 @@ export const useRadio = (props: UseRadioProps) => {
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const {inputProps} = useReactAriaRadio(
+  const radio = useReactAriaRadio(
     {
       ...otherProps,
       ...groupContext,
@@ -59,6 +59,10 @@ export const useRadio = (props: UseRadioProps) => {
     groupContext.radioGroupState,
     inputRef,
   );
+
+  const inputProps = useMemo(() => {
+    return {...radio.inputProps, name: groupContext.name};
+  }, [radio.inputProps, groupContext.name]);
 
   const isDisabled = useMemo(() => inputProps.disabled ?? false, [inputProps.disabled]);
 

--- a/packages/react/src/use-id/index.ts
+++ b/packages/react/src/use-id/index.ts
@@ -1,0 +1,3 @@
+import {useId} from "./use-id";
+
+export default useId;

--- a/packages/react/src/use-id/use-id.ts
+++ b/packages/react/src/use-id/use-id.ts
@@ -1,39 +1,17 @@
-import type {DependencyList, EffectCallback} from "react";
+import {useState} from "react";
 
-import React, {useEffect, useLayoutEffect, useState, useCallback} from "react";
+import {useReactId, useIsomorphicLayoutEffect, formatId} from "./utils";
 
-let identifier = Number(0);
-
-const __REACT_USE_ID__ = Boolean(typeof (React as any).useId === "function");
-
-const __CLIENT__ = Boolean(typeof window !== "undefined" && typeof window.document !== "undefined");
-
-const useIsomorphicLayoutEffect: (
-  effect: EffectCallback,
-  deps?: DependencyList | undefined,
-) => void = __CLIENT__ ? useLayoutEffect : useEffect;
-
-const useReactId: () => string | undefined = (React as any).useId ?? (() => undefined);
+let identifier = 0;
 
 export const useId = (id?: string): string => {
   const initial = useReactId();
 
-  // TODO: Define an initial value
-  const [clientSideId, setClientSideId] = useState<number | undefined>(undefined);
+  const [clientSideId, setClientSideId] = useState<number | string | undefined>(id ?? initial);
 
   useIsomorphicLayoutEffect(() => {
-    if (clientSideId === undefined) {
-      setClientSideId((prevState: number | undefined) => prevState ?? ++identifier);
-    }
+    if (!clientSideId) setClientSideId((prevId) => prevId ?? ++identifier);
   }, []);
-
-  const formatId = useCallback((id?: number): string => `:nextui-${id ?? "id"}:`, []);
-
-  if (typeof id === "string" && id.length > 0) return id;
-
-  if (__REACT_USE_ID__ && initial) return initial;
-
-  if (!__CLIENT__) return formatId();
 
   return formatId(clientSideId);
 };

--- a/packages/react/src/use-id/use-id.ts
+++ b/packages/react/src/use-id/use-id.ts
@@ -1,0 +1,39 @@
+import type {DependencyList, EffectCallback} from "react";
+
+import React, {useEffect, useLayoutEffect, useState, useCallback} from "react";
+
+let identifier = Number(0);
+
+const __REACT_USE_ID__ = Boolean(typeof (React as any).useId === "function");
+
+const __CLIENT__ = Boolean(typeof window !== "undefined" && typeof window.document !== "undefined");
+
+const useIsomorphicLayoutEffect: (
+  effect: EffectCallback,
+  deps?: DependencyList | undefined,
+) => void = __CLIENT__ ? useLayoutEffect : useEffect;
+
+const useReactId: () => string | undefined = (React as any).useId ?? (() => undefined);
+
+export const useId = (id?: string): string => {
+  const initial = useReactId();
+
+  // TODO: Define an initial value
+  const [clientSideId, setClientSideId] = useState<number | undefined>(undefined);
+
+  useIsomorphicLayoutEffect(() => {
+    if (clientSideId === undefined) {
+      setClientSideId((prevState: number | undefined) => prevState ?? ++identifier);
+    }
+  }, []);
+
+  const formatId = useCallback((id?: number): string => `:nextui-${id ?? "id"}:`, []);
+
+  if (typeof id === "string" && id.length > 0) return id;
+
+  if (__REACT_USE_ID__ && initial) return initial;
+
+  if (!__CLIENT__) return formatId();
+
+  return formatId(clientSideId);
+};

--- a/packages/react/src/use-id/utils.ts
+++ b/packages/react/src/use-id/utils.ts
@@ -1,0 +1,18 @@
+import type {DependencyList, EffectCallback} from "react";
+
+import React, {useEffect, useLayoutEffect} from "react";
+
+const __CLIENT__ = typeof window !== "undefined" && typeof window.document !== "undefined";
+
+export const useReactId: () => string | undefined = (React as any).useId ?? (() => undefined);
+
+export const useIsomorphicLayoutEffect: (
+  effect: EffectCallback,
+  deps?: DependencyList | undefined,
+) => void = __CLIENT__ ? useLayoutEffect : useEffect;
+
+export const formatId = (value?: number | string): string => {
+  if (typeof value === "string") return value;
+
+  return value ? `:nextui-${value}:` : "";
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/198, https://github.com/nextui-org/nextui/issues/605

## 📝 Description

Fix id mismatch during hydration in [strict mode](https://reactjs.org/docs/strict-mode.html).

#### Component Task

- [ ] **Table**
      https://github.com/nextui-org/nextui/discussions/778
- [x] **Collapse**
- [x] **Navbar**
- [x] **Input**
      https://github.com/nextui-org/nextui/issues/198
- [x] **Checkbox Group**
- [x] **Radio**
- [x] **Popover**
- [x] **Dropdown**
      https://github.com/nextui-org/nextui/issues/605

## ⛳️ Current behavior (updates)

#### React 17
- Generate id on the client side only.
- Override the id generated by [`react-aria useId`](https://react-spectrum.adobe.com/react-aria/useId.html).

#### React 18
- The id'll be generated by react's built-in [`useId`](https://reactjs.org/blog/2022/03/29/react-v18.html#useid).

## 🚀 New behavior

- Add `useId` hook for generating id.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

> **Note** Based on `next` branch.