### PR TITLE
Add name to switch input element.

### DIFF
--- a/apps/docs/content/docs/components/switch.mdx
+++ b/apps/docs/content/docs/components/switch.mdx
@@ -32,7 +32,7 @@ import { Switch } from '@nextui-org/react';
 <Playground
   title="Disabled"
   desc="Unusable and un-clickable `Switch`."
-  files={switchContent.disabled}  
+  files={switchContent.disabled}
 />
 
 <Playground
@@ -100,6 +100,7 @@ import { Switch } from '@nextui-org/react';
 | **iconOn**         | `ReactNode`                                  | -                              | Add an icon for on status                                                 | -         |
 | **iconOff**        | `ReactNode`                                  | -                              | Add an icon for off status                                                | -         |
 | **preventDefault** | `boolean`                                    | `true/false`                   | Prevent default event on when is selected through the `Space, Enter` keys | `true`    |
+| **name**           | `string`                                     | -                              | Add a name to the **input** of the switch.                                | -         |
 | **onChange**       | `(e:`[SwitchEvent](#switch-event)) `=> void` | -                              | The callback invoked when the checked state of the switch changes.        | -         |
 | **css**            | `Stitches.CSS`                               | -                              | Override Default CSS style                                                | -         |
 | **as**             | `keyof JSX.IntrinsicElements`                | -                              | Changes which tag component outputs                                       | `div`     |

--- a/packages/react/src/switch/switch.stories.tsx
+++ b/packages/react/src/switch/switch.stories.tsx
@@ -96,3 +96,11 @@ export const Icons = () => {
     </div>
   );
 };
+
+export const WithName = () => (
+  <div style={{ display: 'flex', flexDirection: 'column' }}>
+    <Switch name="switch" />
+    <br />
+    <Switch name="switch" initialChecked />
+  </div>
+);

--- a/packages/react/src/switch/switch.tsx
+++ b/packages/react/src/switch/switch.tsx
@@ -35,6 +35,7 @@ interface Props {
   iconOff?: React.ReactNode;
   initialChecked?: boolean;
   preventDefault?: boolean;
+  name?: string;
   disabled?: boolean;
   onChange?: (ev: SwitchEvent) => void;
   as?: keyof JSX.IntrinsicElements;
@@ -71,6 +72,7 @@ const Switch: React.FC<SwitchProps> = ({
   iconOff,
   animated,
   preventDefault,
+  name,
   ...props
 }) => {
   const [selfChecked, setSelfChecked] = useState<boolean>(initialChecked);
@@ -142,6 +144,7 @@ const Switch: React.FC<SwitchProps> = ({
         disabled={disabled}
         checked={selfChecked}
         onChange={changeHandle}
+        name={name}
       />
       <StyledSwitch
         role="switch"


### PR DESCRIPTION
Useful when a switch appears in a form with conjunction with formData.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description
Add's the ability to pass in the `name` prop to `<Switch/>`, and passes it to the `input` element created inside the component. Doing this allows us to get the value using formData instead of relying on state controlled toggle. 

## ⛳️ Current behavior (updates)
Cannot pass `name` prop to Switch so that the input has a name. 

## 🚀 New behavior
`<Switch name={"helloWorld"}/>` will render `<input name={"helloWorld"] ...restOfTheObject/>`. This is useful for when placing a Switch instead of a form, and need to extract the value with formData instead of using state + controlled.

## 💣 Is this a breaking change (Yes/No):
no

## 📝 Additional Information
