### PR TITLE
fix(react-radio) inaccessible prop types and duplicate class name

### DIFF
--- a/packages/react/src/radio/index.ts
+++ b/packages/react/src/radio/index.ts
@@ -12,6 +12,7 @@ export {
   StyledRadioGroup,
   StyledRadioGroupContainer,
 } from "./radio.styles";
+
 export type {
   RadioLabelVariantsProps,
   RadioTexVariantsProps,
@@ -21,5 +22,9 @@ export type {
   RadioGroupVariantsProps,
   RadioGroupContainerVariantsProps,
 } from "./radio.styles";
+
+export type {RadioProps} from "./radio";
+
+export type {RadioGroupProps} from "./radio-group";
 
 export default Radio;

--- a/packages/react/src/radio/radio.tsx
+++ b/packages/react/src/radio/radio.tsx
@@ -102,7 +102,7 @@ export const Radio = React.forwardRef((props: RadioProps, ref: ReactRef<HTMLInpu
           </VisuallyHidden>
         </StyledRadioPoint>
         <StyledRadioText
-          className="nextui-radio-label"
+          className="nextui-radio-text"
           color={labelColor}
           isDisabled={isDisabled}
           isInvalid={isInvalid}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/759

## 📝 Description

- Export `radio` and `radio-group` prop types
- Fix duplicate class names

<!---
## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->

## 💣 Is this a breaking change (Yes/No):

No

<!--- ## 📝 Additional Information -->
