### PR TITLE
Fix typos in card component docs and storybook (fix #792)

### DIFF
--- a/apps/docs/content/components/card/action.ts
+++ b/apps/docs/content/components/card/action.ts
@@ -13,7 +13,7 @@ export default function App() {
       price: "$3.00",
     },
     {
-      title: "Raspberry",
+      title: "Cherry",
       img: "/images/fruit-3.jpeg",
       price: "$10.00",
     },
@@ -23,7 +23,7 @@ export default function App() {
       price: "$5.30",
     },
     {
-      title: "Advocato",
+      title: "Avocado",
       img: "/images/fruit-5.jpeg",
       price: "$15.70",
     },

--- a/packages/react/src/card/card.stories.tsx
+++ b/packages/react/src/card/card.stories.tsx
@@ -443,7 +443,7 @@ export const PrimaryAction = () => {
       price: "$3.00",
     },
     {
-      title: "Raspberry",
+      title: "Cherry",
       img: "/images/fruit-3.jpeg",
       price: "$10.00",
     },
@@ -453,7 +453,7 @@ export const PrimaryAction = () => {
       price: "$5.30",
     },
     {
-      title: "Advocato",
+      title: "Avocado",
       img: "/images/fruit-5.jpeg",
       price: "$15.70",
     },


### PR DESCRIPTION
Closes #792

## 📝 Description

There are typos in the Card Component docs:
1. The word "Raspberry" bellow the picture of a Cherry, changed it to "Cherry".
2. The word "Advocato", changed it to "Avocado"

Also fixed both typos in the storybook for the card component.

## ⛳️ Current behavior (updates)

![image](https://user-images.githubusercontent.com/76695417/193904784-08f4946c-28ce-4bc6-adb8-9327ff863c70.png)

## 🚀 New behavior

![image](https://user-images.githubusercontent.com/76695417/193905136-fb1564e2-2b1e-4bee-972c-ec7f9e1ce925.png)

## 💣 Is this a breaking change (Yes/No): No

