### PR TITLE
fix(docs): playground `isExternal` in link component

### DIFF
--- a/apps/docs/content/components/link/icon.ts
+++ b/apps/docs/content/components/link/icon.ts
@@ -3,11 +3,11 @@ const App = `import { Link, Spacer } from "@nextui-org/react";
 export default function App() {
   return (
     <>
-      <Link href="#" icon>
+      <Link href="#" isExternal>
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
       <Spacer />
-      <Link href="#" icon color>
+      <Link href="#" isExternal color="success">
         "First solve the problem. Then, write the code." - Jon Johnson.
       </Link>
     </>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Change prop `icon` to `isExternal` in the Playground.

![image](https://user-images.githubusercontent.com/6625004/194453714-6efed334-9469-4bad-a096-ba983b058355.png)


## ⛳️ Current behavior (updates)

The <Link> components should be using the isExternal prop instead of icon.
[Issue 777](https://github.com/nextui-org/nextui/issues/777)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
