### PR TITLE
fix: navbar link does not respect parent size

### DIFF
--- a/packages/react/src/navbar/navbar-link.tsx
+++ b/packages/react/src/navbar/navbar-link.tsx
@@ -46,6 +46,7 @@ const NavbarLink = forwardRef<NavbarLinkProps, "a">((props, ref) => {
     return {
       color: "inherit",
       height: "100%",
+      width: "fit-content",
       ...css,
     };
   }, [color, css]);


### PR DESCRIPTION
Closes # 
[https://github.com/nextui-org/nextui/issues/803](https://github.com/nextui-org/nextui/issues/803)

## 📝 Description

fix: navbar link does not respect parent size in Firefox

## ⛳️ Current behavior (updates)

Now the Navbar Link component uses `width: fit-content`

The result:
![image](https://user-images.githubusercontent.com/6625004/194678610-b84d4928-c582-4afe-933d-9cc037b2046f.png)


## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
