### PR TITLE
fix(react-card): footer blur not working on Firefox

### DIFF
--- a/packages/react/src/card/card.styles.ts
+++ b/packages/react/src/card/card.styles.ts
@@ -59,6 +59,10 @@ export const StyledCard = styled(
             boxShadow: "$lg",
             dropShadow: "none",
           },
+          "@-moz-document url-prefix()": {
+            boxShadow: "$lg",
+            dropShadow: "none",
+          },
         },
         bordered: {
           borderStyle: "solid",
@@ -107,6 +111,10 @@ export const StyledCard = styled(
             boxShadow: "$lg",
             dropShadow: "none",
           },
+          "@-moz-document url-prefix()": {
+            boxShadow: "$lg",
+            dropShadow: "none",
+          },
         },
       },
     },
@@ -134,6 +142,10 @@ export const StyledCard = styled(
         css: {
           dropShadow: "$xl",
           "@safari": {
+            boxShadow: "$xl",
+            dropShadow: "none",
+          },
+          "@-moz-document url-prefix()": {
             boxShadow: "$xl",
             dropShadow: "none",
           },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #727 

## 📝 Description

Drop shadow was causing an issue with the footer blur on Firefox.

## ⛳️ Current behavior (updates)
Footer blur not working.

![image](https://user-images.githubusercontent.com/16178358/194740634-4817e6a8-dc84-4458-8506-3686a729885f.png)

## 🚀 New behavior
Footer blur working on Firefox

![image](https://user-images.githubusercontent.com/16178358/194740762-83829a80-d7a8-4389-a1fa-06195d09089e.png)

## 💣 Is this a breaking change (Yes/No):

No
