### PR TITLE
fix(react-navbar): box-sizing causing navbar issues on firefox

### DIFF
--- a/packages/react/src/navbar/navbar.styles.ts
+++ b/packages/react/src/navbar/navbar.styles.ts
@@ -1,5 +1,7 @@
 import {styled, VariantProps} from "../theme/stitches.config";
 import {cssFocusVisible, cssHideShowIn} from "../theme/shared-css";
+import {StyledButton} from "../button/";
+import {StyledLink} from "../link";
 
 const itemColors = {
   default: {
@@ -253,6 +255,9 @@ export const StyledNavbarItem = styled(
       right: 0,
       bottom: 0,
       borderRadius: "$sm",
+    },
+    [`& ${StyledButton}, & ${StyledLink}`]: {
+      boxSizing: "content-box",
     },
     "&:after": {
       opacity: 0,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #713 

## 📝 Description

BoxSizing "border-box" is causing issues on firefox and width are not being calculated properly. Probably because of using it in combination with flex components.

This PR changes box-sizing of Links and Buttons inside the NavBar to be "content-box" instead "bordex-box" which fixes the issues currently seen on Firefox

## ⛳️ Current behavior (updates)
![image](https://user-images.githubusercontent.com/16178358/194775051-5419e2d2-9217-45fa-9279-c5704fe12b0d.png)
![image](https://user-images.githubusercontent.com/16178358/194784446-4c58d7ec-6bbc-460e-a983-087544c9f8e7.png)
![image](https://user-images.githubusercontent.com/16178358/194775097-505c2dde-bc1d-4fae-b4e5-a7db051ca7b1.png)
![image](https://user-images.githubusercontent.com/16178358/194775114-7ecea3dd-a4fe-44e9-9dcf-1f60cf219ef5.png)
![image](https://user-images.githubusercontent.com/16178358/194774890-2daa7899-e290-4142-9105-a90878a91c42.png)


## 🚀 New behavior
![image](https://user-images.githubusercontent.com/16178358/194775297-4b57e06d-db7d-4340-8cf8-5b332c6bae5e.png)
![image](https://user-images.githubusercontent.com/16178358/194784518-e308ce3f-97bf-4cd2-9667-dd549cb190da.png)
![image](https://user-images.githubusercontent.com/16178358/194775188-3c280214-a1d5-482b-b80b-cf8393c04d8f.png)
![image](https://user-images.githubusercontent.com/16178358/194775144-be7d8517-0af3-4ee1-b0cb-ac1a16a61b14.png)
![image](https://user-images.githubusercontent.com/16178358/194775170-7799b5b5-3ffc-4492-abcf-732f503e06d0.png)


## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
Only tested on Firefox and Chrome.
Need help with Safari testing.
