### PR TITLE
fix(react-navbar): collapse wrapper background on safari

### DIFF
--- a/packages/react/src/navbar/navbar.styles.ts
+++ b/packages/react/src/navbar/navbar.styles.ts
@@ -133,7 +133,8 @@ export const StyledNavbarCollapse = styled(
           "@supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none))": {
             bg: "$$navbarListBlurBackgroundColor",
             backdropFilter: "saturate(180%) blur($$navbarListBlur)",
-            "@safari": {
+            // safari
+            "@media screen and (-webkit-min-device-pixel-ratio:0)": {
               [`& ${StyledNavbarCollapseWrapper}`]: {
                 bg: "$$navbarListBlurBackgroundColor",
                 backdropFilter: "saturate(180%) blur($$navbarListBlur)",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

The collapse wrapper doesn't have a blurred background on safari

## ⛳️ Current behavior (updates)

The collapse wrapper doesn't have a blurred background on safari
![Screenshot 2022-11-06 at 21 07 08](https://user-images.githubusercontent.com/30373425/200203032-1c6191a9-dec1-4470-a5ac-b50cb3baf4d5.png)


## 🚀 New behavior

Safari specific styles added

![Screenshot 2022-11-06 at 21 07 14](https://user-images.githubusercontent.com/30373425/200203046-cd730647-bf01-49c9-8f6d-6c28981f5b4f.png)


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
