### PR TITLE
[BUG] - `disabled` prop of Loading Buttons in StoryBook restricts `color type` visibility.

### DIFF
--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -69,8 +69,8 @@ export const Loadings = () => (
       </Button>
     </Grid>
     <Grid>
-      <Button auto color="warning" css={{px: "$13"}}>
-        <Loading color="currentColor" size="sm" type="points-opacity" />
+      <Button auto color="error" css={{px: "$13"}}>
+        <Loading color="currentColor" size="sm" type="spinner" />
       </Button>
     </Grid>
   </Grid.Container>

--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -49,22 +49,27 @@ export const Sizes = () => (
 export const Loadings = () => (
   <Grid.Container gap={2}>
     <Grid>
-      <Button auto disabled color="primary" css={{px: "$13"}}>
+      <Button auto color="primary" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="secondary" css={{px: "$13"}}>
+      <Button auto color="secondary" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="spinner" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="success" css={{px: "$13"}}>
+      <Button auto color="success" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="points" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="warning" css={{px: "$13"}}>
+      <Button auto color="warning" css={{px: "$13"}}>
+        <Loading color="currentColor" size="sm" type="points-opacity" />
+      </Button>
+    </Grid>
+    <Grid>
+      <Button auto color="warning" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="points-opacity" />
       </Button>
     </Grid>

--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -68,11 +68,6 @@ export const Loadings = () => (
         <Loading color="currentColor" size="sm" type="points-opacity" />
       </Button>
     </Grid>
-    <Grid>
-      <Button auto disabled color="error" css={{px: "$13"}}>
-        <Loading color="currentColor" size="sm" type="spinner" />
-      </Button>
-    </Grid>
   </Grid.Container>
 );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #878

## 📝 Description

This PR removes duplicate `Spinner Button` from `Button->Loading StoryBook`

## ⛳️ Current behavior (updates)

Duplicate `Spinner Button` in`Button->Loading StoryBook`

## 🚀 New behavior

No duplicate `Spinner Button` in`Button->Loading StoryBook`

## 💣 Is this a breaking change (Yes/No): No


## 📝 Additional Information
No Comments