### PR TITLE
chore: eslint ignore nextjs style unknown-property

### DIFF
--- a/apps/docs/.eslintrc.json
+++ b/apps/docs/.eslintrc.json
@@ -10,7 +10,17 @@
               "jsx": true
             }
         },
-        "rules": {}
+        "rules": {
+          "react/no-unknown-property": [
+            2,
+            {
+              "ignore": [
+                "jsx",
+                "global"
+              ]
+            }
+          ]
+        }
       },
       {
         "files": ["*.ts", "*.tsx"],


### PR DESCRIPTION


## 📝 Description

> Add a brief description

resolve nextjs style unknown property global & jsx lint error, according to https://github.com/vercel/next.js/discussions/40269

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
