### PR TITLE
disabled prop of Loading Buttons in StoryBook restricts color type vi…

### DIFF
--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -49,27 +49,27 @@ export const Sizes = () => (
 export const Loadings = () => (
   <Grid.Container gap={2}>
     <Grid>
-      <Button auto disabled color="primary" css={{px: "$13"}}>
+      <Button auto color="primary" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="secondary" css={{px: "$13"}}>
+      <Button auto color="secondary" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="spinner" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="success" css={{px: "$13"}}>
+      <Button auto color="success" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="points" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="warning" css={{px: "$13"}}>
+      <Button auto color="warning" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="points-opacity" />
       </Button>
     </Grid>
     <Grid>
-      <Button auto disabled color="error" css={{px: "$13"}}>
+      <Button auto color="error" css={{px: "$13"}}>
         <Loading color="currentColor" size="sm" type="spinner" />
       </Button>
     </Grid>


### PR DESCRIPTION
Closes https://github.com/nextui-org/nextui/issues/878

📝 Description
This PR removes duplicate `Spinner Button` from `Button->Loading StoryBook`

⛳️ Current behavior (updates)
Duplicate `Spinner Button` in `Button->Loading StoryBook`

🚀 New behavior
No duplicate `Spinner Button` in `Button->Loading StoryBook`

💣 Is this a breaking change (Yes/No): No

📝 Additional Information
#### Creating new PR because earlier PR (https://github.com/nextui-org/nextui/pull/879) is not able to run GitHub Actions even after 2 approvals.