### PR TITLE
fix: fixed a11y role issue in progress bar component

### DIFF
--- a/packages/react/src/progress/progress.tsx
+++ b/packages/react/src/progress/progress.tsx
@@ -60,6 +60,10 @@ const Progress: React.FC<ProgressProps> = ({
 
   return (
     <StyledProgress
+      aria-label="progress"
+      aria-valuemax={max}
+      aria-valuemin={min}
+      aria-valuenow={value}
       css={{
         "nextui-progress-wrapper-enter": {
           opacity: 0,
@@ -83,9 +87,6 @@ const Progress: React.FC<ProgressProps> = ({
       >
         <StyledProgressBar
           animated={animated}
-          aria-valuemax={max}
-          aria-valuemin={min}
-          aria-valuenow={value}
           className={clsx(`${preClass}-bar`, {
             [`${preClass}-striped`]: striped,
             [`${preClass}-indeterminated`]: indeterminated,


### PR DESCRIPTION
Resolves the following violations:
- Elements must only use allowed ARIA attributes
- ARIA progressbar nodes must have an accessible name

![2022-12-01-195721_1369x421_scrot](https://user-images.githubusercontent.com/25524993/205137317-637c3cd9-e9a4-4f6e-a3fc-eae95cc2541f.png)
