### PR TITLE
fix: sticky navbar style in large screen

### DIFF
--- a/packages/react/src/navbar/navbar.styles.ts
+++ b/packages/react/src/navbar/navbar.styles.ts
@@ -489,7 +489,6 @@ export const StyledNavbarContainer = styled("div", {
   boxSizing: "border-box",
   color: "inherit",
   px: "$$navbarPadding",
-  bg: "$$navbarBackgroundColor",
   maxW: "$$navbarContainerMaxWidth",
   zIndex: "$5",
   "@xsMax": {
@@ -505,6 +504,7 @@ export const StyledNavbar = styled("nav", {
   height: "auto",
   color: "$$navbarTextColor",
   zIndex: "$2",
+  bg: "$$navbarBackgroundColor",
   variants: {
     variant: {
       static: {
@@ -575,12 +575,11 @@ export const StyledNavbar = styled("nav", {
     },
     disableBlur: {
       false: {
-        "@supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none))": {
-          [`& ${StyledNavbarContainer}`]: {
+        "@supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none))":
+          {
             bg: "$$navbarBlurBackgroundColor",
             backdropFilter: "saturate(180%) blur($$navbarBlur)",
           },
-        },
       },
     },
   },


### PR DESCRIPTION
## 📝 Description

> fix: sticky navbar style in large screen

## ⛳️ Current behavior (updates)

Removed StyledNavbarContainer background-color and backdrop-filter, added to StyledNavbar

before:
![image](https://user-images.githubusercontent.com/23077405/206489643-f0e20635-1d28-434a-bbd6-0119d5ce30fc.png)

after:
![Screen Shot 2022-12-08 at 11 26 57 PM](https://user-images.githubusercontent.com/23077405/206488237-eb6beb8c-acd7-42ec-9cd0-f619f05a3d24.png)


## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
