### PR TITLE
fix: Yarn PnP `@react-stately/collections` Module not found error

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,9 @@
     "@react-aria/utils": "3.13.2",
     "@react-aria/visually-hidden": "3.4.0",
     "@react-stately/checkbox": "3.2.0",
+    "@react-stately/collections": "^3.5.0",
     "@react-stately/data": "3.6.0",
+    "@react-stately/menu": "^3.4.3",
     "@react-stately/overlays": "3.4.0",
     "@react-stately/radio": "3.5.0",
     "@react-stately/table": "3.3.0",
@@ -93,7 +95,6 @@
     "directory": "lib"
   },
   "devDependencies": {
-    "react": "17.0.2",
     "@babel/cli": "^7.14.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
     "@babel/plugin-transform-runtime": "^7.14.5",
@@ -131,6 +132,7 @@
     "p-iteration": "^1.1.8",
     "parcel": "^2.3.1",
     "prettier": "^2.3.1",
+    "react": "17.0.2",
     "rimraf": "^3.0.2",
     "terser": "5.10.0",
     "ts-jest": "^26.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4013,6 +4013,14 @@
     "@babel/runtime" "^7.6.2"
     "@react-types/shared" "^3.14.0"
 
+"@react-stately/collections@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/collections/-/collections-3.5.0.tgz#01606d4aa12364cc4296cc036e77690e48ec818c"
+  integrity sha512-3BAMRjJqrka0IGvyK4m3WslqCeiEfQGx7YsXEIgIgMJoLpk6Fi1Eh4CI8coBnl/wcVLiIRMCIvxubwFRWTgzdg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-types/shared" "^3.16.0"
+
 "@react-stately/data@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@react-stately/data/-/data-3.6.0.tgz#6af1cb81940e7ec3c8ef93b07fb968617a2951bb"
@@ -4042,6 +4050,17 @@
     "@react-types/menu" "^3.7.0"
     "@react-types/shared" "^3.14.0"
 
+"@react-stately/menu@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@react-stately/menu/-/menu-3.4.3.tgz#65bb3fe29634047d3f6a3024577d3535e00802ae"
+  integrity sha512-ZWym6XQSLaC5uFUTZl6+mreEgzc8EUG6ElcnvdXYcH4DWUfswhLxCi3IdnG0lusWEi4NcHbZ2prEUxpT8VKqrg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/overlays" "^3.4.3"
+    "@react-stately/utils" "^3.5.1"
+    "@react-types/menu" "^3.7.3"
+    "@react-types/shared" "^3.16.0"
+
 "@react-stately/overlays@3.4.0", "@react-stately/overlays@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.4.0.tgz#4023d0c7cd48363fe046e5b6084d703ac461c907"
@@ -4050,6 +4069,15 @@
     "@babel/runtime" "^7.6.2"
     "@react-stately/utils" "^3.5.1"
     "@react-types/overlays" "^3.6.2"
+
+"@react-stately/overlays@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.4.3.tgz#2e935c404c0845ee7a7c6f001ff057d315161a16"
+  integrity sha512-WZCr3J8hj0cplQki1OVBR3MXg2l9V017h15Y2h+TNduWvnKH0yYOE/XfWviAT4KUP0LYoQfCnZ7XMHv+UI+8JA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/utils" "^3.5.1"
+    "@react-types/overlays" "^3.6.5"
 
 "@react-stately/radio@3.5.0", "@react-stately/radio@^3.5.0":
   version "3.5.0"
@@ -4172,12 +4200,27 @@
     "@react-types/overlays" "^3.6.2"
     "@react-types/shared" "^3.14.0"
 
+"@react-types/menu@^3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@react-types/menu/-/menu-3.7.3.tgz#beb8d0fb7f1e50254e2e7661dfbfa4bb38826dad"
+  integrity sha512-3Pax24I/FyNKBjKyNR4ePD8eZs35Th57HzJAVjamQg2fHEDRomg9GQ7fdmfGj72Dv3x3JRCoPYqhJ3L5R3kbzg==
+  dependencies:
+    "@react-types/overlays" "^3.6.5"
+    "@react-types/shared" "^3.16.0"
+
 "@react-types/overlays@3.6.2", "@react-types/overlays@^3.6.2":
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.6.2.tgz#f11f8abe5073ca7a80d3beada018b715af25859c"
   integrity sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==
   dependencies:
     "@react-types/shared" "^3.14.0"
+
+"@react-types/overlays@^3.6.5":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.6.5.tgz#466b325d9be51f67beb98b7bec3fd9295c72efac"
+  integrity sha512-IeWcF+YTucCYYHagNh8fZLH6R4YUONO1VHY57WJyIHwMy0qgEaKSQCwq72VO1fQJ0ySZgOgm31FniOyKkg6+eQ==
+  dependencies:
+    "@react-types/shared" "^3.16.0"
 
 "@react-types/radio@^3.2.2":
   version "3.2.2"
@@ -4190,6 +4233,11 @@
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.14.0.tgz#240991d6672f32ecd2a172111e163be0fe0778f2"
   integrity sha512-K069Bh/P0qV3zUG8kqabeO8beAUlFdyVPvpcNVPjRl+0Q9NDS9mfdQbmUa0LqdVo5e6jRPdos77Ylflkrz8wcw==
+
+"@react-types/shared@^3.16.0":
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.16.0.tgz#cab7bf0376969d1773480ecb2d6da5aa91391db5"
+  integrity sha512-IQgU4oAEvMwylEvaTsr2XB1G/mAoMe1JFYLD6G78v++oAR9l8o9MQxZ0YSeANDkqTamb2gKezGoT1RxvSKjVxw==
 
 "@react-types/switch@^3.2.2":
   version "3.2.2"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #940 

## 📝 Description

`@react-statelly/collections` `@react-stately/menu` is used in 'packages/react/src/dropdown' but is not installed, so I installed it.


## ⛳️ Current behavior (updates)

When using 'yarn PnP', error 'Module not found' occurs

## 🚀 New behavior

solve `Module not found` error

## 💣 Is this a breaking change (Yes/No):
