### PR TITLE
fix(react-dropdown): `onClose` and `onOpenChange` events

### DIFF
--- a/packages/react/src/dropdown/dropdown.tsx
+++ b/packages/react/src/dropdown/dropdown.tsx
@@ -38,7 +38,7 @@ const Dropdown = (props: DropdownProps) => {
         isOpen={context.state.isOpen}
         scrollRef={context.menuRef}
         triggerRef={context.menuTriggerRef}
-        onClose={context.state.close}
+        onClose={context.onClose}
       >
         {menuTrigger}
         {menu}

--- a/packages/react/src/dropdown/use-dropdown.ts
+++ b/packages/react/src/dropdown/use-dropdown.ts
@@ -44,6 +44,9 @@ export function useDropdown(props: UseDropdownProps = {}) {
     closeOnSelect,
     disableAnimation = false,
     disableTriggerPressedAnimation = false,
+    isOpen,
+    defaultOpen,
+    onOpenChange,
     ...popoverProps
   } = props;
 
@@ -52,13 +55,18 @@ export function useDropdown(props: UseDropdownProps = {}) {
   const menuRef = useRef<HTMLUListElement>(null);
   const menuPopoverRef = useRef<HTMLDivElement>(null);
 
-  const state = useMenuTriggerState(props);
+  const state = useMenuTriggerState({...props, isOpen, defaultOpen, onOpenChange});
 
   const {menuTriggerProps, menuProps} = useMenuTrigger(
     {type, trigger, isDisabled},
     state,
     menuTriggerRef,
   );
+
+  const handleClose = useCallback(() => {
+    state.close();
+    popoverProps.onClose?.();
+  }, [state.close, popoverProps.onClose]);
 
   const getMenuTriggerProps = useCallback(
     (props = {}, _ref = null) => {
@@ -89,7 +97,7 @@ export function useDropdown(props: UseDropdownProps = {}) {
     popoverProps,
     state,
     ref: menuRef,
-    onClose: state.close,
+    onClose: handleClose,
     autoFocus: state.focusStrategy || true,
     disableAnimation,
     disableTriggerPressedAnimation,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- Closes # Github issue # here -->

## 📝 Description

- `onClose` is not executed.
- `onOpenChange` executes twice when opening and ending with `false`.

## ⛳️ Current behavior (updates)

- Solve multiple execution of `onOpenChange` by passing `OverlayTriggerProps` into `useMenuTriggerState`.

## 🚀 New behavior

- Add `handleClose` to handle the close event.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

> **Note** Based on `next` branch.