### PR TITLE
fix(react-theme): white border of the focus ring

### DIFF
--- a/packages/react/src/theme/shared-css.ts
+++ b/packages/react/src/theme/shared-css.ts
@@ -16,15 +16,13 @@ export const sharedFocus = css({
 });
 
 export const cssFocusVisible = css({
+  outline: "none",
   variants: {
     isFocusVisible: {
       true: {
         boxShadow: "0 0 0 2px $colors$background, 0 0 0 4px $colors$primary",
       },
-      false: {
-        outline: "none",
-        boxShadow: "none",
-      },
+      false: {},
     },
   },
 });

--- a/packages/react/src/theme/shared-css.ts
+++ b/packages/react/src/theme/shared-css.ts
@@ -19,12 +19,11 @@ export const cssFocusVisible = css({
   variants: {
     isFocusVisible: {
       true: {
-        outline: "transparent solid 2px",
-        outlineOffset: "2px",
         boxShadow: "0 0 0 2px $colors$background, 0 0 0 4px $colors$primary",
       },
       false: {
         outline: "none",
+        boxShadow: "none",
       },
     },
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- Closes # Github issue # here -->

## 📝 Description

There is a white border in the animation of the focus ring caused by the `outline` property.

## ⛳️ Current behavior (updates)

- Remove `outline` styles from the `isFocusVisible` variant.

<!-- ## 🚀 New behavior

> Please describe the behavior or changes this PR adds  -->

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

> **Note** Based on `next` branch.

Take `Radio`'s focus ring as an example, however, not all components have *white border* in the animation of the focus ring.

Before:

[before.webm](https://user-images.githubusercontent.com/32772271/207093070-c151dbf5-ad23-4df8-9cfa-7a6a48703306.webm)

After:

[after.webm](https://user-images.githubusercontent.com/32772271/207093110-cbb8c72c-f3d0-42dd-aaae-6ec710611610.webm)