### PR TITLE
fix(react-popover): unknown event property when custom trigger

### DIFF
--- a/packages/react/src/popover/popover-trigger.tsx
+++ b/packages/react/src/popover/popover-trigger.tsx
@@ -1,6 +1,6 @@
 import type {ReactRef} from "../utils/refs";
 
-import * as React from "react";
+import React, {Children, cloneElement, useMemo} from "react";
 import {useButton} from "@react-aria/button";
 import {mergeProps} from "@react-aria/utils";
 
@@ -10,42 +10,49 @@ import {__DEV__} from "../utils/assertion";
 
 import {usePopoverContext} from "./popover-context";
 
+interface Props {
+  children?: React.ReactNode;
+}
+
 /**
  * PopoverTrigger opens the popover's content. It must be an interactive element
  * such as `button` or `a`.
  */
-const PopoverTrigger = React.forwardRef(
-  (props: {children?: React.ReactNode}, _: ReactRef<HTMLElement>) => {
-    const {state, triggerRef, getTriggerProps} = usePopoverContext();
-    const {children, ...otherProps} = props;
+const PopoverTrigger = React.forwardRef((props: Props, _: ReactRef<HTMLElement>) => {
+  const {state, triggerRef, getTriggerProps} = usePopoverContext();
 
-    const onPress = () => state.open();
+  const {children, ...otherProps} = props;
 
-    const {buttonProps} = useButton(
-      {
-        onPress,
-        ...otherProps,
-      },
-      triggerRef,
-    );
+  // enforce a single child
+  const child = useMemo<any>(() => {
+    if (typeof children === "string") return <Text>{children}</Text>;
 
-    // enforce a single child
-    const child: any =
-      typeof children === "string" ? <Text>{children}</Text> : React.Children.only(children);
+    return Children.only(children);
+  }, [children]);
 
-    // validates if contains a NextUI Button as a child
-    const [, triggerChildren] = pickChild(props.children, Button);
-    const hasNextUIButton = triggerChildren?.[0] !== undefined;
+  const {onPress, onPressStart, ...rest} = useMemo(() => {
+    return getTriggerProps(mergeProps(child.props, otherProps), child.ref);
+  }, [getTriggerProps, child.props, otherProps, child.ref]);
 
-    return React.cloneElement(
-      child,
-      getTriggerProps(
-        mergeProps(child.props, hasNextUIButton ? {onPress} : buttonProps, otherProps),
-        child.ref,
-      ),
-    );
-  },
-);
+  const {buttonProps} = useButton({onPress, onPressStart, ...rest}, triggerRef);
+
+  // validates if contains a NextUI Button as a child
+  const [, triggerChildren] = pickChild(props.children, Button);
+
+  const hasNextUIButton = useMemo<boolean>(() => {
+    return triggerChildren?.[0] !== undefined;
+  }, [triggerChildren]);
+
+  const nextUIButtonProps = useMemo(() => {
+    return {
+      ...rest,
+      onPressStart,
+      onPress: () => state.open(),
+    };
+  }, [rest, onPressStart, state.open]);
+
+  return cloneElement(child, mergeProps(rest, hasNextUIButton ? nextUIButtonProps : buttonProps));
+});
 
 if (__DEV__) {
   PopoverTrigger.displayName = "NextUI.PopoverTrigger";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/735
Closes https://github.com/nextui-org/nextui/issues/703

## 📝 Description

Fixed invalid event property passed into the DOM (`onPress, onPressStart`).

## ⛳️ Current behavior (updates)

- Deconstructing the props of the `Button` component and custom-trigger from `triggerProps`.

<!---
## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->
## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

> **Note** Based on `next` branch.