### PR TITLE
fix: process overflow visible #958

### DIFF
--- a/packages/react/src/progress/progress.styles.ts
+++ b/packages/react/src/progress/progress.styles.ts
@@ -14,7 +14,7 @@ export const StyledProgress = styled("div", {
   padding: 0,
   width: "100%",
   position: "relative",
-  overflow: "auto",
+  overflow: "hidden",
   variants: {
     color: {
       default: {

--- a/packages/react/src/progress/progress.styles.ts
+++ b/packages/react/src/progress/progress.styles.ts
@@ -14,7 +14,7 @@ export const StyledProgress = styled("div", {
   padding: 0,
   width: "100%",
   position: "relative",
-  overflow: "visible",
+  overflow: "auto",
   variants: {
     color: {
       default: {


### PR DESCRIPTION
## 📝 Description


The progress bar shows an exception.

exception: 

![Kapture 2022-12-21 at 21 34 28](https://user-images.githubusercontent.com/45115006/208919144-00526fed-f033-45f6-a751-5c9077df3bd0.gif)

Correct
![Kapture 2022-12-21 at 21 36 46](https://user-images.githubusercontent.com/45115006/208919853-a82ece56-e030-4e48-b203-9c22202b6052.gif)

## ⛳️ Current behavior (updates)

Setting small values makes the problem worse, as colored areas start to "highlight" circular progress bars visibly.

## 🚀 New behavior

Display normal

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
For small values, the colored portion of the progress bar component clips out of the circular shape，
Is the design correct?

<img width="684" alt="image" src="https://user-images.githubusercontent.com/45115006/208921754-bcd7fa14-6e9f-41d3-beb4-d19cb601aac8.png">
