### PR TITLE
fix(docs-playground): dynamic live font styles

### DIFF
--- a/apps/docs/src/components/playground/dynamic-live.tsx
+++ b/apps/docs/src/components/playground/dynamic-live.tsx
@@ -189,6 +189,12 @@ const LiveContainer = Components.styled(Box, {
   },
 });
 
+const StyledInView = Components.styled(InView, {
+  fontSize: "$base",
+  lineHeight: "$md",
+  fontFamily: "$sans",
+});
+
 export const scope = {
   ...Components,
   ...Icons,
@@ -239,7 +245,7 @@ const DynamicLive: React.FC<Props & {css?: Components.CSS}> = ({
 
   return (
     <LiveProvider code={code} noInline={noInline} scope={scope} theme={codeTheme}>
-      <InView className="inview-section" triggerOnce={isProd} onChange={setIsVisible}>
+      <StyledInView className="inview-section" triggerOnce={isProd} onChange={setIsVisible}>
         <LiveContainer
           className="dynamic-live-container"
           css={{
@@ -322,7 +328,7 @@ const DynamicLive: React.FC<Props & {css?: Components.CSS}> = ({
           )}
           {showEditor && <Editor code={code} initialOpen={initialEditorOpen} />}
         </LiveContainer>
-      </InView>
+      </StyledInView>
     </LiveProvider>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- Closes # Github issue # here -->

## 📝 Description

The theme of sandpack makes `DynamicLive` applied `$sm` font-size and line-height, which is the font-size and line-height of `LiveCode`.

As the live preview is not the `$base` font-size and `$md` line-height, it causes some content shift.

https://github.com/nextui-org/nextui/blob/66153ecb82e4f4b838d41763e4f83c6f8ac95c2e/apps/docs/src/components/sandpack/themes.ts#L29-L34

## ⛳️ Current behavior (updates)

Reapply the right font-size and line-height to `InView`.

<!-- ## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Before:

[before.webm](https://user-images.githubusercontent.com/32772271/209175226-288cfd1f-2fa4-4e3f-b8c3-886c679b5783.webm)

After:

[after.webm](https://user-images.githubusercontent.com/32772271/209175261-e579bfe0-cbd3-470c-8107-935d34029d62.webm)
