### PR TITLE
fix(react-popover): popover trigger on mobile device

### DIFF
--- a/packages/react/src/popover/popover-trigger.tsx
+++ b/packages/react/src/popover/popover-trigger.tsx
@@ -19,7 +19,7 @@ interface Props {
  * such as `button` or `a`.
  */
 const PopoverTrigger = React.forwardRef((props: Props, _: ReactRef<HTMLElement>) => {
-  const {state, triggerRef, getTriggerProps} = usePopoverContext();
+  const {triggerRef, getTriggerProps} = usePopoverContext();
 
   const {children, ...otherProps} = props;
 
@@ -30,11 +30,11 @@ const PopoverTrigger = React.forwardRef((props: Props, _: ReactRef<HTMLElement>)
     return Children.only(children);
   }, [children]);
 
-  const {onPress, onPressStart, ...rest} = useMemo(() => {
+  const {onPress, onKeyDown, onPressStart, ...rest} = useMemo(() => {
     return getTriggerProps(mergeProps(child.props, otherProps), child.ref);
   }, [getTriggerProps, child.props, otherProps, child.ref]);
 
-  const {buttonProps} = useButton({onPress, onPressStart, ...rest}, triggerRef);
+  const {buttonProps} = useButton({onPress, onKeyDown, onPressStart, ...rest}, triggerRef);
 
   // validates if contains a NextUI Button as a child
   const [, triggerChildren] = pickChild(props.children, Button);
@@ -43,13 +43,15 @@ const PopoverTrigger = React.forwardRef((props: Props, _: ReactRef<HTMLElement>)
     return triggerChildren?.[0] !== undefined;
   }, [triggerChildren]);
 
+  // avoid the error that cannot read properties of undefined (reading 'contains')
   const nextUIButtonProps = useMemo(() => {
     return {
       ...rest,
+      onPress,
+      onKeyDown,
       onPressStart,
-      onPress: () => state.open(),
     };
-  }, [rest, onPressStart, state.open]);
+  }, [rest, onPress, onKeyDown, onPressStart]);
 
   return cloneElement(child, mergeProps(rest, hasNextUIButton ? nextUIButtonProps : buttonProps));
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/649
Closes https://github.com/nextui-org/nextui/issues/969

## 📝 Description

`Popover` triggers are not triggered on mobile devices, also affected by this issue is `Dropdown`.

## ⛳️ Current behavior (updates)

The issue is the wrong behavior of `onPress` in `nextUIButtonProps` 🤔 solved by passing `onPress` directly instead of handling `OverlayTriggerState` in `onPress`.

<!--- ## 🚀 New behavior

> Please describe the behavior or changes this PR adds
-->

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Related to https://github.com/nextui-org/nextui/pull/953.

> **Note** Based on `next` branch.

