### PR TITLE
Fix: Tooltip trigger click event

### DIFF
--- a/packages/react/src/tooltip/tooltip.tsx
+++ b/packages/react/src/tooltip/tooltip.tsx
@@ -150,7 +150,7 @@ const Tooltip: React.FC<TooltipProps> = ({
       role="button"
       tabIndex={-1}
       onBlur={() => mouseEventHandler(false)}
-      onClick={clickEventHandler}
+      onClickCapture={clickEventHandler}
       onFocus={() => mouseEventHandler(true)}
       onKeyUp={() => mouseEventHandler(true)}
       onMouseEnter={() => mouseEventHandler(true)}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #968

## 📝 Description

When setting the trigger to click, the tooltip isn't displayed even if clicked.

## 🚀 New behavior

The `StyledTooltipTrigger` `onClick` event was not being triggered as expected, and changed it to `onClickCapture` in order to ensure that the event is correctly captured and handled.

The `onClick` event is a bubbling event, which means that it is triggered on the element that is clicked, and then it bubbles up the DOM tree to be handled by parent elements if needed. In contrast, the `onClickCapture` event is a capturing event, which means that it is triggered on the element's parent first, and then it propagates down the DOM tree to be handled by the element itself and any of its children.

By using the `onClickCapture` event instead of the `onClick` event, you can make sure that the event is captured and handled by the parent element before it reaches the element itself. This can be useful in cases where the parent element needs to handle the event before the child element does, or where the child element's behavior depends on the parent's handling of the event.

Thanks for the help @Isaac-alencar and @BrunoViveiros

## 📝 Additional Information

References:
https://www.freecodecamp.org/news/event-propagation-event-bubbling-event-catching-beginners-guide/

