### PR TITLE
added missing styled import

### DIFF
--- a/apps/docs/content/docs/theme/customize-theme.mdx
+++ b/apps/docs/content/docs/theme/customize-theme.mdx
@@ -148,7 +148,7 @@ dark.colors.background.computedValue; // var(--nextui-colors-background)
 You can add styles based on themes by retrieving the generated theme class.
 
 ```jsx
-import { Button, createTheme } from '@nextui-org/react';
+import { Button, createTheme, styled } from '@nextui-org/react';
 
 const myTheme = createTheme({
   theme: {

--- a/apps/docs/content/docs/theme/customize-theme.mdx
+++ b/apps/docs/content/docs/theme/customize-theme.mdx
@@ -202,7 +202,7 @@ const MyApp = () => {
 A function to create a global CSS `@keyframe` rule.
 
 ```jsx
-import { keyframes, Text } from '@nextui-org/react';
+import { keyframes, Text, styled } from '@nextui-org/react';
 
 const scaleUp = keyframes({
   '0%': { transform: 'scale(1)' },


### PR DESCRIPTION
## 📝 Description

> Added the missing import `styled` to a section of the documentation code.

## ⛳️ Current behavior (updates)

> The documentation used code that was not imported (`styled`).

## 🚀 New behavior

> Documentation was missing the styled import; copying the code will now work out of the box with the new import.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
