### PR TITLE
Added missing styled imports

### DIFF
--- a/apps/docs/content/docs/theme/customize-theme.mdx
+++ b/apps/docs/content/docs/theme/customize-theme.mdx
@@ -148,7 +148,7 @@ dark.colors.background.computedValue; // var(--nextui-colors-background)
 You can add styles based on themes by retrieving the generated theme class.
 
 ```jsx
-import { Button, createTheme } from '@nextui-org/react';
+import { Button, createTheme, styled } from '@nextui-org/react';
 
 const myTheme = createTheme({
   theme: {
@@ -202,7 +202,7 @@ const MyApp = () => {
 A function to create a global CSS `@keyframe` rule.
 
 ```jsx
-import { keyframes, Text } from '@nextui-org/react';
+import { keyframes, Text, styled } from '@nextui-org/react';
 
 const scaleUp = keyframes({
   '0%': { transform: 'scale(1)' },


### PR DESCRIPTION
Added the missing imports for styled in the Keyframes section as well as the Theme specific styles section.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> The documentation uses unimported members. I added the missing imports for styled in the Keyframes section as well as the Theme specific styles section.

## ⛳️ Current behavior (updates)

> Developers might not known where the `styled` member come from.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
