### PR TITLE
fix: fix input cursor postposition #975

### DIFF
--- a/packages/react/src/input/input.tsx
+++ b/packages/react/src/input/input.tsx
@@ -172,9 +172,7 @@ const Input = React.forwardRef<FormElement, InputProps>(
 
     const isTextarea = useMemo(() => Component === "textarea", [Component]);
 
-    const controlledValue = isControlledComponent
-      ? {value: selfValue}
-      : {defaultValue: initialValue};
+    const controlledValue = isControlledComponent ? {value} : {defaultValue: initialValue};
 
     const inputProps = {
       ...props,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #975 

## 📝 Description

>  When `value` in the props has changed, `selfValue` will update in `useEffect`. But `target.value` is not equal `selfValue` and it will reset the value of input element causing the cursor postposition. So, `controlledValue` should use `value` instead of `selfValue` when `isControlledComponent` is `true`.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
