### PR TITLE
[FEATURE] Points Loader - points-shib

### DIFF
--- a/packages/react/src/button/button.stories.tsx
+++ b/packages/react/src/button/button.stories.tsx
@@ -70,7 +70,7 @@ export const Loadings = () => (
     </Grid>
     <Grid>
       <Button auto color="error" css={{px: "$13"}}>
-        <Loading color="currentColor" size="sm" type="spinner" />
+        <Loading color="currentColor" size="sm" type="points-shib" />
       </Button>
     </Grid>
   </Grid.Container>

--- a/packages/react/src/loading/loading.stories.tsx
+++ b/packages/react/src/loading/loading.stories.tsx
@@ -112,5 +112,9 @@ export const Types = () => (
     <Loading style={{marginLeft: "-0.5rem"}} type="gradient">
       gradient
     </Loading>
+    <Spacer y={2} />
+    <Loading style={{marginLeft: "-0.5rem"}} type="points-shib">
+      points-shib
+    </Loading>
   </Container>
 );

--- a/packages/react/src/loading/loading.styles.ts
+++ b/packages/react/src/loading/loading.styles.ts
@@ -42,6 +42,18 @@ const spinner = keyframes({
   },
 });
 
+const pointsShib = keyframes({
+  "0%": {
+    transform: "translateX(calc($$loadingSize * -1.1))",
+  },
+  "50%": {
+    transform: "translateX(calc($$loadingSize * 1.1))",
+  },
+  "100%": {
+    transform: "translateX(calc($$loadingSize * -1.1))",
+  },
+});
+
 export const StyledLoadingContainer = styled("div", {
   d: "inline-flex",
   fd: "column",
@@ -329,6 +341,28 @@ export const StyledLoading = styled("span", {
           display: "none",
         },
       },
+      "points-shib": {
+        d: "flex",
+        br: "$rounded",
+        position: "relative",
+        size: "$$loadingSize",
+        i: {
+          position: "absolute",
+          top: "0px",
+          size: "100%",
+          br: "inherit",
+          bg: "$$loadingColor",
+          animation: `${pointsShib} 1.5s infinite`,
+        },
+        "._2": {
+          animationDelay: "0.12s",
+          opacity: "0.25",
+        },
+        "._3": {
+          animationDelay: "0.06s",
+          opacity: "0.5",
+        },
+      },
     },
   },
   compoundVariants: [
@@ -410,6 +444,46 @@ export const StyledLoading = styled("span", {
       type: "points",
       css: {
         $$loadingSize: "$space$5",
+      },
+    },
+    // points-shib & xs size
+    {
+      size: "xs",
+      type: "points-shib",
+      css: {
+        $$loadingSize: "$space$6",
+      },
+    },
+    // points-shib & sm size
+    {
+      size: "sm",
+      type: "points-shib",
+      css: {
+        $$loadingSize: "$space$7",
+      },
+    },
+    // points-shib & md size
+    {
+      size: "md",
+      type: "points-shib",
+      css: {
+        $$loadingSize: "$space$8",
+      },
+    },
+    // points-shib & lg size
+    {
+      size: "lg",
+      type: "points-shib",
+      css: {
+        $$loadingSize: "$space$9",
+      },
+    },
+    // points-shib & xl size
+    {
+      size: "xl",
+      type: "points-shib",
+      css: {
+        $$loadingSize: "$space$10",
       },
     },
   ],

--- a/packages/react/src/utils/prop-types.ts
+++ b/packages/react/src/utils/prop-types.ts
@@ -53,7 +53,14 @@ export const extraColors = tuple(
   "cyan",
 );
 
-export const normalLoaders = tuple("default", "points", "points-opacity", "gradient", "spinner");
+export const normalLoaders = tuple(
+  "default",
+  "points",
+  "points-opacity",
+  "gradient",
+  "spinner",
+  "points-shib",
+);
 
 export const normalWeights = tuple("light", "normal", "bold", "extrabold", "black");
 


### PR DESCRIPTION
## 📝 Description

> Added new type of loader with points.
>1. It can be added with a label.
>2. It can be added in a button.

## 🚀 New behavior

> Please refer below previews of new loader:
> 1. Different sizes in **Dark Mode**.
![points-shib-sizes-dark](https://user-images.githubusercontent.com/116849110/212339726-219e78ae-37f8-4734-b054-90ff1bd4027b.gif)

> 2. Different sizes in **Light Mode**.
![points-shib-sizes-light](https://user-images.githubusercontent.com/116849110/212339793-22421a82-c7c2-4dd2-ae4d-5744c04c20f7.gif)

> 3. In a button    
![points-shib-btn](https://user-images.githubusercontent.com/116849110/212339810-57c204ca-cfcb-4e7b-b3f5-db4cd807c074.gif)

## 💣 Is this a breaking change (Yes/No):
> No Impact on users.

## 📝 Additional Information
**Note:** Reverted the default loader in **Loading > Sizes**
