### PR TITLE
fix: invalid role value

### DIFF
--- a/packages/react/src/card/card.tsx
+++ b/packages/react/src/card/card.tsx
@@ -52,7 +52,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
         isHovered={isHovered}
         isPressable={isPressable}
         isPressed={isPressed}
-        role={isPressable ? "button" : "section"}
+        role={isPressable ? "button" : "region"}
         tabIndex={isPressable ? 0 : -1}
         variant={variant}
         {...getCardProps()}


### PR DESCRIPTION
Closes # <!-- Github issue # here -->

## 📝 Description
While running a lighthouse test I noticed it warned about `"section"` not being valid.
Looking on [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/section_role) it looks like the correct value would be `"region"` instead.

## ⛳️ Current behavior (updates)
Changes `role` from `"section"` to `"region"`.

## 🚀 New behavior
None

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
