### PR TITLE
refactoring tsconfig.json

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "typescript-config/strict": "off"
+  }
+}

--- a/.hintrc
+++ b/.hintrc
@@ -1,8 +1,0 @@
-{
-  "extends": [
-    "development"
-  ],
-  "hints": {
-    "typescript-config/strict": "off"
-  }
-}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -13,6 +13,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "ignoreDeprecations": "5.0",
     "target": "es6",
     "module": "esnext",
     "typeRoots": ["../../node_modules/@types", "./typings"]


### PR DESCRIPTION
## 📝 Description

> Flag 'suppressImplicitAnyIndexErrors' is deprecated and will stop functioning in TypeScript 5.5 .

## ⛳️ Current behavior (updates)

```
{
  "extends": "../../tsconfig.base.json",
  "compilerOptions": {
    "baseUrl": ".",
    "jsx": "react",
    "skipLibCheck": true,
    "moduleResolution": "node",
    "allowJs": true,
    "allowSyntheticDefaultImports": true,
    "types": ["node", "jest"],
    "strict": false,
    "forceConsistentCasingInFileNames": true,
    "noEmit": true,
    "resolveJsonModule": true,
    "isolatedModules": true,
    "ignoreDeprecations": "5.0", // Added
    "target": "es6",
    "module": "esnext",
    "typeRoots": ["../../node_modules/@types", "./typings"]
  },
  "include": [
    "**/*.ts",
    "**/*.tsx",
    "**/*.js",
    "**/*.jsx",
    "next-env.d.ts"
  ],
  "exclude": ["node_modules", "storybook-static", "dist", "lib"]
}
```

## 🚀 New behavior

> None

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information

> There is no additional information
