### PR TITLE
fix: linter rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "plugin:react-hooks/recommended",
     "plugin:jsx-a11y/recommended"
   ],
-  "plugins": ["react", "prettier", "import", "@typescript-eslint", "jsx-a11y"],
+  "plugins": ["react", "unused-imports", "import", "@typescript-eslint", "jsx-a11y", "prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
@@ -34,6 +34,9 @@
     "jsx-a11y/click-events-have-key-events": "warn",
     "jsx-a11y/interactive-supports-focus": "warn",
     "prettier/prettier": "warn",
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "warn",
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -13,16 +13,14 @@ const removeIgnoredFiles = async (files) => {
 };
 
 module.exports = {
-  // *.!(js|ts|jsx|tsx|d.ts)
-  "./packages/**/**/*.{js,cjs,mjs,ts,jsx,tsx,json,md}": async (files) => {
+  "**/*.{cjs,mjs,js,ts,jsx,tsx}": async (files) => {
+    const filesToLint = await removeIgnoredFiles(files);
+
+    return [`eslint -c .eslintrc.json --max-warnings=0 --fix ${filesToLint}`];
+  },
+  "**/*.{css,json,md}": async (files) => {
     const filesToLint = await removeIgnoredFiles(files);
 
     return [`prettier --config .prettierrc.json --ignore-path --write ${filesToLint}`];
   },
-  // TODO: fix linter rules
-  // "./packages/**/**/*.{js,cjs,mjs,ts,jsx,tsx}": async (files) => {
-  //   const filesToLint = await removeIgnoredFiles(files);
-
-  //   return [`eslint -c .eslintrc.json --max-warnings=0 --fix ${filesToLint}`];
-  // },
 };

--- a/apps/docs/.eslintrc.json
+++ b/apps/docs/.eslintrc.json
@@ -1,35 +1,31 @@
 {
-    "extends": ["../../.eslintrc.json"],
-    "ignorePatterns": ["!**/*"],
-    "overrides": [
-      {
-        "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
-        "parserOptions": {
-            "project": ["apps/docs/tsconfig(.*)?.json"],
-            "ecmaFeatures": {
-              "jsx": true
-            }
-        },
-        "rules": {
-          "react/no-unknown-property": [
-            2,
-            {
-              "ignore": [
-                "jsx",
-                "global"
-              ]
-            }
-          ]
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "parserOptions": {
+        "project": ["apps/docs/tsconfig(.*)?.json"],
+        "ecmaFeatures": {
+          "jsx": true
         }
       },
-      {
-        "files": ["*.ts", "*.tsx"],
-        "rules": {}
-      },
-      {
-        "files": ["*.js", "*.jsx"],
-        "rules": {}
+      "rules": {
+        "react/no-unknown-property": [
+          2,
+          {
+            "ignore": ["jsx", "global"]
+          }
+        ]
       }
-    ]
-  }
-  
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "execa": "^5.1.1",
     "find-up": "^6.3.0",
     "fs-extra": "^10.0.0",

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -2,8 +2,8 @@ import {forwardRef} from "@nextui-org/system";
 import {__DEV__} from "@nextui-org/shared-utils";
 import {useMemo} from "react";
 
-import {useAvatar, UseAvatarProps} from "./use-avatar";
 import {AvatarIcon} from "./avatar-icon";
+import {useAvatar, UseAvatarProps} from "./use-avatar";
 
 export interface AvatarProps extends UseAvatarProps {}
 

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import {render} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import {Checkbox, CheckboxProps} from "../src";
+import {Checkbox} from "../src";
 
 describe("Checkbox", () => {
   it("should render correctly", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ importers:
       eslint-plugin-promise: ^6.0.0
       eslint-plugin-react: ^7.23.2
       eslint-plugin-react-hooks: ^4.6.0
+      eslint-plugin-unused-imports: ^2.0.0
       execa: ^5.1.1
       find-up: ^6.3.0
       fs-extra: ^10.0.0
@@ -149,6 +150,7 @@ importers:
       eslint-plugin-promise: 6.1.1_eslint@7.32.0
       eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
+      eslint-plugin-unused-imports: 2.0.0_ysufuzzt3cjmp72q35wizjhorm
       execa: 5.1.1
       find-up: 6.3.0
       fs-extra: 10.1.0
@@ -5285,7 +5287,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 5.75.0
+      webpack: 5.75.0_igc2o5duttbeim43y2d2sdpxx4
     dev: true
 
   /@polka/url/1.0.0-next.21:
@@ -10368,7 +10370,7 @@ packages:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /babel-plugin-add-module-exports/1.0.4:
@@ -10956,7 +10958,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -11963,7 +11965,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /css-loader/5.2.7_webpack@5.75.0:
@@ -13589,6 +13591,26 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
+  /eslint-plugin-unused-imports/2.0.0_ysufuzzt3cjmp72q35wizjhorm:
+    resolution: {integrity: sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 5.51.0_r6r774cmu5uauzi735irvz3uwm
+      eslint: 7.32.0
+      eslint-rule-composer: 0.3.0
+    dev: true
+
+  /eslint-rule-composer/0.3.0:
+    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==}
+    engines: {node: '>=4.0.0'}
+    dev: true
+
   /eslint-scope/3.7.3:
     resolution: {integrity: sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==}
     engines: {node: '>=4.0.0'}
@@ -14166,7 +14188,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /file-system-cache/1.1.0:
@@ -15385,7 +15407,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /html-webpack-plugin/5.5.0_webpack@5.75.0:
@@ -19454,7 +19476,7 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.1.1
       semver: 7.3.8
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /postcss-loader/4.3.0_postcss@7.0.39:
@@ -19831,6 +19853,17 @@ packages:
         optional: true
     dev: true
 
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
+    dev: true
+
   /promise.allsettled/1.0.6:
     resolution: {integrity: sha512-22wJUOD3zswWFqgwjNHa1965LvqTX87WPu/lreY2KSd7SVcERfuZ4GfUaOnJNnvtoIv2yXT/W00YIGMetXtFXg==}
     engines: {node: '>= 0.4'}
@@ -20032,7 +20065,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /react-autosuggest/10.1.0_react@17.0.2:
@@ -21893,7 +21926,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /style-loader/2.0.0_webpack@5.75.0:
@@ -22222,7 +22255,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: true
@@ -22241,7 +22274,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.16.3
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - bluebird
@@ -23069,7 +23102,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /url-parse/1.5.10:
@@ -23415,7 +23448,7 @@ packages:
       mime: 2.6.0
       mkdirp: 0.5.6
       range-parser: 1.2.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
       webpack-log: 2.0.0
     dev: true
 
@@ -23440,7 +23473,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@3.3.12
     dev: true
 
   /webpack-hot-middleware/2.25.3:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

<!-- Closes # Github issue # here -->


## 📝 Description

Fix the issue that lint-staged cannot be formatted automatically.

Issue key point: 
  - cannot automatically remove unused imports.

## ⛳️ Current behavior (updates)

- Move `eslint-plugin-prettier` to the end of the plugins list.

## 🚀 New behavior

- New deps [`eslint-plugin-unused-imports`](https://github.com/sweepline/eslint-plugin-unused-imports) for automatic removal of unused imports.
- Turn of `no-unused-vars, unused-imports/no-unused-vars` and keep `@typescript-eslint/no-unused-vars` to detect unused vars.

## 💣 Is this a breaking change (Yes/No):

No

<!---
## 📝 Additional Information
-->