### PR TITLE
Used labeled tuple for CalculatedNodeHeights instead of number array

### DIFF
--- a/packages/react/src/textarea/utils.ts
+++ b/packages/react/src/textarea/utils.ts
@@ -98,10 +98,7 @@ export const getSizingData = (node: HTMLElement): SizingData | null => {
   };
 };
 
-// TODO: use labelled tuples once they are avaiable:
-//   export type CalculatedNodeHeights = [height: number, rowHeight: number];
-// https://github.com/microsoft/TypeScript/issues/28259
-export type CalculatedNodeHeights = number[];
+export type CalculatedNodeHeights = [height: number, rowHeight: number];
 
 let hiddenTextarea: HTMLTextAreaElement | null = null;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes ToDo item

## 📝 Description

> Used tuple instead of the number array

## ⛳️ Current behavior (updates)

>  Returns number array

## 🚀 New behavior

> Returns labeled tuple 

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
