### PR TITLE
fix deprecated `MediaQueryList`

### DIFF
--- a/apps/docs/content/components/grid/hideElement.ts
+++ b/apps/docs/content/components/grid/hideElement.ts
@@ -12,14 +12,14 @@ export const useMediaQuery = (width)=> {
   }, []);
   React.useEffect(() => {
     const media = window.matchMedia(\`(max-width: \${width}px)\`);
-    media.addListener(updateTarget);
+    media.addEventListener('change', updateTarget);
 
     // Check on mount (callback is not called until a change occurs)
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeListener(updateTarget);
+    return () => media.removeEventListener('change', updateTarget);
   }, []);
 
   return targetReached;

--- a/apps/docs/content/components/grid/responsive.ts
+++ b/apps/docs/content/components/grid/responsive.ts
@@ -12,14 +12,14 @@ export const useMediaQuery = (width)=> {
   }, []);
   React.useEffect(() => {
     const media = window.matchMedia(\`(max-width: \${width}px)\`);
-    media.addListener(updateTarget);
+    addEventListener('change', updateTarget);
 
     // Check on mount (callback is not called until a change occurs)
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeListener(updateTarget);
+    return () => media.removeEventListener('change', updateTarget);
   }, []);
 
   return targetReached;

--- a/apps/docs/src/hooks/use-media-query.ts
+++ b/apps/docs/src/hooks/use-media-query.ts
@@ -14,14 +14,14 @@ export const useMediaQuery = (width: number): boolean => {
   useEffect(() => {
     const media = window.matchMedia(`(max-width: ${width}px)`);
 
-    media.addListener(updateTarget);
+    media.addEventListener("change", updateTarget);
 
     // Check on mount (callback is not called until a change occurs)
     if (media.matches) {
       setTargetReached(true);
     }
 
-    return () => media.removeListener(updateTarget);
+    return () => media.removeEventListener("change", updateTarget);
   }, []);
 
   return targetReached;

--- a/apps/docs/src/hooks/use-prefers-reduced-motion.ts
+++ b/apps/docs/src/hooks/use-prefers-reduced-motion.ts
@@ -23,14 +23,14 @@ function usePrefersReducedMotion() {
     if (mediaQueryList.addEventListener) {
       mediaQueryList.addEventListener("change", listener);
     } else {
-      mediaQueryList.addListener(listener);
+      mediaQueryList.addEventListener("change", listener);
     }
 
     return () => {
       if (mediaQueryList.removeEventListener) {
         mediaQueryList.removeEventListener("change", listener);
       } else {
-        mediaQueryList.removeListener(listener);
+        mediaQueryList.removeEventListener("change", listener);
       }
     };
   }, []);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Minor fix to rename two methods `addListener` and `removeListener` to `addEventListener` and `removeEventListener`

## ⛳️ Current behavior (updates)

> Refer to open issue https://github.com/nextui-org/nextui/issues/1068 about the deprecated method via Typescript code.

## 🚀 New behavior

> Renamed the deprecated methods to the new ones

## 💣 Is this a breaking change (Yes/No):

> no, it does not JS, but only affects TS

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
