### PR TITLE
fix(react-link): update example by handle next 13

### DIFF
--- a/apps/docs/content/components/link/nextLink.ts
+++ b/apps/docs/content/components/link/nextLink.ts
@@ -1,12 +1,11 @@
 const App = `import { Link } from "@nextui-org/react";
+import NextLink from "next/link";
 
 export default function App() {
   return (
-    <NextLink href="/docs/components/button">
-      <Link block color="secondary">
-        Go to Button
-      </Link>
-    </NextLink>
+    <Link href="/" as={NextLink} block color="secondary">
+      Go to Button
+    </Link>
   );
 }`;
 

--- a/apps/docs/content/docs/components/link.mdx
+++ b/apps/docs/content/docs/components/link.mdx
@@ -48,13 +48,8 @@ import { Link } from "@nextui-org/react";
 
 <Playground
   title="Next.js Link"
-  desc="If you are using [Next.js](https://nextjs.org) you can use `next/link` as a parent."
-  code={`<NextLink href="/docs/components/button">
-  <Link block color="secondary">
-    Go to Button
-  </Link>
-</NextLink>
-`}
+  desc="If you are using [Next.js](https://nextjs.org) you can use `next/link` as an `as` prop."
+  files={linkContent.nextLink}
 />
 
 <Spacer y={3} />


### PR DESCRIPTION


## 📝 Description

- Using `linkContent` at link - Next.js Link
  - there are already exist file, but not using it

- next.js 13 handling example
  - current example cause hydration error
  - there are two way to handle it, what I found
    - using `legacyBehavior` prop
    - using `Link` tags 'as' prop with `NextLink`

I found this PR, so I handle with this as prop https://github.com/nextui-org/nextui/pull/446

## ⛳️ Current behavior (updates)

<img width="476" alt="스크린샷 2023-03-16 오후 4 16 55" src="https://user-images.githubusercontent.com/26461307/225542448-da0a6af8-0eae-43f9-88ae-d7a964d9f97f.png">


## 🚀 New behavior

<img width="603" alt="image" src="https://user-images.githubusercontent.com/26461307/225543335-df73e027-b6df-4bb9-87ce-eddf67bbd756.png">


## 💣 Is this a breaking change (Yes/No):

No. just changin docs

## 📝 Additional Information

does not work example `Go to Button`, I do not know why 😢 

> I guess... are there not allowed importing 'next/link' where linkContent mdx files?