### PR TITLE
fix: Make entire navigation link area clickable on sidebar for the docs app. 

### DIFF
--- a/apps/docs/src/components/nav-link/index.tsx
+++ b/apps/docs/src/components/nav-link/index.tsx
@@ -28,6 +28,8 @@ export type NavLinkProps = Props & typeof defaultProps & NativeAttrs;
 const BaseLink = styled(Link, {
   d: "flex",
   textDecoration: "none",
+  width: "100%",
+  maxW: "100%",
   "@smMax": {
     pt: 0,
     pl: 0,
@@ -66,6 +68,7 @@ const NavLink: React.FC<NavLinkProps> = ({
   selected,
   comingSoon,
   onClick,
+  children,
 }) => {
   const router = useRouter();
   const onlyHashChange = pathname === router.pathname;
@@ -96,7 +99,8 @@ const NavLink: React.FC<NavLinkProps> = ({
         selected={selected}
         onClick={(e: any) => !comingSoon && onClick && onClick(e)}
       >
-        {title}
+        <span>{title}</span>
+        {children}
       </BaseLink>
     </NextLink>
   );

--- a/apps/docs/src/components/sidebar/post.tsx
+++ b/apps/docs/src/components/sidebar/post.tsx
@@ -50,23 +50,24 @@ const Post: React.FC<PostProps> = ({isMobile, route, level = 1, onClick}) => {
 
   return (
     <div ref={ref} className={cn("link", `level-${level}`, {disabled: route?.comingSoon})}>
-      <NavLink {...route} color={linkColor} onClick={onClick} />
-      <Spacer inline x={0.2} />
-      {route?.newPost && (
-        <Badge className="post__new-badge" type="primary">
-          New
-        </Badge>
-      )}
-      {route?.updated && (
-        <Badge className="post__new-badge" type="secondary">
-          Updated
-        </Badge>
-      )}
-      {route?.comingSoon && (
-        <Badge className="post__coming-soon-badge" type="disabled">
-          Coming soon
-        </Badge>
-      )}
+      <NavLink {...route} color={linkColor} onClick={onClick}>
+        <Spacer inline x={0.2} />
+        {route?.newPost && (
+          <Badge className="post__new-badge" type="primary">
+            New
+          </Badge>
+        )}
+        {route?.updated && (
+          <Badge className="post__new-badge" type="secondary">
+            Updated
+          </Badge>
+        )}
+        {route?.comingSoon && (
+          <Badge className="post__coming-soon-badge" type="disabled">
+            Coming soon
+          </Badge>
+        )}
+      </NavLink>
       <style jsx>{`
         .link {
           margin: 18px 0;


### PR DESCRIPTION
## 📝 Description

> Add a brief description

This PR addresses the issue where navigation links in the sidebar for the docs app were only clickable on the link text itself. The changes make the entire area within the navigation link clickable, improving the user experience. 

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

Currently, the navigation links in the sidebar are only clickable on the link text itself. Clicking outside the text in the horizontal direction did not trigger the link. This can lead to a frustrating user experience, especially on mobile devices. 

[old_behavior.webm](https://user-images.githubusercontent.com/59168430/229267290-f6e5eb32-4c37-4e7e-b85d-f77d91c81d21.webm)

## ⛳️ New behavior (updates)
> Please describe the behavior or changes this PR adds

This PR changes the behavior. The navigation links will be clickable from the whole horizontal area and not only the link text. 

[new_behavior.webm](https://user-images.githubusercontent.com/59168430/229267504-38380c48-fcc5-4a35-83ad-e1db3ceb145d.webm)

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


### Solution
 - Wrap the <Post> component inside the <NavLink> component to ensure the entire area within the NavLink is clickable.

 - Apply the CSS properties width: 100%; and maxW: 100%; to the BaseLink component within the NavLink. This ensures the link expands to fill the full width of its container, making it clickable even outside the link text area.
 
### Testing

The application was tested after making the changes using the  command `yarn test:update`