### PR TITLE
Fix: #1085 - Updated Textarea component to proper resize when controlled

### DIFF
--- a/packages/react/src/textarea/textarea.tsx
+++ b/packages/react/src/textarea/textarea.tsx
@@ -84,7 +84,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
       const [height, rowHeight] = calculateNodeHeight(
         nodeSizingData,
-        node.value || node.placeholder || "x",
+        (isControlled && (props.value as string)) || node.value || node.placeholder || "x",
         rows || minRows,
         rows || maxRows,
       );
@@ -97,9 +97,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     };
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      if (!isControlled) {
-        resizeTextarea();
-      }
+      resizeTextarea();
       onChange && onChange(event);
     };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1085 

## 📝 Description

> Updated the Textarea component to properly handle resizing when controlled by an outside state controller such as `useState` or `useInput`

## ⛳️ Current behavior (updates)

> The current behavior causes the form to not properly handle resizing, resulting in a scrollbar appearing no matter the props (such as `maxRows`) passed in, when such props would typically cause the Textarea to expand accordingly.

## 🚀 New behavior

> The Textarea now correctly expands when utilizing props such as `maxRows`.

## 💣 Is this a breaking change (Yes/No): 
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
As a consideration, the general typing of for `value` when using an input allows for `string | string[] | number | undefined`. This PR does cause this to be assumed to be `string` which should be fine as all three of the available types are translated to `string` under the hood.