### PR TITLE
Fix: #938 Removed absolute positioning from clear button

### DIFF
--- a/packages/react/src/input/input.styles.ts
+++ b/packages/react/src/input/input.styles.ts
@@ -837,7 +837,6 @@ export const StyledInputContent = styled("span", {
 });
 
 export const StyledInputClearButton = styled("button", {
-  position: "absolute",
   right: 0,
   margin: 0,
   d: "inline-flex",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #938 

## 📝 Description

> A `position: absolute` on the styling of the input clear button allowed text to render under the button.

## ⛳️ Current behavior (updates)

> A `position: absolute` on the styling of the input clear button allowed text to render under the button.

## 🚀 New behavior

> Button now has its own width, preventing text from rendering under it.

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->