### PR TITLE
feat(Button): borderWidth prop added

### DIFF
--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -49,13 +49,13 @@ const button = tv({
   ],
   variants: {
     variant: {
-      solid: "",
-      bordered: "border-2 !bg-transparent",
-      light: "!bg-transparent",
-      flat: "",
-      faded: "border-2",
-      shadow: "",
-      ghost: "border-2 !bg-transparent",
+      solid: "!border-0",
+      bordered: "!bg-transparent",
+      light: "!border-0 !bg-transparent",
+      flat: "!border-0",
+      faded: "",
+      shadow: "!border-0",
+      ghost: "!bg-transparent",
     },
     size: {
       xs: "px-2 h-6 text-xs",
@@ -83,6 +83,14 @@ const button = tv({
       "3xl": "rounded-3xl",
       full: "rounded-full",
     },
+    borderWidth: {
+      none: "border-0",
+      light: "border",
+      normal: "border-2",
+      bold: "border-[3px]",
+      extrabold: "border-4",
+      black: "border-[5px]",
+    },
     fullWidth: {
       true: "w-full",
     },
@@ -105,6 +113,7 @@ const button = tv({
     variant: "solid",
     color: "neutral",
     radius: "xl",
+    borderWidth: "normal",
     fullWidth: false,
     isDisabled: false,
     isInGroup: false,


### PR DESCRIPTION
support borderWidth for bordered button

Note: naming `borderWidth` prop instead of `borderWeight` to be friendly with the `border-width` class of the tailwindcss


<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
