### PR TITLE
Fix: Add Sun Icon to Theme Switcher in Docs Page

### DIFF
--- a/apps/docs/src/components/theme-switch/index.tsx
+++ b/apps/docs/src/components/theme-switch/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {Switch, SwitchProps, useTheme} from "@nextui-org/react";
 import {useTheme as useNextTheme} from "next-themes";
 
-import {Moon} from "../icons";
+import {Moon, Sun} from "../icons";
 
 export const ThemeToggle: React.FC<Partial<SwitchProps>> = ({...props}) => {
   const [isSelfDark, setIsSelfDark] = React.useState(false);
@@ -20,7 +20,8 @@ export const ThemeToggle: React.FC<Partial<SwitchProps>> = ({...props}) => {
   return (
     <Switch
       checked={isSelfDark || isDark}
-      icon={<Moon filled />}
+      iconOff={<Moon filled />}
+      iconOn={<Sun filled />}
       size="xl"
       onChange={handleToggleTheme}
       {...props}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1124

## 📝 Description

Added two new props for Switch component `iconOn` and `iconOff`  to show different icons on different themes.

## ⛳️ Current behavior (updates)

Currently there is only moon icon on both light and dark theme

https://github.com/nextui-org/nextui/assets/65389981/dc599cc6-06bc-45be-bdd3-719f0275909d

## 🚀 New behavior

Now the icon changes as the theme changes from light to dark and vice versa.

https://github.com/nextui-org/nextui/assets/65389981/9a1be9d1-45e3-429d-ae45-937ae80e10bb

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
