### PR TITLE
fix: fixed bordered button styling issues inside group

### DIFF
--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -376,7 +376,7 @@ const button = tv({
     {
       isInGroup: true,
       variant: ["bordered", "ghost"],
-      class: "[&:not(:first-child)]:border-l-0",
+      class: "[&:not(:first-child)]:ml-[calc(theme(borderWidth.2)*-1)]",
     },
     // isIconOnly / size
     {


### PR DESCRIPTION
#### Focus state
Before: ![image](https://github.com/nextui-org/nextui/assets/25524993/604fc090-2fb6-4765-b37f-2c131b30be02)
After: ![image](https://github.com/nextui-org/nextui/assets/25524993/3b1dca06-de30-4bd6-81db-6ae2d19e43dc)
#### Pressed state
Before: ![image](https://github.com/nextui-org/nextui/assets/25524993/04424a9b-9fc0-4a26-9978-1cfca9709ff4)
After: ![image](https://github.com/nextui-org/nextui/assets/25524993/2bd457b4-b129-4873-b01e-7fe0e9adfb6e)
#### Sizing
If the content is the same, the buttons are all the same size.
![image](https://github.com/nextui-org/nextui/assets/25524993/ca44da26-067a-4e32-88d3-28cf90cb9c6c)

