### PR TITLE
 feat(tabs): improve tab accessibility

### DIFF
--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -84,21 +84,21 @@ describe("Tabs", () => {
   test("should select the correct tab with keyboard navigation", async () => {
     const wrapper = render(
       <Tabs aria-label="Tabs static test">
-        <Tab key="item1" data-testid="item1" title="Item 1">
+        <Tab key="item1" title="Item 1">
           <div>Content 1</div>
         </Tab>
-        <Tab key="item2" data-testid="item2" title="Item 2">
+        <Tab key="item2" title="Item 2">
           <div>Content 2</div>
         </Tab>
-        <Tab key="item3" data-testid="item3" title="Item 3">
+        <Tab key="item3" title="Item 3">
           <div>Content 3</div>
         </Tab>
       </Tabs>,
     );
 
-    const tab1 = wrapper.getByTestId("item1");
-    const tab2 = wrapper.getByTestId("item2");
-    const tab3 = wrapper.getByTestId("item3");
+    const tab1 = wrapper.getByRole("tab", {name: "Item 1"});
+    const tab2 = wrapper.getByRole("tab", {name: "Item 2"});
+    const tab3 = wrapper.getByRole("tab", {name: "Item 3"});
 
     expect(tab1).toHaveAttribute("aria-selected", "true");
     expect(tab2).toHaveAttribute("aria-selected", "false");

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -13,7 +13,7 @@ import {useIsMounted} from "@nextui-org/use-is-mounted";
 
 import {useTabsContext} from "./tabs-context";
 
-export interface TabItemProps<T = object> extends HTMLNextUIProps<"div"> {
+export interface TabItemProps<T = object> extends HTMLNextUIProps<"button"> {
   /**
    * The tab item.
    */
@@ -23,14 +23,14 @@ export interface TabItemProps<T = object> extends HTMLNextUIProps<"div"> {
 /**
  * @internal
  */
-const Tab = forwardRef<TabItemProps, "div">((props, ref) => {
+const Tab = forwardRef<TabItemProps, "button">((props, ref) => {
   const {className, as, item, style, onClick, ...otherProps} = props;
 
   const {key} = item;
 
   const domRef = useDOMRef(ref);
 
-  const Component = as || "div";
+  const Component = as || "button";
 
   const {
     slots,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

I've made improvements to the tab component by updating the HTML element from `<div>` to `<button>`. 
This change aligns with the accessibility guidelines outlined in the "Role, Property, State, and Tabindex Attributes" section of the following page: [Link to the ARIA tabs example](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/). 
By using the <button> element, we ensure better semantic representation and enhance keyboard accessibility for tab navigation.

## ⛳️ Current behavior (updates)


The current behavior of the tab component is using a `<div>` element to represent each tab item.


## 🚀 New behavior

With this change, the tab component now uses the more appropriate `<button>` element for each tab item. This improves the accessibility and ensures proper keyboard interaction with the tab navigation.


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No

## 📝 Additional Information

Using the getByRole function instead of getByTestId for retrieving the tab items is considered a best practice for testing accessibility. 