### PR TITLE
fix: fixed pagination problems

### DIFF
--- a/packages/components/pagination/src/use-pagination.ts
+++ b/packages/components/pagination/src/use-pagination.ts
@@ -304,6 +304,7 @@ export function usePagination(originalProps: UsePaginationProps) {
   const getItemProps: PropGetter = (props = {}) => {
     return {
       ...props,
+      key: props.value,
       ref: (node) => getItemRef(node, props.value),
       "data-slot": "item",
       isActive: props.value === activePage,

--- a/packages/core/theme/src/components/pagination.ts
+++ b/packages/core/theme/src/components/pagination.ts
@@ -27,7 +27,8 @@ const pagination = tv({
       "flex-nowrap",
       "h-fit",
       "max-w-fit",
-      "py-2.5",
+      "p-2.5",
+      "-m-2.5",
       "relative",
       "gap-1",
       "items-center",
@@ -45,6 +46,7 @@ const pagination = tv({
       "justify-center",
       "origin-center",
       "left-0",
+      "z-20",
     ],
     forwardIcon: "hidden group-hover:block data-[before=true]:rotate-180",
     ellipsis: "group-hover:hidden",
@@ -195,7 +197,7 @@ const pagination = tv({
       isCompact: true,
       variant: "bordered",
       class: {
-        item: "[&:not(:first-of-type)]:border-l-0",
+        item: "[&:not(:first-of-type)]:ml-[calc(theme(borderWidth.2)*-1)]",
       },
     },
     /**
@@ -335,6 +337,7 @@ const pagination = tv({
         "justify-center",
         "text-default-foreground",
         // focus ring
+        "data-[focus-visible=true]:z-10",
         "data-[focus-visible=true]:outline-none",
         "data-[focus-visible=true]:ring-2",
         "data-[focus-visible=true]:ring-primary",


### PR DESCRIPTION
This PR:
- removes the padding from the top and bottom (elements should not be padded IMO).
- makes it so the focus ring is not cut off anymore.
- makes it so the focus does not get lost when elements move.