### PR TITLE
fix: accordion warning keys

### DIFF
--- a/packages/components/accordion/src/accordion.tsx
+++ b/packages/components/accordion/src/accordion.tsx
@@ -1,6 +1,7 @@
 import {forwardRef} from "@nextui-org/system";
 import {LayoutGroup} from "framer-motion";
 import {Divider} from "@nextui-org/divider";
+import {Fragment} from "react";
 
 import {UseAccordionProps, useAccordion} from "./use-accordion";
 import {AccordionProvider} from "./accordion-context";
@@ -25,16 +26,15 @@ const AccordionGroup = forwardRef<AccordionProps, "div">((props, ref) => {
   });
 
   const content = [...state.collection].map((item, index) => (
-    <>
+    <Fragment key={item.key}>
       <AccordionItem
-        key={item.key}
         item={item}
         onFocusChange={(isFocused) => handleFocusChanged(isFocused, item.key)}
         {...item.props}
         classNames={{...itemClasses, ...(item.props.classNames || {})}}
       />
       {!isSplitted && showDivider && index < state.collection.size - 1 && <Divider />}
-    </>
+    </Fragment>
   ));
 
   return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
This PR fixes `warning-keys` in Accordion components.

## ⛳️ Current behavior (updates)
The following warning appear when using the Accordion component.
`Warning: Each child in a list should have a unique "key" prop.`

## 🚀 New behavior
No warning appears.

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
