### PR TITLE
fix: progress bar with more than 100% is shown as full and with proper label

### DIFF
--- a/packages/components/progress/src/use-aria-progress.ts
+++ b/packages/components/progress/src/use-aria-progress.ts
@@ -1,5 +1,5 @@
 import {AriaProgressBarProps} from "@react-types/progress";
-import {clamp, filterDOMProps, mergeProps} from "@react-aria/utils";
+import {filterDOMProps, mergeProps} from "@react-aria/utils";
 import {DOMAttributes} from "@react-types/shared";
 import {useAriaLabel} from "@nextui-org/use-aria-label";
 import {useNumberFormatter} from "@react-aria/i18n";
@@ -36,7 +36,7 @@ export function useProgressBar(props: AriaProgressBarProps): ProgressBarAria {
     labelElementType: "span",
   });
 
-  value = clamp(value, minValue, maxValue);
+  value = Math.max(value, minValue);
   const percentage = (value - minValue) / (maxValue - minValue);
   const formatter = useNumberFormatter(formatOptions);
 

--- a/packages/components/progress/src/use-progress.ts
+++ b/packages/components/progress/src/use-progress.ts
@@ -5,7 +5,7 @@ import type {AriaProgressBarProps} from "@react-types/progress";
 import {HTMLNextUIProps, mapPropsVariants} from "@nextui-org/system";
 import {progress} from "@nextui-org/theme";
 import {useDOMRef} from "@nextui-org/react-utils";
-import {clsx, dataAttr} from "@nextui-org/shared-utils";
+import {clampPercentage, clsx, dataAttr} from "@nextui-org/shared-utils";
 import {ReactRef} from "@nextui-org/react-utils";
 import {mergeProps} from "@react-aria/utils";
 import {useMemo, useCallback} from "react";
@@ -104,7 +104,7 @@ export function useProgress(originalProps: UseProgressProps) {
     () =>
       isIndeterminate || !selfMounted
         ? undefined
-        : ((value - minValue) / (maxValue - minValue)) * 100,
+        : clampPercentage(((value - minValue) / (maxValue - minValue)) * 100),
     [selfMounted, isIndeterminate, value, minValue, maxValue],
   );
 

--- a/packages/utilities/shared-utils/src/numbers.ts
+++ b/packages/utilities/shared-utils/src/numbers.ts
@@ -9,3 +9,7 @@ export function range(start: number, end: number) {
 
   return Array.from({length}, (_, index) => index + start);
 }
+
+export function clampPercentage(value: number) {
+  return Math.min(Math.max(value, 0), 100);
+}


### PR DESCRIPTION
## Example with `value: 555`

https://storiesv2.nextui.org/?path=/story/components-progress--with-value-formatting&args=value:555

Now the label reflects the value and the progress bar is not stuck anymore.

The label is also fixed for circular progress by this change.

### Before
![image](https://github.com/nextui-org/nextui/assets/25524993/0d33fc11-0caa-4d51-97ed-fbbb062314c5)

### After
![image](https://github.com/nextui-org/nextui/assets/25524993/a7b07f9d-cc35-4300-a664-ae42ebcaf55e)

