### PR TITLE
fix: added alt fallback to avatar component

### DIFF
--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -29,26 +29,20 @@ const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
   const fallback = useMemo(() => {
     if (!showFallback && src) return null;
 
-    const ariaLabel = alt || name || "avatar";
-
     if (fallbackComponent) {
       return (
-        <div
-          aria-label={ariaLabel}
-          className={slots.fallback({class: classNames?.fallback})}
-          role="img"
-        >
+        <div aria-label={alt} className={slots.fallback({class: classNames?.fallback})} role="img">
           {fallbackComponent}
         </div>
       );
     }
 
     return name ? (
-      <span aria-label={ariaLabel} className={slots.name({class: classNames?.name})} role="img">
+      <span aria-label={alt} className={slots.name({class: classNames?.name})} role="img">
         {getInitials(name)}
       </span>
     ) : (
-      <span aria-label={ariaLabel} className={slots.icon({class: classNames?.icon})} role="img">
+      <span aria-label={alt} className={slots.icon({class: classNames?.icon})} role="img">
         {icon}
       </span>
     );

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -109,7 +109,7 @@ export function useAvatar(props: UseAvatarProps = {}) {
     icon,
     classNames,
     fallback,
-    alt = name,
+    alt = name || "avatar",
     imgRef: imgRefProp,
     color = groupContext?.color ?? "default",
     radius = groupContext?.radius ?? "full",


### PR DESCRIPTION
https://storiesv2.nextui.org/?path=/story/components-avatar--with-image did not have an alt tag, now the alt tag falls back to `"avatar"` when `name` and `alt` is not defined.