### PR TITLE
docs (pagination): use onPress instead of onClick

### DIFF
--- a/apps/docs/content/components/pagination/custom-items.ts
+++ b/apps/docs/content/components/pagination/custom-items.ts
@@ -61,7 +61,7 @@ export default function App() {
   }: PaginationItemRenderProps<HTMLButtonElement>) => {
     if (value === PaginationItemType.NEXT) {
       return (
-        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onClick={onNext}>
+        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onPress={onNext}>
           <ChevronIcon className="rotate-180" />
         </button>
       );
@@ -69,7 +69,7 @@ export default function App() {
 
     if (value === PaginationItemType.PREV) {
       return (
-        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onClick={onPrevious}>
+        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onPress={onPrevious}>
           <ChevronIcon />
         </button>
       );
@@ -88,7 +88,7 @@ export default function App() {
           isActive &&
             "text-white bg-gradient-to-br from-indigo-500 to-pink-500 font-bold",
         )}
-        onClick={() => setPage(value)}
+        onPress={() => setPage(value)}
       >
         {value}
       </button>
@@ -124,7 +124,7 @@ export default function App() {
   }) => {
     if (value === PaginationItemType.NEXT) {
       return (
-        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onClick={onNext}>
+        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onPress={onNext}>
           <ChevronIcon className="rotate-180" />
         </button>
       );
@@ -132,7 +132,7 @@ export default function App() {
 
     if (value === PaginationItemType.PREV) {
       return (
-        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onClick={onPrevious}>
+        <button className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onPress={onPrevious}>
           <ChevronIcon />
         </button>
       );
@@ -151,7 +151,7 @@ export default function App() {
           isActive &&
           "text-white bg-gradient-to-br from-indigo-500 to-pink-500 font-bold",
         )}
-        onClick={() => setPage(value)}
+        onPress={() => setPage(value)}
       >
         {value}
       </button>


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> In pagination docs, there are some button use `onClick` is deprecated. I change it to `onPress`

## ⛳️ Current & New behavior (updates)

> There is no change in behavior

## 💣 Is this a breaking change (Yes/No):
> No, It's not breaking anything
