### PR TITLE
fix: resolved cursor issues in pagination

### DIFF
--- a/.changeset/eighty-knives-heal.md
+++ b/.changeset/eighty-knives-heal.md
@@ -1,0 +1,10 @@
+---
+"@nextui-org/pagination": patch
+"@nextui-org/theme": patch
+---
+
+fix: resolved cursor issues in pagination
+
+- The cursor does not animate anymore on initial render and non page change prop changes.
+- The cursor hover state now looks good with disableAnimation set.
+- The animated cursor is now transparent to the cursor (pointer-events: none).

--- a/packages/components/pagination/src/use-pagination.ts
+++ b/packages/components/pagination/src/use-pagination.ts
@@ -175,42 +175,47 @@ export function usePagination(originalProps: UsePaginationProps) {
     }
   }
 
-  function scrollTo(value: number) {
+  function scrollTo(value: number, skipAnimation: boolean) {
     const map = getItemsRefMap();
 
     const node = map.get(value);
 
+    if (!node || !cursorRef.current) return;
+
     // clean up the previous cursor timer (if any)
     cursorTimer.current && clearTimeout(cursorTimer.current);
 
-    if (node) {
-      // scroll parent to the item
-      scrollIntoView(node, {
-        scrollMode: "always",
-        behavior: "smooth",
-        block: "start",
-        inline: "start",
-        boundary: domRef.current,
-      });
+    // scroll parent to the item
+    scrollIntoView(node, {
+      scrollMode: "always",
+      behavior: "smooth",
+      block: "start",
+      inline: "start",
+      boundary: domRef.current,
+    });
 
-      // get position of the item
-      const {offsetLeft} = node;
+    // get position of the item
+    const {offsetLeft} = node;
 
-      // move the cursor to the item
-      if (cursorRef.current) {
-        cursorRef.current.setAttribute("data-moving", "true");
-        cursorRef.current.style.transform = `translateX(${offsetLeft}px) scale(1.1)`;
-      }
-
-      cursorTimer.current = setTimeout(() => {
-        // reset the scale of the cursor
-        if (cursorRef.current) {
-          cursorRef.current.setAttribute("data-moving", "false");
-          cursorRef.current.style.transform = `translateX(${offsetLeft}px) scale(1)`;
-        }
-        cursorTimer.current && clearTimeout(cursorTimer.current);
-      }, CURSOR_TRANSITION_TIMEOUT);
+    // only shows the animation when the page changes, not on intial render or layout shift
+    if (skipAnimation) {
+      cursorRef.current.setAttribute("data-moving", "false");
+      cursorRef.current.style.transform = `translateX(${offsetLeft}px) scale(1)`;
+      return;
     }
+
+    // move the cursor to the item
+    cursorRef.current.setAttribute("data-moving", "true");
+    cursorRef.current.style.transform = `translateX(${offsetLeft}px) scale(1.1)`;
+
+    cursorTimer.current = setTimeout(() => {
+      // reset the scale of the cursor
+      if (cursorRef.current) {
+        cursorRef.current.setAttribute("data-moving", "false");
+        cursorRef.current.style.transform = `translateX(${offsetLeft}px) scale(1)`;
+      }
+      cursorTimer.current && clearTimeout(cursorTimer.current);
+    }, CURSOR_TRANSITION_TIMEOUT);
   }
 
   const {range, activePage, setPage, previous, next, first, last} = useBasePagination({
@@ -223,15 +228,19 @@ export function usePagination(originalProps: UsePaginationProps) {
     onChange,
   });
 
+  const activePageRef = useRef(activePage);
   useEffect(() => {
     if (activePage && !originalProps.disableAnimation) {
-      scrollTo(activePage);
+      scrollTo(activePage, activePage === activePageRef.current);
     }
+    activePageRef.current = activePage;
   }, [
     activePage,
     originalProps.disableAnimation,
-    originalProps.isCompact,
     originalProps.disableCursorAnimation,
+    originalProps.dotsJump,
+    originalProps.isCompact,
+    originalProps.showControls,
   ]);
 
   const slots = useMemo(

--- a/packages/core/theme/src/components/pagination.ts
+++ b/packages/core/theme/src/components/pagination.ts
@@ -139,6 +139,7 @@ const pagination = tv({
         cursor: [
           "data-[moving=true]:transition-transform",
           "!data-[moving=true]:duration-300",
+          // this hides the cursor and only shows it once it has been moved to its initial position
           "opacity-0",
           "data-[moving]:opacity-100",
         ],

--- a/packages/core/theme/src/components/pagination.ts
+++ b/packages/core/theme/src/components/pagination.ts
@@ -45,6 +45,7 @@ const pagination = tv({
       "left-0",
       "select-none",
       "touch-none",
+      "pointer-events-none",
       "z-20",
     ],
     forwardIcon:
@@ -135,7 +136,12 @@ const pagination = tv({
       },
       false: {
         item: ["data-[pressed=true]:scale-[0.97]", "transition-transform-background"],
-        cursor: ["transition-transform", "!duration-300"],
+        cursor: [
+          "data-[moving=true]:transition-transform",
+          "!data-[moving=true]:duration-300",
+          "opacity-0",
+          "data-[moving]:opacity-100",
+        ],
       },
     },
   },
@@ -353,17 +359,28 @@ const pagination = tv({
     {
       slots: ["item", "prev", "next"],
       variant: "flat",
-      class: ["bg-default-100", "data-[hover=true]:bg-default-200", "active:bg-default-300"],
+      class: [
+        "bg-default-100",
+        "[&[data-hover=true]:not([data-active=true])]:bg-default-200",
+        "active:bg-default-300",
+      ],
     },
     {
       slots: ["item", "prev", "next"],
       variant: "faded",
-      class: ["bg-default-50", "data-[hover=true]:bg-default-100", "active:bg-default-200"],
+      class: [
+        "bg-default-50",
+        "[&[data-hover=true]:not([data-active=true])]:bg-default-100",
+        "active:bg-default-200",
+      ],
     },
     {
       slots: ["item", "prev", "next"],
       variant: "light",
-      class: ["data-[hover=true]:bg-default-100", "active:bg-default-200"],
+      class: [
+        "[&[data-hover=true]:not([data-active=true])]:bg-default-100",
+        "active:bg-default-200",
+      ],
     },
     // size
     {


### PR DESCRIPTION
- The cursor does not animate anymore on initial render and non page change prop changes.
- The cursor hover state now looks good with `disableAnimation` set.
- The animated cursor is now transparent to the cursor (`pointer-events: none`).