### PR TITLE
fix way to specify accents0 to support table striped without selectionMode

### DIFF
--- a/packages/react/src/table/table.styles.ts
+++ b/packages/react/src/table/table.styles.ts
@@ -273,12 +273,10 @@ export const StyledTable = styled("table", {
     },
     striped: {
       true: {
-        [`& ${StyledTableRow}[aria-selected=false]:nth-child(even)`]: {
+        [`& ${StyledTableRow}:nth-child(even)`]: {
           [`& ${StyledTableCell}`]: {
             bg: "$accents0",
           },
-        },
-        [`& ${StyledTableRow}:nth-child(even)`]: {
           [`& ${StyledTableCell}:first-child`]: {
             br: "$lg 0 0 $lg",
           },


### PR DESCRIPTION
Closes #1106

## 📝 Description

Support for table's striped props without specifying selectionMode.

## ⛳️ Current behavior (updates)

The stripes can be seen without selectionMode.(old)

## 🚀 New behavior

The strips can be seen even without selectionMode.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
Nothing