### PR TITLE
fix(tooltip): behavior of tooltip trigger with delay

### DIFF
--- a/.changeset/olive-hounds-bake.md
+++ b/.changeset/olive-hounds-bake.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tooltip": patch
+---
+
+Fix the trigger behavior to prevent it from opening again after the delay is not reached and the cursor moves out.

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -208,8 +208,6 @@ export function useTooltip(originalProps: UseTooltipProps) {
       ...mergeProps(triggerProps, props),
       ref: mergeRefs(_ref, triggerRef),
       "aria-describedby": isOpen ? tooltipId : undefined,
-      onPointerEnter: () => state.open(),
-      onPointerLeave: () => state.isOpen && state.close(),
     }),
     [triggerProps, isOpen, tooltipId, state],
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/1168

## 📝 Description

The tooltip should not open again after the delay is not reached and the cursor moves out.

## ⛳️ Current behavior (updates)

Fix the trigger behavior to prevent it from opening again after the delay is not reached and the cursor moves out.

## 🚀 New behavior

Use `triggerProps` instead of custom on-pointer events, it already includes the correct pointer behavior.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

#### Before

[before.webm](https://github.com/nextui-org/nextui/assets/32772271/2e1d08bc-d34c-4c85-8b9b-0341e9cd8e1b)

#### After

[after.webm](https://github.com/nextui-org/nextui/assets/32772271/f9d83313-9b6a-4098-9545-fc0ac650f289)



