### PR TITLE
fix: show focus ring when table row is focused in read mode

### DIFF
--- a/.changeset/witty-trees-buy.md
+++ b/.changeset/witty-trees-buy.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": patch
+---
+
+fix: show focus ring when table row is focused in read mode

--- a/packages/components/table/src/table-row.tsx
+++ b/packages/components/table/src/table-row.tsx
@@ -70,7 +70,8 @@ const TableRow = forwardRef<"tr", TableRowProps>((props, ref) => {
       data-selected={dataAttr(isSelected)}
       {...mergeProps(
         rowProps,
-        isSelectable ? {...hoverProps, ...focusProps} : {},
+        focusProps,
+        isSelectable ? hoverProps : {},
         filterDOMProps(node.props, {
           enabled: shouldFilterDOMProps,
         }),


### PR DESCRIPTION
A table is still focusable in read mode and should still show a focus ring.

Steps to reproduce:

1. Open https://storybook.nextui.org/iframe.html?args=&id=components-table--static&viewMode=story
2. Press <kbd>tab</kbd>
3. Press <kbd>left</kbd><kbd>left</kbd><kbd>left</kbd><kbd>left</kbd>

Fixed:

https://github.com/nextui-org/nextui/assets/25524993/dd3b1b24-4cf1-4719-9dd7-bb24ff49ee42

