### PR TITLE
fix(input): duplicate triggering of input events

### DIFF
--- a/.changeset/mean-parrots-whisper.md
+++ b/.changeset/mean-parrots-whisper.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/react-rsc-utils": patch
+---
+
+Support for omit-event-names option.

--- a/.changeset/new-zoos-hug.md
+++ b/.changeset/new-zoos-hug.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fixed event functions call twice.

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -88,4 +88,15 @@ describe("Input", () => {
 
     expect(container6.querySelector("input")).toHaveAttribute("type", "text");
   });
+
+  it("should call dom event handlers only once", () => {
+    const onFocus = jest.fn();
+
+    const {container} = render(<Input label="test input" onFocus={onFocus} />);
+
+    container.querySelector("input")?.focus();
+    container.querySelector("input")?.blur();
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -240,7 +240,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
           filterDOMProps(otherProps, {
             enabled: true,
             labelable: true,
-            omitNames: new Set(Object.keys(inputProps)),
+            omitEventNames: new Set(Object.keys(inputProps)),
           }),
           props,
         ),

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -234,7 +234,16 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       return {
         ref: domRef,
         className: slots.input({class: clsx(classNames?.input, !!inputValue ? "is-filled" : "")}),
-        ...mergeProps(focusProps, inputProps, filterDOMProps(otherProps), props),
+        ...mergeProps(
+          focusProps,
+          inputProps,
+          filterDOMProps(otherProps, {
+            enabled: true,
+            labelable: true,
+            omitNames: new Set(Object.keys(inputProps)),
+          }),
+          props,
+        ),
         required: originalProps.isRequired,
         "aria-readonly": dataAttr(originalProps.isReadOnly),
         "aria-required": dataAttr(originalProps.isRequired),

--- a/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
+++ b/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
@@ -27,9 +27,9 @@ interface Options {
    */
   propNames?: Set<string>;
   /**
-   * A Set of property names that should be excluded from the filter.
+   * A Set of event names that should be excluded from the filter.
    */
-  omitNames?: Set<string>;
+  omitEventNames?: Set<string>;
 }
 
 const propRe = /^(data-.*)$/;
@@ -48,14 +48,14 @@ export function filterDOMProps(
     enabled: true,
   },
 ): DOMProps & AriaLabelingProps {
-  let {labelable, propNames, omitNames} = opts;
+  let {labelable, propNames, omitEventNames} = opts;
   let filteredProps = {};
 
   if (!opts.enabled) {
     return props;
   }
   for (const prop in props) {
-    if (omitNames?.has(prop)) {
+    if (omitEventNames?.has(prop) && funcRe.test(prop)) {
       continue;
     }
 

--- a/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
+++ b/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
@@ -26,6 +26,10 @@ interface Options {
    * A Set of other property names that should be included in the filter.
    */
   propNames?: Set<string>;
+  /**
+   * A Set of property names that should be excluded from the filter.
+   */
+  omitNames?: Set<string>;
 }
 
 const propRe = /^(data-.*)$/;
@@ -44,14 +48,17 @@ export function filterDOMProps(
     enabled: true,
   },
 ): DOMProps & AriaLabelingProps {
-  let {labelable, propNames} = opts;
+  let {labelable, propNames, omitNames} = opts;
   let filteredProps = {};
 
   if (!opts.enabled) {
     return props;
   }
-
   for (const prop in props) {
+    if (omitNames?.has(prop)) {
+      continue;
+    }
+
     if (
       (Object.prototype.hasOwnProperty.call(props, prop) &&
         (DOMPropNames.has(prop) ||


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/1308

## 📝 Description

This PR fixes the issue where native DOM events for the input were being triggered twice. This issue was caused by the duplication of `inputProps` and `otherProps` in the `mergeProps`.

Firstly, `inputProps` is derived from `originalProps` after being processed by `useTextField`, which already includes the native DOM events. Secondly, `otherProps` also contain a similar set of props.

In this scenario, there could be two identical DOM event functions present in `mergeProps`. However, within `mergeProps`, the identical functions are executed in a chain ([source](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/utils/src/mergeProps.ts#L56)), leading to the execution of the functions twice.

## ⛳️ Current behavior (updates)

Filter out duplicate event functions in `filterDOMProps`.

## 🚀 New behavior

The `filterDOMProps` utility method now supports the `omitEventNames` option to prevent redundant event functions. (Skips only functions with names starting with `on[A-Z]`).

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Test cases have been added and passed successfully.