### PR TITLE
fix: moved sr only modal close buttons to not show unnecessary scroll bar

### DIFF
--- a/.changeset/sour-lizards-allow.md
+++ b/.changeset/sour-lizards-allow.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/modal": patch
+---
+
+fix: moved sr only modal close buttons to not show unnecessary scroll bar

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -60,14 +60,12 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
   );
 
   const content = (
-    <>
+    <Component {...getDialogProps(mergeProps(dialogProps, otherProps))}>
       <DismissButton onDismiss={onClose} />
-      <Component {...getDialogProps(mergeProps(dialogProps, otherProps))}>
-        {!hideCloseButton && closeButtonContent}
-        {typeof children === "function" ? children(onClose) : children}
-      </Component>
+      {!hideCloseButton && closeButtonContent}
+      {typeof children === "function" ? children(onClose) : children}
       <DismissButton onDismiss={onClose} />
-    </>
+    </Component>
   );
 
   const backdropContent = useMemo(() => {


### PR DESCRIPTION
This pr removes the 2px overflow from the modal in mobile view and consequently removes the scroll bar.

This was the result of visually hidden elements being 1x1px in size.