### PR TITLE
fix: storybook image stories ReferenceError: require is not defined

### DIFF
--- a/packages/components/image/stories/image.stories.tsx
+++ b/packages/components/image/stories/image.stories.tsx
@@ -47,7 +47,7 @@ export default {
 
 const defaultProps = {
   ...image.defaultVariants,
-  src: require("./assets/local-image-1.jpeg"),
+  src: "local-image-1.jpeg",
   alt: "NextUI hero image",
   disableSkeleton: true,
 };
@@ -82,7 +82,7 @@ export const Blurred = {
     ...defaultProps,
     width: 300,
     isBlurred: true,
-    src: require("./assets/local-image-small.jpg"),
+    src: "/local-image-small.jpg",
     // src:
     //   "https://images.unsplash.com/photo-1519638831568-d9897f54ed69?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80",
   },
@@ -105,7 +105,7 @@ export const Shadow = {
     isZoomed: true,
     radius: "lg",
     shadow: "md",
-    src: require("./assets/local-image-small.jpg"),
+    src: "/local-image-small.jpg",
   },
 };
 

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -4,7 +4,7 @@ module.exports = {
     "../../components/**/stories/**/*.stories.@(js|jsx|ts|tsx)",
     "../../core/theme/stories/*.stories.@(js|jsx|ts|tsx)",
   ],
-  staticDirs: ["../public"],
+  staticDirs: ["../public", "../../components/image/stories/assets"],
   addons: [
     "@storybook/addon-a11y",
     "@storybook/addon-essentials",


### PR DESCRIPTION
## 📝 Description

Issue : #1356

When we run storybook in dev static files are not loaded correctly using require("path/to/file")
I think the possible solution that I applied in this PR is to add the assets folder to .storybook/main.js :

`module.exports = {
...,
staticDirs: ["../public", "../../components/image/stories/assets"], 
...
}`


## ⛳️ Current behavior (updates)

[ReferenceError: require is not defined]

![storybook](https://github.com/nextui-org/nextui/assets/46867906/9e9431b8-2a34-4f64-a46a-d092b063df95)


## 🚀 New behavior

Images now load correctly

![fix-storybook](https://github.com/nextui-org/nextui/assets/46867906/cfa5dec5-7338-46f8-b5a7-0654fdf063b2)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I'm not sure this is the right solution to include every static folder from each component that need images to the staticDirs array
