### PR TITLE
fix: fix incorrect import in blurred card

### DIFF
--- a/apps/docs/content/components/card/blurred.ts
+++ b/apps/docs/content/components/card/blurred.ts
@@ -140,7 +140,7 @@ const ShuffleIcon = `export const ShuffleIcon = ({size = 24, width, height, ...p
   </svg>
 );`;
 
-const App = `import {Card, CardFooter, Image, Button, Progress} from "@nextui-org/react";
+const App = `import {Card, CardBody, Image, Button, Progress} from "@nextui-org/react";
 import {HeartIcon} from "./HeartIcon";
 import {PauseCircleIcon} from "./PauseCircleIcon";
 import {NextIcon} from "./NextIcon";


### PR DESCRIPTION


Closes #1362

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

>  

## 🚀 New behavior

> Imported CardBody instead of CardFooter. CodeSandbox now renders the preview instead of a blank screen

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
