### PR TITLE
docs: On individual instalation instructions at tailwind setup, require package should be @nextui/theme

### DIFF
--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -144,7 +144,7 @@ styles of the components your using to your `tailwind.config.js` file. For examp
 
 ```js {8,13-14}
 // tailwind.config.js
-const {nextui} = require("@nextui-org/react");
+const {nextui} = require("@nextui-org/theme");
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

> There is an error in the documentation for installing individual components on the tailwind configuration, i is specified to require @nextui-org/react but in the previous step it is indicated to install "@nextui-org/system" and "@nextui-org/theme"

## ⛳️ Current behavior (updates)

> Not modifying behavior

## 🚀 New behavior

> No new behavior

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information

> This PR is of type docs.