### PR TITLE
fix(input): add type number for InputProps

### DIFF
--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -62,7 +62,11 @@ export interface Props<T extends HTMLInputElement | HTMLTextAreaElement = HTMLIn
 }
 
 export type UseInputProps<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement> =
-  Props<T> & Omit<AriaTextFieldProps, "onChange"> & InputVariantProps;
+  Props<T> &
+    Omit<AriaTextFieldProps, "value" | "onChange"> &
+    InputVariantProps & {
+      value?: string | number | (readonly string[] & string);
+    };
 
 export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement>(
   originalProps: UseInputProps<T>,
@@ -94,8 +98,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   );
 
   const [inputValue, setInputValue] = useControlledState<string | undefined>(
-    props.value,
-    props.defaultValue,
+    typeof props.value === "number" ? String(props.value) : props.value,
+    typeof props.defaultValue === "number" ? String(props.defaultValue) : props.defaultValue,
     handleValueChange,
   );
 


### PR DESCRIPTION
Add type number in InputProps. Also cast number to string incase of number value

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1400 

## 📝 Description

> I could have updated or replaced `AriaTextFieldProps` in `UseInputProps` but since I don't know how it would effect other files I have opted to hardcode the type value. I have also casted the value to `string` incase of it being `number`.

## ⛳️ Current behavior (updates)

> Doing `<Input value={12} />` throw type error.

## 🚀 New behavior

> Doing `<Input value={12} />` does not throw type error.

## 💣 Is this a breaking change (Yes/No):

> No
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

> -
