### PR TITLE
fix(input): don't always use controlled mode

### DIFF
--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -125,7 +125,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         originalProps?.placeholder,
       ),
       inputElementType: isMultiline ? "textarea" : "input",
-      value: inputValue ?? "",
+      value: inputValue, // don't pass "" if value === undefined, it will switch the input to controlled mode
       onChange: setInputValue,
     },
     domRef,


### PR DESCRIPTION
closes: #1395 

## 📝 Description

Passing "" to react-aria forces the input to be in controlled mode, where there ref value is ignored

## ⛳️ Current behavior (updates)

Input does not use ref value

## 🚀 New behavior

Input can be initialized with `ref.current.value = 'xx'`, which is what react-hook-form does

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
