### PR TITLE
fix: import the cardFooter in the card component doc

### DIFF
--- a/apps/docs/content/components/card/composition.ts
+++ b/apps/docs/content/components/card/composition.ts
@@ -1,4 +1,4 @@
-const App = `import {Card, CardHeader, CardBody, Avatar, Button} from "@nextui-org/react";
+const App = `import {Card, CardHeader, CardBody, CardFooter, Avatar, Button} from "@nextui-org/react";
 
 export default function App() {
   const [isFollowed, setIsFollowed] = React.useState(false);


### PR DESCRIPTION
## 📝 Description

Added the missing import statement for CardFooter in the code as it was not present. This fix is necessary to prevent errors for users following the documentation.


## ⛳️ Current behavior (updates)

Currently, the import statement for CardFooter is missing in the code. This leads to issues for users who are following the provided documentation.

## 🚀 New behavior

The new behavior involves including the necessary import statement for CardFooter in the codebase. This change ensures that users who follow the documentation will no longer encounter errors.

## 💣 Is this a breaking change (Yes/No):

No