### PR TITLE
refactor(tooltip): style prop merged with the passed one

### DIFF
--- a/.changeset/little-comics-report.md
+++ b/.changeset/little-comics-report.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/tooltip": patch
+"@nextui-org/modal": patch
+---
+
+Tooltip style prop merged, this allows users change the z-index

--- a/packages/components/modal/src/use-modal.ts
+++ b/packages/components/modal/src/use-modal.ts
@@ -109,7 +109,7 @@ export function useModal(originalProps: UseModalProps) {
   const headerId = useId();
   const bodyId = useId();
 
-  // Sync ref with popoverRef from passed ref.
+  // Sync ref with modalRef from passed ref.
   useImperativeHandle(ref, () =>
     // @ts-ignore
     createDOMRef(dialogRef),

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -219,7 +219,8 @@ export function useTooltip(originalProps: UseTooltipProps) {
       "data-disabled": dataAttr(isDisabled),
       "data-placement": getArrowPlacement(placement, placementProp),
       className: slots.base({class: baseStyles}),
-      ...mergeProps(tooltipProps, positionProps, overlayProps, otherProps),
+      ...mergeProps(tooltipProps, overlayProps, otherProps),
+      style: mergeProps(positionProps.style, otherProps.style, props.style),
       id: tooltipId,
     }),
     [


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Style prop is now being merged with the position props for the `Tooltip` component, this allows changing the `z-index`  position.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
