### PR TITLE
fix: added value to aria label of select

### DIFF
--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -4,6 +4,7 @@ import {ScrollShadow} from "@nextui-org/scroll-shadow";
 import {ChevronDownIcon} from "@nextui-org/shared-icons";
 import {forwardRef} from "@nextui-org/system";
 import {FocusScope} from "@react-aria/focus";
+import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {cloneElement, ForwardedRef, ReactElement, Ref, useMemo} from "react";
 
 import {HiddenSelect} from "./hidden-select";
@@ -95,7 +96,10 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
             {!shouldLabelBeOutside ? labelContent : null}
             <div {...getInnerWrapperProps()}>
               {startContent}
-              <span {...getValueProps()}>{renderSelectedItem}</span>
+              <span {...getValueProps()}>
+                {renderSelectedItem}
+                <VisuallyHidden>,</VisuallyHidden>
+              </span>
               {endContent}
             </div>
             {clonedIcon}

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect.ts
@@ -129,10 +129,14 @@ export function useMultiSelect<T>(
       ...triggerProps,
       onKeyDown: chain(triggerProps.onKeyDown, triggerOnKeyDown, props.onKeyDown),
       onKeyUp: props.onKeyUp,
-      "aria-labelledby":
+      "aria-labelledby": [
+        valueId,
         domProps["aria-label"] !== undefined
-          ? domProps["aria-labelledby"]
+          ? domProps["aria-labelledby"] !== undefined
+            ? domProps["aria-labelledby"]
+            : triggerProps.id
           : triggerProps["aria-labelledby"],
+      ].join(" "),
       onFocus(e: FocusEvent) {
         if (state.isFocused) {
           return;


### PR DESCRIPTION
Before it just read out the label i.e. `Favorite Animal`, now it reads out `Dog, Favorite Animal`.

I added a visually hidden comma so most screen readers put a liddle pause between the value and label.