### PR TITLE
docs(tooltip): decrease zIndex so it doesn't overlap other elements

### DIFF
--- a/apps/docs/components/marketing/hero/floating-components.tsx
+++ b/apps/docs/components/marketing/hero/floating-components.tsx
@@ -111,6 +111,9 @@ export const FloatingComponents: React.FC<{}> = () => {
             content="Developers love Next.js"
             isOpen={!isTablet}
             placement="top"
+            style={{
+              zIndex: 39,
+            }}
           >
             <Button
               className="absolute left-[200px] top-[160px] max-w-fit animate-[levitate_14s_ease_infinite_0.5s]"

--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -124,9 +124,7 @@ export const Navbar: FC<NavbarProps> = ({children, routes, mobileRoutes = [], sl
   return (
     <NextUINavbar
       ref={ref}
-      className={clsx({
-        "z-[100001]": isMenuOpen,
-      })}
+      className="z-[100001]"
       isMenuOpen={isMenuOpen}
       maxWidth="xl"
       position="sticky"

--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -124,7 +124,9 @@ export const Navbar: FC<NavbarProps> = ({children, routes, mobileRoutes = [], sl
   return (
     <NextUINavbar
       ref={ref}
-      className="z-[100001]"
+      className={clsx({
+        "z-[100001]": isMenuOpen,
+      })}
       isMenuOpen={isMenuOpen}
       maxWidth="xl"
       position="sticky"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

The floating Tooltip was overlapping the navbar and other elements on the home page.

I decreased its `z-index` to 39 because the navbar is `.z-40`

## ⛳️ Current behavior (updates)

https://github.com/nextui-org/nextui/assets/54036572/69685a81-88ee-48e8-9e24-9c677e77ffe2

## 🚀 New behavior

https://github.com/nextui-org/nextui/assets/54036572/5fe3bf4a-3925-4838-b89e-316a62a7f883

## 💣 Is this a breaking change (Yes/No):

No
