### PR TITLE
docs(components): :memo: change to the new rsc link

### DIFF
--- a/apps/docs/components/docs/components/component-links.tsx
+++ b/apps/docs/components/docs/components/component-links.tsx
@@ -81,7 +81,7 @@ export const ComponentLinks = ({
       )}
       {rscCompatible && (
         <ButtonLink
-          href="https://nextjs.org/docs/getting-started/react-essentials#server-components"
+          href="https://nextjs.org/docs/app/building-your-application/rendering/server-components"
           startContent={<NextJsIcon size={18} />}
           tooltip={
             <p>


### PR DESCRIPTION
## 📝 Description

> The new docs for Next.js RSC has been moved to a new section.

## ⛳️ Current behavior (updates)

> The current link is redirecting incorrectly due to the recent change in the Next.js documentation.

## 🚀 New behavior

> This PR fixes this issue by correctly adding the right link.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
https://github.com/vercel/next.js/commit/1dc5c066cb11a0a5e4227c84182d874f92394717