### PR TITLE
fix(shared-utils): expose getProp

### DIFF
--- a/.changeset/chilly-taxis-matter.md
+++ b/.changeset/chilly-taxis-matter.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": patch
+---
+
+Expose getProp for use with Tables, similar to getKeyValue. getProp allows for keying into nested objects.

--- a/packages/components/table/src/index.ts
+++ b/packages/components/table/src/index.ts
@@ -12,7 +12,7 @@ export type {
 export {useTable} from "./use-table";
 
 // export utils
-export {getKeyValue} from "@nextui-org/shared-utils";
+export {getKeyValue, getProp} from "@nextui-org/shared-utils";
 
 // export component
 export {default as Table} from "./table";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Exposes the `getProp` helper function, which unlike `getKeyValue`, allows for retrieving properties from nested objects. This is helpful when working with dynamic `Table` instances.

## ⛳️ Current behavior (updates)

`getProp` is not exported for consumers to use.

## 🚀 New behavior

`getProp` can be properly imported for consumers to use.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
