### PR TITLE
fix(navbar): unable to Close NavbarMenu

### DIFF
--- a/.changeset/small-badgers-look.md
+++ b/.changeset/small-badgers-look.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/navbar": patch
+---
+
+fix unable to close NavbarMenu

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -58,7 +58,7 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
       </ul>
     </MenuWrapper>
   ) : (
-    <AnimatePresence>
+    <AnimatePresence mode="wait">
       {isMenuOpen ? (
         <MenuWrapper>
           <motion.ul


### PR DESCRIPTION
Closes #1440 

## 📝 Description

fix unable to Close NavbarMenu

## ⛳️ Current behavior (updates)

When you close and open (clicking) fastly multiple times the NavbarMenu, the Menu crashes and you are unable to close it. And you need to reload the browser to use your website!

## 🚀 New behavior

You can close it normally.

## 💣 Is this a breaking change (No):


## 📝 Additional Information
