### PR TITLE
fix(popover): arrow color

### DIFF
--- a/.changeset/nine-seas-smoke.md
+++ b/.changeset/nine-seas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Fix Popover/Tooltip arrow color

--- a/packages/core/theme/src/components/popover.ts
+++ b/packages/core/theme/src/components/popover.ts
@@ -41,7 +41,6 @@ const popover = tv({
       "z-[-1]",
       "absolute",
       "rotate-45",
-      "bg-inherit",
       "w-2.5",
       "h-2.5",
       "rounded-sm",
@@ -84,25 +83,31 @@ const popover = tv({
     color: {
       default: {
         base: "bg-content1",
-        arrow: "shadow-small",
+        arrow: "shadow-small bg-content1",
       },
       foreground: {
         base: colorVariants.solid.foreground,
+        arrow: "bg-foreground",
       },
       primary: {
         base: colorVariants.solid.primary,
+        arrow: "bg-primary",
       },
       secondary: {
         base: colorVariants.solid.secondary,
+        arrow: "bg-secondary",
       },
       success: {
         base: colorVariants.solid.success,
+        arrow: "bg-success",
       },
       warning: {
         base: colorVariants.solid.warning,
+        arrow: "bg-warning",
       },
       danger: {
         base: colorVariants.solid.danger,
+        arrow: "bg-danger",
       },
     },
     radius: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fix he popover and tooltip arrow color

## ⛳️ Current behavior (updates)

Popover and Tooltip don't have the correct color applied to the arrow

## 🚀 New behavior

The arrow color fixed it follows the same color passed by the user


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

#### Popover
![CleanShot 2023-08-26 at 10 52 55@2x](https://github.com/nextui-org/nextui/assets/30373425/f6b705c2-8a56-47e1-9e65-65e18bba812f)

#### Tooltip
![CleanShot 2023-08-26 at 10 52 38@2x](https://github.com/nextui-org/nextui/assets/30373425/c4cebcc9-b9d4-4e07-87f3-ca57544d2999)
