### PR TITLE
fix: #1531 title prop of a tab should be a string

### DIFF
--- a/.changeset/friendly-teachers-work.md
+++ b/.changeset/friendly-teachers-work.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": major
+---
+
+Title prop of a tab should be a string

--- a/packages/components/tabs/src/base/tab-item-base.ts
+++ b/packages/components/tabs/src/base/tab-item-base.ts
@@ -8,7 +8,7 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"div", T>, "childr
   /**
    * The title of the component.
    */
-  title?: ReactNode | null;
+  title?: string;
 }
 
 export type TabItemProps<T extends object = {}> = Props<T>;

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -85,6 +85,10 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
     });
   };
 
+  if (otherProps && otherProps.title && typeof otherProps.title !== "string") {
+    otherProps.title = "";
+  }
+
   return (
     <Component
       ref={domRef}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1531 

## 📝When the title prop of Tab is not a string, it should not be passed to HTML elements


> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

