### PR TITLE
Fix/1531

### DIFF
--- a/.changeset/big-moose-switch.md
+++ b/.changeset/big-moose-switch.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": patch
+---
+
+Fix #1531 title props filtered, titleValue prop added to pass the title to the HTML element.

--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -13,7 +13,7 @@ Tabs organize content into multiple sections and allow users to navigate between
 
 ---
 
-<CarbonAd/>
+<CarbonAd />
 
 ## Import
 
@@ -157,10 +157,11 @@ You can customize the `Tabs` component by passing custom Tailwind CSS classes to
 
 ### Tab Props
 
-| Attribute  | Type        | Description             | Default |
-| ---------- | ----------- | ----------------------- | ------- |
-| children\* | `ReactNode` | The content of the tab. | -       |
-| title      | `ReactNode` | The title of the tab.   | -       |
+| Attribute  | Type        | Description                                                                                | Default |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------ | ------- |
+| children\* | `ReactNode` | The content of the tab.                                                                    | -       |
+| title      | `ReactNode` | The title of the tab.                                                                      | -       |
+| titleValue | `string`    | A string representation of the item's contents. Use this when the `title` is not readable. | -       |
 
 #### Motion Props
 

--- a/packages/components/tabs/src/base/tab-item-base.ts
+++ b/packages/components/tabs/src/base/tab-item-base.ts
@@ -1,6 +1,6 @@
 import {BaseItem, ItemProps} from "@nextui-org/aria-utils";
 import {ReactNode} from "react";
-interface Props<T extends object = {}> extends Omit<ItemProps<"div", T>, "children" | "title"> {
+interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "children" | "title"> {
   /**
    * The content of the component.
    */
@@ -9,6 +9,11 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"div", T>, "childr
    * The title of the component.
    */
   title?: ReactNode | null;
+  /**
+   *  A string representation of the item's contents. Use this when the title is not readable.
+   *  This will be used as native `title` attribute.
+   * */
+  titleValue?: string;
 }
 
 export type TabItemProps<T extends object = {}> = Props<T>;

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -1,4 +1,6 @@
-import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
+import type {TabItemProps as BaseTabItemProps} from "./base/tab-item-base";
+
+import {forwardRef} from "@nextui-org/system";
 import {useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {clsx, dataAttr} from "@nextui-org/shared-utils";
 import {chain, mergeProps} from "@react-aria/utils";
@@ -12,7 +14,7 @@ import {useIsMounted} from "@nextui-org/use-is-mounted";
 
 import {ValuesType} from "./use-tabs";
 
-export interface TabItemProps<T = object> extends HTMLNextUIProps<"button"> {
+export interface TabItemProps<T extends object = object> extends BaseTabItemProps<T> {
   item: Node<T>;
   state: ValuesType["state"];
   slots: ValuesType["slots"];
@@ -106,9 +108,11 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
           : {},
         filterDOMProps(otherProps, {
           enabled: shouldFilterDOMProps,
+          omitPropNames: new Set(["title"]),
         }),
       )}
       className={slots.tab?.({class: tabStyles})}
+      title={otherProps?.titleValue}
       type={Component === "button" ? "button" : undefined}
       onClick={handleClick}
     >

--- a/packages/components/tabs/stories/tabs.stories.tsx
+++ b/packages/components/tabs/stories/tabs.stories.tsx
@@ -89,12 +89,16 @@ const WithIconsTemplate = (args: TabsProps) => (
       tab: "text-lg",
     }}
   >
-    <Tab key="align-left" title={<AlignLeftBoldIcon />} />
-    <Tab key="align-vertically" title={<AlignVerticallyBoldIcon />} />
-    <Tab key="align-right" title={<AlignRightBoldIcon />} />
-    <Tab key="align-top" title={<AlignTopBoldIcon />} />
-    <Tab key="align-horizontally" title={<AlignHorizontallyBoldIcon />} />
-    <Tab key="align-bottom" title={<AlignBottomBoldIcon />} />
+    <Tab key="align-left" title={<AlignLeftBoldIcon />} titleValue="Align left" />
+    <Tab key="align-vertically" title={<AlignVerticallyBoldIcon />} titleValue="Align vertically" />
+    <Tab key="align-right" title={<AlignRightBoldIcon />} titleValue="Align right" />
+    <Tab key="align-top" title={<AlignTopBoldIcon />} titleValue="Align top" />
+    <Tab
+      key="align-horizontally"
+      title={<AlignHorizontallyBoldIcon />}
+      titleValue="Align horizontally"
+    />
+    <Tab key="align-bottom" title={<AlignBottomBoldIcon />} titleValue="Align bottom" />
   </Tabs>
 );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1531 

## 📝 Description

Tab passes the `title` to the HTML element which lead to render [Object object] values

## ⛳️ Current behavior (updates)

Tab passes the `title` to the HTML element

## 🚀 New behavior

New prop added to Tab items `titleValue` which allows users pass the native`title` prop to the HTML element, original title was removed from the list of valid properties.

## 💣 Is this a breaking change (Yes/No): NO

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
