### PR TITLE
fix: added input error message and description screen reader support

### DIFF
--- a/.changeset/light-ads-smoke.md
+++ b/.changeset/light-ads-smoke.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+fix: added input error message and description screen reader support

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -122,6 +122,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const {labelProps, inputProps, descriptionProps, errorMessageProps} = useTextField(
     {
       ...originalProps,
+      description,
+      errorMessage,
       "aria-label": safeAriaLabel(
         originalProps?.["aria-label"],
         originalProps?.label,


### PR DESCRIPTION
## 📝 Description

`useTextField` uses `useField` which adds `aria-describedby` only when the `errorMessage` or `description is provided.

## ⛳️ Current behavior (updates)

`aria-describedby` does not include the error message or description and thus does not get read out by screen readers.

## 🚀 New behavior

It gets read out by screen readers.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

https://github.com/adobe/react-spectrum/blob/main/packages/%40react-types/shared/src/inputs.d.ts#L77