### PR TITLE
fix: resolved overlap issue with arrow in select

### DIFF
--- a/.changeset/sour-dolphins-accept.md
+++ b/.changeset/sour-dolphins-accept.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fix: resolved overlap issue with arrow in select

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -9,7 +9,7 @@ const select = tv({
     label: "block text-small font-medium text-foreground-500 pointer-events-none",
     mainWrapper: "w-full flex flex-col",
     trigger:
-      "relative px-3 gap-3 w-full inline-flex flex-row items-center shadow-sm outline-none tap-highlight-transparent",
+      "relative px-3 gap-3 w-full inline-flex flex-row items-center shadow-sm outline-none tap-highlight-transparent pr-10",
     innerWrapper:
       "inline-flex h-full w-[calc(100%_-_theme(spacing.unit-6))] items-center gap-1.5 box-border",
     selectorIcon: "absolute right-3 w-unit-4 h-unit-4",

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -11,7 +11,7 @@ const select = tv({
     trigger:
       "relative px-3 gap-3 w-full inline-flex flex-row items-center shadow-sm outline-none tap-highlight-transparent pr-10",
     innerWrapper:
-      "inline-flex h-full w-[calc(100%_-_theme(spacing.unit-6))] items-center gap-1.5 box-border",
+      "inline-flex h-full items-center gap-1.5 box-border",
     selectorIcon: "absolute right-3 w-unit-4 h-unit-4",
     spinner: "absolute right-3",
     value: "font-normal w-full text-left opacity-60 group-data-[filled=true]:opacity-100",


### PR DESCRIPTION
Before the content could grow until it was under the arrow.

Now:

![image](https://github.com/nextui-org/nextui/assets/25524993/4e23721e-6582-48b5-9bbf-e3f683ab74b2)