### PR TITLE
fix(links): corrected typo in accordion link

### DIFF
--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -194,7 +194,7 @@ Here's an example of how to customize the accordion styles:
 | fullWidth                 | `boolean`                                       | Whether the accordion should take up the full width of its parent container.                            | `true`   |
 | motionProps               | `MotionProps`                                   | The motion properties of the Accordion.                                                                 |          |
 | disabledKeys              | `React.Key[]`                                   | The item keys that are disabled. These items cannot be selected, focused, or otherwise interacted with. |          |
-| itemClasses               | [Classnames](#accordiom-item-classnames)        | The accordion items classNames.                                                                         |          |
+| itemClasses               | [Classnames](#accordion-item-classnames)        | The accordion items classNames.                                                                         |          |
 | selectedKeys              | `all` \| `React.Key[]`                          | The currently selected keys in the collection (controlled).                                             |          |
 | defaultSelectedKeys       | `all` \| `React.Key[]`                          | The initial selected keys in the collection (uncontrolled).                                             |          |
 | disabledKeys              | `React.Key[]`                                   | The currently disabled keys in the collection (controlled).                                             |          |
@@ -221,7 +221,7 @@ Here's an example of how to customize the accordion styles:
 | hideIndicator             | `boolean`                                         | Whether the AccordionItem indicator is hidden.                                                        | `false` |
 | disableAnimation          | `boolean`                                         | Whether the AccordionItem animation is disabled.                                                      | `false` |
 | disableIndicatorAnimation | `boolean`                                         | Whether the AccordionItem indicator animation is disabled.                                            | `false` |
-| classNames                | [Classnames](#accordiom-item-classnames)          | Allows to set custom class names for the accordion item slots.                                        | -       |
+| classNames                | [Classnames](#accordion-item-classnames)          | Allows to set custom class names for the accordion item slots.                                        | -       |
 
 ### Accordion Item Events
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR corrects a typo error in one of the links on the website. The link previously read "accordiom-item-classnames" and has been updated to "accordion-item-classnames" to ensure users can access the intended content without disruptions.

## ⛳️ Current behavior (updates)

The current link on the website, "accordiom-item-classnames", leads to a non-existent or unintended page due to the typo.

## 🚀 New behavior

With this PR, the link "accordion-item-classnames" will correctly direct users to the intended page.

## 💣 Is this a breaking change (Yes/No):

No.

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

Ensuring accurate links enhances the user experience and ensures seamless navigation throughout the website.
