### PR TITLE
fix: avoid `src` in import path

### DIFF
--- a/packages/components/ripple/src/index.ts
+++ b/packages/components/ripple/src/index.ts
@@ -2,6 +2,7 @@ import Ripple from "./ripple";
 
 // export types
 export type {RippleProps} from "./ripple";
+export type {RippleType} from "./use-ripple";
 
 // export hooks
 export {useRipple} from "./use-ripple";

--- a/packages/components/select/src/hidden-select.tsx
+++ b/packages/components/select/src/hidden-select.tsx
@@ -7,10 +7,7 @@ import React, {ReactNode, RefObject} from "react";
 import {useFormReset} from "@react-aria/utils";
 import {useInteractionModality} from "@react-aria/interactions";
 import {useVisuallyHidden} from "@react-aria/visually-hidden";
-import {
-  MultiSelectProps,
-  MultiSelectState,
-} from "@nextui-org/use-aria-multiselect/src/use-multiselect-state";
+import {MultiSelectProps, MultiSelectState} from "@nextui-org/use-aria-multiselect";
 
 export interface AriaHiddenSelectProps {
   /**

--- a/packages/hooks/use-aria-multiselect/src/index.ts
+++ b/packages/hooks/use-aria-multiselect/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./use-multiselect";
 export * from "./use-multiselect-list-state";
 export {useMultiSelectState} from "./use-multiselect-state";
+export type {MultiSelectState} from "./use-multiselect-state";


### PR DESCRIPTION
Related to #1595 

## 📝 Description

To prevent `src` in import path in '*.d.ts', the types should be exported in `index.ts`.

Specifically, the following error is fixed:

```
node_modules/@nextui-org/button/dist/use-button.d.ts:1:52 - error TS2307: Cannot find module '@nextui-org/ripple/src/use-ripple' or its corresponding type declarations.

1 import * as _nextui_org_ripple_src_use_ripple from '@nextui-org/ripple/src/use-ripple';
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@nextui-org/card/dist/use-card.d.ts:1:52 - error TS2307: Cannot find module '@nextui-org/ripple/src/use-ripple' or its corresponding type declarations.

1 import * as _nextui_org_ripple_src_use_ripple from '@nextui-org/ripple/src/use-ripple';
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@nextui-org/select/dist/hidden-select.d.ts:4:52 - error TS2307: Cannot find module '@nextui-org/use-aria-multiselect/src/use-multiselect-state' or its corresponding type declarations.

4 import { MultiSelectState, MultiSelectProps } from '@nextui-org/use-aria-multiselect/src/use-multiselect-state';
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/@nextui-org/select/dist/use-select.d.ts:2:77 - error TS2307: Cannot find module '@nextui-org/use-aria-multiselect/src/use-multiselect-state' or its corresponding type declarations.

2 import * as _nextui_org_use_aria_multiselect_src_use_multiselect_state from '@nextui-org/use-aria-multiselect/src/use-multiselect-state';
```

## ⛳️ Current behavior (updates)

Running `tsc` gives the above errors.

## 🚀 New behavior

Errors are fixed. No impact on runtime.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
