### PR TITLE
Fix/1632

### DIFF
--- a/.changeset/fresh-paws-exist.md
+++ b/.changeset/fresh-paws-exist.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/dropdown": patch
+"@nextui-org/modal": patch
+---
+
+Fix #1632 modal closes immediately if it is opened from the Dropdown component.

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import {act, render} from "@testing-library/react";
 import {Button} from "@nextui-org/button";
+import {Modal, ModalContent} from "@nextui-org/modal";
+import {useDisclosure} from "@nextui-org/use-disclosure";
 import userEvent from "@testing-library/user-event";
 
 import {Dropdown, DropdownTrigger, DropdownMenu, DropdownItem, DropdownSection} from "../src";
@@ -385,5 +387,71 @@ describe("Dropdown", () => {
     });
 
     expect(onSelectionChange).toBeCalledTimes(0);
+  });
+
+  it("should not close the modal content", async () => {
+    const ModalItem = () => {
+      const {isOpen, onOpen, onClose} = useDisclosure();
+
+      return (
+        <>
+          <button
+            data-testid="trigger-test-modal"
+            onClick={() => {
+              onOpen();
+            }}
+          >
+            Open Modal
+          </button>
+          <Modal backdrop={"opaque"} isOpen={isOpen} onClose={onClose}>
+            <ModalContent>
+              <div data-testid="modal-content">Modal Content</div>
+            </ModalContent>
+          </Modal>
+        </>
+      );
+    };
+
+    const wrapper = render(
+      <Dropdown placement="bottom-end">
+        <DropdownTrigger className="mt-10 ml-10">
+          <button data-testid="trigger-test">trigger</button>
+        </DropdownTrigger>
+        <DropdownMenu variant="flat">
+          <DropdownItem>
+            <ModalItem />
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    expect(triggerButton).toBeTruthy();
+
+    act(() => {
+      triggerButton.click();
+    });
+
+    let menu = wrapper.getByRole("menu");
+
+    expect(menu).toBeTruthy();
+
+    let triggerModalButton = wrapper.getByTestId("trigger-test-modal");
+
+    expect(triggerModalButton).toBeTruthy();
+
+    act(() => {
+      triggerModalButton.click();
+    });
+
+    let modal = document.querySelector("[data-modal-open=true]");
+
+    expect(modal).toBeTruthy();
+
+    let modalContent = wrapper.getByTestId("modal-content");
+
+    expect(modalContent).toBeTruthy();
+    expect(modalContent.textContent).toBe("Modal Content");
   });
 });

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -53,7 +53,9 @@
   "devDependencies": {
     "@nextui-org/button": "workspace:*",
     "@nextui-org/avatar": "workspace:*",
+    "@nextui-org/modal": "workspace:*",
     "@nextui-org/user": "workspace:*",
+    "@nextui-org/use-disclosure": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
     "framer-motion": "^10.15.1",
     "clean-package": "2.2.0",

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -8,7 +8,7 @@ import {useMenuTrigger} from "@react-aria/menu";
 import {dropdown} from "@nextui-org/theme";
 import {clsx} from "@nextui-org/shared-utils";
 import {ReactRef, mergeRefs} from "@nextui-org/react-utils";
-import {useMemo, useRef} from "react";
+import {useEffect, useMemo, useRef} from "react";
 import {mergeProps} from "@react-aria/utils";
 import {MenuProps} from "@nextui-org/menu";
 
@@ -66,6 +66,7 @@ export function useDropdown(props: UseDropdownProps) {
   const menuTriggerRef = triggerRefProp || triggerRef;
   const menuRef = useRef<HTMLUListElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const menuActionTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   const state = useMenuTriggerState({
     trigger,
@@ -93,13 +94,25 @@ export function useDropdown(props: UseDropdownProps) {
     [className],
   );
 
+  useEffect(() => {
+    return () => {
+      if (menuActionTimeoutRef.current) clearTimeout(menuActionTimeoutRef.current);
+    };
+  }, []);
+
   const onMenuAction = (menuCloseOnSelect?: boolean) => {
-    if (menuCloseOnSelect !== undefined && !menuCloseOnSelect) {
-      return;
-    }
-    if (closeOnSelect) {
-      state.close();
-    }
+    menuActionTimeoutRef.current = setTimeout(() => {
+      if (
+        (menuCloseOnSelect !== undefined && !menuCloseOnSelect) ||
+        document.querySelector("[data-modal-open=true]")
+      ) {
+        return;
+      }
+
+      if (closeOnSelect) {
+        state.close();
+      }
+    }, 0);
   };
 
   const getPopoverProps: PropGetter = (props = {}) => ({

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -89,7 +89,7 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
   }, [backdrop, disableAnimation, getBackdropProps]);
 
   return (
-    <div tabIndex={-1}>
+    <div data-modal-open={isOpen} tabIndex={-1}>
       {backdropContent}
       <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
         {disableAnimation ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,9 +1028,15 @@ importers:
       '@nextui-org/button':
         specifier: workspace:*
         version: link:../button
+      '@nextui-org/modal':
+        specifier: workspace:*
+        version: link:../modal
       '@nextui-org/shared-icons':
         specifier: workspace:*
         version: link:../../utilities/shared-icons
+      '@nextui-org/use-disclosure':
+        specifier: workspace:*
+        version: link:../../hooks/use-disclosure
       '@nextui-org/user':
         specifier: workspace:*
         version: link:../user


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1632 

## 📝 Description

The modal closes immediately if it is opened from the Dropdown component.

## ⛳️ Current behavior (updates)

The modal automatically closes when triggered by ```onMenuAction``` in ```use-dropdown.ts```.

## 🚀 New behavior

The modal will not close when menuAction is performed.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Please kindly let me know if any suggestions.
