### PR TITLE
refactor: optimize the time of ripple destroy

### DIFF
--- a/.changeset/fresh-cameras-provide.md
+++ b/.changeset/fresh-cameras-provide.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/button": patch
+"@nextui-org/card": patch
+"@nextui-org/ripple": patch
+---
+
+refactor: optimize the time of ripple destroy

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -20,6 +20,7 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     endContent,
     isLoading,
     disableRipple,
+    onClear,
     getButtonProps,
   } = useButton({
     ...props,
@@ -33,7 +34,7 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
       {children}
       {isLoading && spinnerPlacement === "end" && spinner}
       {endContent}
-      {!disableRipple && <Ripple ripples={ripples} />}
+      {!disableRipple && <Ripple ripples={ripples} onClear={onClear} />}
     </Component>
   );
 });

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -32,7 +32,7 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
       {children}
       {isLoading && spinnerPlacement === "end" && spinner}
       {endContent}
-      {!disableRipple && <Ripple ripples={ripples} onClear={onClear} />}
+      {!disableRipple && <Ripple {...getRippelProps()} />}
     </Component>
   );
 });

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -23,8 +23,6 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     getRippelProps,
   } = useButton({...props, ref});
 
-  const {ripples, onClear} = getRippelProps();
-
   return (
     <Component ref={domRef} className={styles} {...getButtonProps()}>
       {startContent}

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -30,7 +30,7 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
       {children}
       {isLoading && spinnerPlacement === "end" && spinner}
       {endContent}
-      {!disableRipple && <Ripple {...getRippelProps()} />}
+      {!disableRipple && <Ripple {...getRippleProps()} />}
     </Component>
   );
 });

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -12,7 +12,6 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     domRef,
     children,
     styles,
-    ripples,
     spinnerSize,
     spinner = <Spinner color="current" size={spinnerSize} />,
     spinnerPlacement,
@@ -20,12 +19,11 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     endContent,
     isLoading,
     disableRipple,
-    onClear,
     getButtonProps,
-  } = useButton({
-    ...props,
-    ref,
-  });
+    getRippelProps,
+  } = useButton({...props, ref});
+
+  const {ripples, onClear} = getRippelProps();
 
   return (
     <Component ref={domRef} className={styles} {...getButtonProps()}>

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -20,7 +20,7 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     isLoading,
     disableRipple,
     getButtonProps,
-    getRippelProps,
+    getRippleProps,
   } = useButton({...props, ref});
 
   return (

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -130,7 +130,7 @@ export function useButton(props: UseButtonProps) {
     ],
   );
 
-  const {onClick: onRippleClickHandler, ripples} = useRipple();
+  const {onClick: onRippleClickHandler, onClear, ripples} = useRipple();
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -223,6 +223,7 @@ export function useButton(props: UseButtonProps) {
     spinnerSize,
     disableRipple,
     getButtonProps,
+    onClear,
   };
 }
 

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -2,6 +2,7 @@ import type {ButtonVariantProps} from "@nextui-org/theme";
 import type {AriaButtonProps} from "@nextui-org/use-aria-button";
 import type {HTMLNextUIProps, PropGetter} from "@nextui-org/system";
 import type {ReactNode} from "react";
+import type {RippleProps} from "@nextui-org/ripple";
 
 import {dataAttr} from "@nextui-org/shared-utils";
 import {ReactRef} from "@nextui-org/react-utils";
@@ -209,6 +210,11 @@ export function useButton(props: UseButtonProps) {
     return buttonSpinnerSizeMap[size];
   }, [size]);
 
+  const getRippleProps = useCallback<() => RippleProps>(
+    () => ({ripples, onClear: onClearRipple}),
+    [ripples, onClearRipple],
+  );
+
   return {
     Component,
     children,
@@ -222,7 +228,7 @@ export function useButton(props: UseButtonProps) {
     spinnerSize,
     disableRipple,
     getButtonProps,
-    getRippleProps: () => ({ripples, onClear: onClearRipple}),
+    getRippleProps,
   };
 }
 

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -213,7 +213,6 @@ export function useButton(props: UseButtonProps) {
     Component,
     children,
     domRef,
-    ripples,
     spinner,
     styles,
     startContent,
@@ -223,7 +222,7 @@ export function useButton(props: UseButtonProps) {
     spinnerSize,
     disableRipple,
     getButtonProps,
-    onClear,
+    getRippelProps: () => ({ripples, onClear}),
   };
 }
 

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -222,7 +222,7 @@ export function useButton(props: UseButtonProps) {
     spinnerSize,
     disableRipple,
     getButtonProps,
-    getRippelProps: () => ({ripples, onClear: onClearRipple}),
+    getRippleProps: () => ({ripples, onClear: onClearRipple}),
   };
 }
 

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -130,7 +130,7 @@ export function useButton(props: UseButtonProps) {
     ],
   );
 
-  const {onClick: onRippleClickHandler, onClear, ripples} = useRipple();
+  const {onClick: onRippleClickHandler, onClear: onClearRipple, ripples} = useRipple();
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -222,7 +222,7 @@ export function useButton(props: UseButtonProps) {
     spinnerSize,
     disableRipple,
     getButtonProps,
-    getRippelProps: () => ({ripples, onClear}),
+    getRippelProps: () => ({ripples, onClear: onClearRipple}),
   };
 }
 

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -21,9 +21,7 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
   return (
     <Component {...getCardProps()}>
       <CardProvider value={context}>{children}</CardProvider>
-      {isPressable && !disableAnimation && !disableRipple && (
-        <Ripple {...getRippelProps()} />
-      )}
+      {isPressable && !disableAnimation && !disableRipple && <Ripple {...getRippelProps()} />}
     </Component>
   );
 });

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -18,8 +18,6 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
     getRippelProps,
   } = useCard({...props, ref});
 
-  const {ripples, onClear} = getRippelProps();
-
   return (
     <Component {...getCardProps()}>
       <CardProvider value={context}>{children}</CardProvider>

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -16,6 +16,7 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
     disableAnimation,
     disableRipple,
     getCardProps,
+    onClear,
   } = useCard({
     ...props,
     ref,
@@ -24,7 +25,9 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
   return (
     <Component {...getCardProps()}>
       <CardProvider value={context}>{children}</CardProvider>
-      {isPressable && !disableAnimation && !disableRipple && <Ripple ripples={ripples} />}
+      {isPressable && !disableAnimation && !disableRipple && (
+        <Ripple ripples={ripples} onClear={onClear} />
+      )}
     </Component>
   );
 });

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -24,7 +24,7 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
     <Component {...getCardProps()}>
       <CardProvider value={context}>{children}</CardProvider>
       {isPressable && !disableAnimation && !disableRipple && (
-        <Ripple ripples={ripples} onClear={onClear} />
+        <Ripple {...getRippelProps()} />
       )}
     </Component>
   );

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -11,16 +11,14 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
     children,
     context,
     Component,
-    ripples,
     isPressable,
     disableAnimation,
     disableRipple,
     getCardProps,
-    onClear,
-  } = useCard({
-    ...props,
-    ref,
-  });
+    getRippelProps,
+  } = useCard({...props, ref});
+
+  const {ripples, onClear} = getRippelProps();
 
   return (
     <Component {...getCardProps()}>

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -15,7 +15,7 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
     disableAnimation,
     disableRipple,
     getCardProps,
-    getRippelProps,
+    getRippleProps,
   } = useCard({...props, ref});
 
   return (

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -21,7 +21,7 @@ const Card = forwardRef<"div", CardProps>((props, ref) => {
   return (
     <Component {...getCardProps()}>
       <CardProvider value={context}>{children}</CardProvider>
-      {isPressable && !disableAnimation && !disableRipple && <Ripple {...getRippelProps()} />}
+      {isPressable && !disableAnimation && !disableRipple && <Ripple {...getRippleProps()} />}
     </Component>
   );
 });

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -192,8 +192,8 @@ export function useCard(originalProps: UseCardProps) {
     isHoverable: originalProps.isHoverable,
     disableAnimation: originalProps.disableAnimation,
     disableRipple,
-    isFocusVisible,
     handleClick,
+    isFocusVisible,
     getCardProps,
     getRippelProps: () => ({ripples, onClear: onClearRipple}),
   };

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -85,7 +85,7 @@ export function useCard(originalProps: UseCardProps) {
 
   const baseStyles = clsx(classNames?.base, className);
 
-  const {onClick: onRippleClickHandler, onClear, ripples} = useRipple();
+  const {onClick: onRippleClickHandler, onClear: onClearRipple, ripples} = useRipple();
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (!originalProps.disableAnimation && !disableRipple && domRef.current) {

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -1,6 +1,7 @@
 import type {FocusableProps, PressEvents} from "@react-types/shared";
 import type {SlotsToClasses, CardSlots, CardReturnType, CardVariantProps} from "@nextui-org/theme";
 import type {AriaButtonProps} from "@nextui-org/use-aria-button";
+import type {RippleProps} from "@nextui-org/ripple";
 
 import {card} from "@nextui-org/theme";
 import {MouseEvent, ReactNode, useCallback, useMemo} from "react";
@@ -180,6 +181,11 @@ export function useCard(originalProps: UseCardProps) {
     ],
   );
 
+  const getRippleProps = useCallback<() => RippleProps>(
+    () => ({ripples, onClear: onClearRipple}),
+    [ripples, onClearRipple],
+  );
+
   return {
     context,
     domRef,
@@ -195,7 +201,7 @@ export function useCard(originalProps: UseCardProps) {
     handleClick,
     isFocusVisible,
     getCardProps,
-    getRippelProps: () => ({ripples, onClear: onClearRipple}),
+    getRippleProps,
   };
 }
 

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -186,17 +186,16 @@ export function useCard(originalProps: UseCardProps) {
     Component,
     classNames,
     children,
-    ripples,
     isHovered,
     isPressed,
     isPressable: originalProps.isPressable,
     isHoverable: originalProps.isHoverable,
     disableAnimation: originalProps.disableAnimation,
     disableRipple,
-    handleClick,
-    onClear,
     isFocusVisible,
+    handleClick,
     getCardProps,
+    getRippelProps: () => ({ripples, onClear}),
   };
 }
 

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -195,7 +195,7 @@ export function useCard(originalProps: UseCardProps) {
     isFocusVisible,
     handleClick,
     getCardProps,
-    getRippelProps: () => ({ripples, onClear}),
+    getRippelProps: () => ({ripples, onClear: onClearRipple}),
   };
 }
 

--- a/packages/components/card/src/use-card.ts
+++ b/packages/components/card/src/use-card.ts
@@ -85,7 +85,7 @@ export function useCard(originalProps: UseCardProps) {
 
   const baseStyles = clsx(classNames?.base, className);
 
-  const {onClick: onRippleClickHandler, ripples} = useRipple();
+  const {onClick: onRippleClickHandler, onClear, ripples} = useRipple();
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (!originalProps.disableAnimation && !disableRipple && domRef.current) {
@@ -194,6 +194,7 @@ export function useCard(originalProps: UseCardProps) {
     disableAnimation: originalProps.disableAnimation,
     disableRipple,
     handleClick,
+    onClear,
     isFocusVisible,
     getCardProps,
   };

--- a/packages/components/ripple/src/ripple.tsx
+++ b/packages/components/ripple/src/ripple.tsx
@@ -9,13 +9,15 @@ export interface RippleProps extends HTMLNextUIProps<"span"> {
   color?: string;
   motionProps?: HTMLMotionProps<"span">;
   style?: React.CSSProperties;
+  onClear: (key: number) => void;
 }
 
 const clamp = (value: number, min: number, max: number) => {
   return Math.min(Math.max(value, min), max);
 };
 
-const Ripple: FC<RippleProps> = ({ripples = [], motionProps, color = "currentColor", style}) => {
+const Ripple: FC<RippleProps> = (props) => {
+  const {ripples = [], motionProps, color = "currentColor", style, onClear} = props;
   return (
     <>
       {ripples.map((ripple) => {
@@ -28,6 +30,8 @@ const Ripple: FC<RippleProps> = ({ripples = [], motionProps, color = "currentCol
               className="nextui-ripple"
               exit={{opacity: 0}}
               initial={{transform: "scale(0)", opacity: 0.35}}
+              onTransitionEnd={() => onClear(ripple.key)}
+              onAnimationEnd={() => onClear(ripple.key)}
               style={{
                 position: "absolute",
                 backgroundColor: color,

--- a/packages/components/ripple/src/ripple.tsx
+++ b/packages/components/ripple/src/ripple.tsx
@@ -9,7 +9,7 @@ export interface RippleProps extends HTMLNextUIProps<"span"> {
   color?: string;
   motionProps?: HTMLMotionProps<"span">;
   style?: React.CSSProperties;
-  onClear: (key: number) => void;
+  onClear: (key: React.Key) => void;
 }
 
 const clamp = (value: number, min: number, max: number) => {

--- a/packages/components/ripple/src/ripple.tsx
+++ b/packages/components/ripple/src/ripple.tsx
@@ -18,6 +18,7 @@ const clamp = (value: number, min: number, max: number) => {
 
 const Ripple: FC<RippleProps> = (props) => {
   const {ripples = [], motionProps, color = "currentColor", style, onClear} = props;
+
   return (
     <>
       {ripples.map((ripple) => {
@@ -30,8 +31,6 @@ const Ripple: FC<RippleProps> = (props) => {
               className="nextui-ripple"
               exit={{opacity: 0}}
               initial={{transform: "scale(0)", opacity: 0.35}}
-              onTransitionEnd={() => onClear(ripple.key)}
-              onAnimationEnd={() => onClear(ripple.key)}
               style={{
                 position: "absolute",
                 backgroundColor: color,
@@ -46,6 +45,8 @@ const Ripple: FC<RippleProps> = (props) => {
                 ...style,
               }}
               transition={{duration}}
+              onAnimationEnd={() => onClear(ripple.key)}
+              onTransitionEnd={() => onClear(ripple.key)}
               {...motionProps}
             />
           </AnimatePresence>

--- a/packages/components/ripple/src/use-ripple.ts
+++ b/packages/components/ripple/src/use-ripple.ts
@@ -1,7 +1,8 @@
-import {useCallback, useState} from "react";
+import {getUniqueID} from "@nextui-org/shared-utils";
+import React, {useCallback, useState} from "react";
 
 export type RippleType = {
-  key: number;
+  key: React.Key;
   x: number;
   y: number;
   size: number;
@@ -21,7 +22,7 @@ export function useRipple(props: UseRippleProps = {}) {
     setRipples((prevRipples) => [
       ...prevRipples,
       {
-        key: Date.now(),
+        key: getUniqueID(prevRipples.length.toString()),
         size,
         x: event.clientX - rect.x - size / 2,
         y: event.clientY - rect.y - size / 2,
@@ -29,7 +30,7 @@ export function useRipple(props: UseRippleProps = {}) {
     ]);
   }, []);
 
-  const onClear = useCallback((key: number) => {
+  const onClear = useCallback((key: React.Key) => {
     setRipples((prevState) => prevState.filter((ripple) => ripple.key !== key));
   }, []);
 

--- a/packages/components/ripple/src/use-ripple.ts
+++ b/packages/components/ripple/src/use-ripple.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from "react";
+import {useCallback, useState} from "react";
 
 export type RippleType = {
   key: number;
@@ -7,18 +7,9 @@ export type RippleType = {
   size: number;
 };
 
-export interface UseRippleProps {
-  /**
-  /**
-   * The time to remove the ripples in ms.
-   * @default 1000
-   */
-  removeAfter?: number;
-}
+export interface UseRippleProps {}
 
 export function useRipple(props: UseRippleProps = {}) {
-  const { ...otherProps } = props;
-
   const [ripples, setRipples] = useState<RippleType[]>([]);
 
   const onClick = useCallback((event: React.MouseEvent<HTMLElement, MouseEvent>) => {
@@ -42,7 +33,7 @@ export function useRipple(props: UseRippleProps = {}) {
     setRipples((prevState) => prevState.filter((ripple) => ripple.key !== key));
   }, []);
 
-  return {ripples, onClick, onClear, ...otherProps};
+  return {ripples, onClick, onClear, ...props};
 }
 
 export type UseRippleReturn = ReturnType<typeof useRipple>;

--- a/packages/components/ripple/src/use-ripple.ts
+++ b/packages/components/ripple/src/use-ripple.ts
@@ -17,22 +17,9 @@ export interface UseRippleProps {
 }
 
 export function useRipple(props: UseRippleProps = {}) {
-  const {removeAfter = 1000, ...otherProps} = props;
+  const { ...otherProps } = props;
 
   const [ripples, setRipples] = useState<RippleType[]>([]);
-
-  useEffect(() => {
-    const timeoutIds = ripples.map(
-      (_, i) =>
-        setTimeout(() => {
-          setRipples((prevState) => prevState.filter((_, index) => index !== i));
-        }, removeAfter), // remove after 1s
-    );
-
-    return () => {
-      timeoutIds.forEach((id) => clearTimeout(id));
-    };
-  }, [ripples]);
 
   const onClick = useCallback((event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     const trigger = event.currentTarget;
@@ -43,7 +30,7 @@ export function useRipple(props: UseRippleProps = {}) {
     setRipples((prevRipples) => [
       ...prevRipples,
       {
-        key: new Date().getTime(),
+        key: Date.now(),
         size,
         x: event.clientX - rect.x - size / 2,
         y: event.clientY - rect.y - size / 2,
@@ -51,7 +38,11 @@ export function useRipple(props: UseRippleProps = {}) {
     ]);
   }, []);
 
-  return {ripples, onClick, ...otherProps};
+  const onClear = useCallback((key: number) => {
+    setRipples((prevState) => prevState.filter((ripple) => ripple.key !== key));
+  }, []);
+
+  return {ripples, onClick, onClear, ...otherProps};
 }
 
 export type UseRippleReturn = ReturnType<typeof useRipple>;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

optimize ripple destroy time, destroy it when the animation ends, not after 1 second


## ⛳️ Current behavior (updates)

Destroy ripple after 1 second

## 🚀 New behavior

Destroy ripple when the animation ends

## 💣 Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

I remove the `setTimeout` method, and replaced  with the `onTransitionEnd` event.
