### PR TITLE
fix: resolved border collapse issue #1626 when border variants are mixed in button group

### DIFF
--- a/.changeset/chilly-trainers-type.md
+++ b/.changeset/chilly-trainers-type.md
@@ -4,4 +4,4 @@
 ---
 
 fix(button): not show the correct borders
-fix(button-group): radis not work
+fix(button-group): radius not work

--- a/.changeset/chilly-trainers-type.md
+++ b/.changeset/chilly-trainers-type.md
@@ -3,5 +3,5 @@
 "@nextui-org/theme": patch
 ---
 
-fix(button): not show the correct borders
-fix(button-group): radius not work
+Fix #1626 The radius now works, and the border is displayed correctly in the buttonGroup.
+

--- a/.changeset/chilly-trainers-type.md
+++ b/.changeset/chilly-trainers-type.md
@@ -3,5 +3,5 @@
 "@nextui-org/theme": patch
 ---
 
-Fix #1626 The radius now works, and the border is displayed correctly in the buttonGroup.
+Fix #1626 The 'radius' will be changed based on the ButtonGroup props. However, the 'border-left' is obscured by 'margin-left ml-[calc(theme(borderWidth.medium)*-1)]', and the border is not covered by its neighbor when the button is set to variant='bordered' in the ButtonGroup.
 

--- a/.changeset/chilly-trainers-type.md
+++ b/.changeset/chilly-trainers-type.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/button": patch
+"@nextui-org/theme": patch
+---
+
+fix(button): not show the correct borders
+fix(button-group): radis not work

--- a/.changeset/chilly-trainers-type.md
+++ b/.changeset/chilly-trainers-type.md
@@ -3,5 +3,5 @@
 "@nextui-org/theme": patch
 ---
 
-Fix #1626 The 'radius' will be changed based on the ButtonGroup props. However, the 'border-left' is obscured by 'margin-left ml-[calc(theme(borderWidth.medium)*-1)]', and the border is not covered by its neighbor when the button is set to variant='bordered' in the ButtonGroup.
+Fix #1626 The 'border-left' is obscured by 'margin-left ml-[calc(theme(borderWidth.medium)*-1)]', and the border is not covered by its neighbor when the button is set to variant='bordered' in the ButtonGroup.
 

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -65,6 +65,7 @@ export type UseButtonProps = Props &
 export function useButton(props: UseButtonProps) {
   const groupContext = useButtonGroupContext();
   const isInGroup = !!groupContext;
+  const isIsolate = isInGroup && !!props.variant;
 
   const {
     ref,
@@ -112,6 +113,7 @@ export function useButton(props: UseButtonProps) {
         fullWidth,
         isDisabled,
         isInGroup,
+        isIsolate,
         disableAnimation,
         isIconOnly,
         className,
@@ -124,6 +126,7 @@ export function useButton(props: UseButtonProps) {
       fullWidth,
       isDisabled,
       isInGroup,
+      isIsolate,
       isIconOnly,
       disableAnimation,
       className,

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -65,7 +65,7 @@ export type UseButtonProps = Props &
 export function useButton(props: UseButtonProps) {
   const groupContext = useButtonGroupContext();
   const isInGroup = !!groupContext;
-  const isIsolate = isInGroup && !!props.variant;
+  const isIsolated = isInGroup && !!props.variant;
 
   const {
     ref,
@@ -113,7 +113,7 @@ export function useButton(props: UseButtonProps) {
         fullWidth,
         isDisabled,
         isInGroup,
-        isIsolate,
+        isIsolated,
         disableAnimation,
         isIconOnly,
         className,
@@ -126,7 +126,7 @@ export function useButton(props: UseButtonProps) {
       fullWidth,
       isDisabled,
       isInGroup,
-      isIsolate,
+      isIsolated,
       isIconOnly,
       disableAnimation,
       className,

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -65,7 +65,6 @@ export type UseButtonProps = Props &
 export function useButton(props: UseButtonProps) {
   const groupContext = useButtonGroupContext();
   const isInGroup = !!groupContext;
-  const isIsolated = isInGroup && !!props.variant;
 
   const {
     ref,
@@ -113,7 +112,6 @@ export function useButton(props: UseButtonProps) {
         fullWidth,
         isDisabled,
         isInGroup,
-        isIsolated,
         disableAnimation,
         isIconOnly,
         className,
@@ -126,7 +124,6 @@ export function useButton(props: UseButtonProps) {
       fullWidth,
       isDisabled,
       isInGroup,
-      isIsolated,
       isIconOnly,
       disableAnimation,
       className,

--- a/packages/components/button/stories/button-group.stories.tsx
+++ b/packages/components/button/stories/button-group.stories.tsx
@@ -64,7 +64,7 @@ const Template = (args: ButtonGroupProps) => (
 );
 
 const VariantButtonTemplate = (args: ButtonGroupProps) => (
-  <ButtonGroup {...args} variant="solid">
+  <ButtonGroup {...args}>
     <Button>One</Button>
     <Button variant={args.variant}>Two</Button>
     <Button>Three</Button>
@@ -84,5 +84,6 @@ export const VariantButton = {
 
   args: {
     ...defaultProps,
+    variant: "solid",
   },
 };

--- a/packages/components/button/stories/button-group.stories.tsx
+++ b/packages/components/button/stories/button-group.stories.tsx
@@ -66,8 +66,26 @@ const Template = (args: ButtonGroupProps) => (
 const VariantButtonTemplate = (args: ButtonGroupProps) => (
   <ButtonGroup {...args}>
     <Button>One</Button>
-    <Button variant="bordered">Two</Button>
+    <Button>Two</Button>
     <Button>Three</Button>
+    <Button variant="bordered">Four</Button>
+    <Button>Five</Button>
+    <Button>Six</Button>
+  </ButtonGroup>
+);
+
+const VariantButtonsTemplate = (args: ButtonGroupProps) => (
+  <ButtonGroup {...args}>
+    <Button color="success" variant="bordered">
+      One
+    </Button>
+    <Button>Two</Button>
+    <Button variant="bordered">Three</Button>
+    <Button color="success" variant="bordered">
+      Four
+    </Button>
+    <Button color="danger">Five</Button>
+    <Button variant="bordered">Six</Button>
   </ButtonGroup>
 );
 
@@ -81,6 +99,15 @@ export const Default = {
 
 export const VariantButton = {
   render: VariantButtonTemplate,
+
+  args: {
+    ...defaultProps,
+    variant: "solid",
+  },
+};
+
+export const VariantButtons = {
+  render: VariantButtonsTemplate,
 
   args: {
     ...defaultProps,

--- a/packages/components/button/stories/button-group.stories.tsx
+++ b/packages/components/button/stories/button-group.stories.tsx
@@ -66,7 +66,7 @@ const Template = (args: ButtonGroupProps) => (
 const VariantButtonTemplate = (args: ButtonGroupProps) => (
   <ButtonGroup {...args}>
     <Button>One</Button>
-    <Button variant={args.variant}>Two</Button>
+    <Button variant="bordered">Two</Button>
     <Button>Three</Button>
   </ButtonGroup>
 );

--- a/packages/components/button/stories/button-group.stories.tsx
+++ b/packages/components/button/stories/button-group.stories.tsx
@@ -79,12 +79,10 @@ const VariantButtonsTemplate = (args: ButtonGroupProps) => (
     <Button color="success" variant="bordered">
       One
     </Button>
-    <Button>Two</Button>
+    <Button color="success">Two</Button>
     <Button variant="bordered">Three</Button>
-    <Button color="success" variant="bordered">
-      Four
-    </Button>
-    <Button color="danger">Five</Button>
+    <Button variant="bordered">Four</Button>
+    <Button variant="bordered">Five</Button>
     <Button variant="bordered">Six</Button>
   </ButtonGroup>
 );

--- a/packages/components/button/stories/button-group.stories.tsx
+++ b/packages/components/button/stories/button-group.stories.tsx
@@ -63,8 +63,24 @@ const Template = (args: ButtonGroupProps) => (
   </ButtonGroup>
 );
 
+const VariantButtonTemplate = (args: ButtonGroupProps) => (
+  <ButtonGroup {...args} variant="solid">
+    <Button>One</Button>
+    <Button variant={args.variant}>Two</Button>
+    <Button>Three</Button>
+  </ButtonGroup>
+);
+
 export const Default = {
   render: Template,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const VariantButton = {
+  render: VariantButtonTemplate,
 
   args: {
     ...defaultProps,

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -319,7 +319,11 @@ const button = tv({
       color: "danger",
       class: colorVariants.ghost.danger,
     },
-    // isInGroup / size
+    // isInGroup / radius
+    {
+      isInGroup: true,
+      class: "rounded-none first:rounded-l-medium last:rounded-r-medium",
+    },
     {
       isInGroup: true,
       radius: "sm",

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -79,7 +79,7 @@ const button = tv({
     isInGroup: {
       true: "[&:not(:first-child):not(:last-child)]:rounded-none",
     },
-    isIsolate: {
+    isIsolated: {
       true: "mr-0 ml-0",
     },
     isIconOnly: {
@@ -347,7 +347,7 @@ const button = tv({
     // isInGroup / bordered / ghost
     {
       isInGroup: true,
-      isIsolate: false,
+      isIsolated: false,
       variant: ["ghost", "bordered"],
       class: "[&:not(:first-child)]:ml-[calc(theme(borderWidth.medium)*-1)]",
     },

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -345,6 +345,44 @@ const button = tv({
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
+      color: "default",
+      className:
+        "nextui-adjacent-default [&+.nextui-adjacent-default]:ml-[calc(theme(borderWidth.medium)*-1)]",
+    },
+    {
+      isInGroup: true,
+      variant: ["ghost", "bordered"],
+      color: "primary",
+      className:
+        "nextui-adjacent-primary [&+.nextui-adjacent-primary]:ml-[calc(theme(borderWidth.medium)*-1)]",
+    },
+    {
+      isInGroup: true,
+      variant: ["ghost", "bordered"],
+      color: "secondary",
+      className:
+        "nextui-adjacent-secondary [&+.nextui-adjacent-secondary]:ml-[calc(theme(borderWidth.medium)*-1)]",
+    },
+    {
+      isInGroup: true,
+      variant: ["ghost", "bordered"],
+      color: "success",
+      className:
+        "nextui-adjacent-success [&+.nextui-adjacent-success]:ml-[calc(theme(borderWidth.medium)*-1)]",
+    },
+    {
+      isInGroup: true,
+      variant: ["ghost", "bordered"],
+      color: "warning",
+      className:
+        "nextui-adjacent-warning [&+.nextui-adjacent-warning]:ml-[calc(theme(borderWidth.medium)*-1)]",
+    },
+    {
+      isInGroup: true,
+      variant: ["ghost", "bordered"],
+      color: "danger",
+      className:
+        "nextui-adjacent-danger [&+.nextui-adjacent-danger]:ml-[calc(theme(borderWidth.medium)*-1)]",
     },
     {
       isIconOnly: true,

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -344,7 +344,6 @@ const button = tv({
     // isInGroup / bordered / ghost
     {
       isInGroup: true,
-      isIsolated: false,
       variant: ["ghost", "bordered"],
     },
     {

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -79,6 +79,9 @@ const button = tv({
     isInGroup: {
       true: "[&:not(:first-child):not(:last-child)]:rounded-none",
     },
+    isIsolate: {
+      true: "mr-0 ml-0",
+    },
     isIconOnly: {
       true: "px-unit-0 !gap-unit-0",
       false: "[&>svg]:max-w-[theme(spacing.unit-8)]",
@@ -340,7 +343,8 @@ const button = tv({
     // isInGroup / bordered / ghost
     {
       isInGroup: true,
-      variant: ["bordered", "ghost"],
+      isIsolate: false,
+      variant: ["ghost", "bordered"],
       class: "[&:not(:first-child)]:ml-[calc(theme(borderWidth.medium)*-1)]",
     },
     {

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -79,9 +79,6 @@ const button = tv({
     isInGroup: {
       true: "[&:not(:first-child):not(:last-child)]:rounded-none",
     },
-    isIsolated: {
-      true: "mr-0 ml-0",
-    },
     isIconOnly: {
       true: "px-unit-0 !gap-unit-0",
       false: "[&>svg]:max-w-[theme(spacing.unit-8)]",
@@ -349,7 +346,6 @@ const button = tv({
       isInGroup: true,
       isIsolated: false,
       variant: ["ghost", "bordered"],
-      class: "[&:not(:first-child)]:ml-[calc(theme(borderWidth.medium)*-1)]",
     },
     {
       isIconOnly: true,

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -319,22 +319,22 @@ const button = tv({
     // isInGroup / size
     {
       isInGroup: true,
-      size: "sm",
+      radius: "sm",
       class: "rounded-none first:rounded-l-small last:rounded-r-small",
     },
     {
       isInGroup: true,
-      size: "md",
+      radius: "md",
       class: "rounded-none first:rounded-l-medium last:rounded-r-medium",
     },
     {
       isInGroup: true,
-      size: "lg",
+      radius: "lg",
       class: "rounded-none first:rounded-l-large last:rounded-r-large",
     },
     {
       isInGroup: true,
-      isRounded: true,
+      radius: "full",
       class: "rounded-none first:rounded-l-full last:rounded-r-full",
     },
     // isInGroup / bordered / ghost

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -326,22 +326,22 @@ const button = tv({
     },
     {
       isInGroup: true,
-      radius: "sm",
+      size: "sm",
       class: "rounded-none first:rounded-l-small last:rounded-r-small",
     },
     {
       isInGroup: true,
-      radius: "md",
+      size: "md",
       class: "rounded-none first:rounded-l-medium last:rounded-r-medium",
     },
     {
       isInGroup: true,
-      radius: "lg",
+      size: "lg",
       class: "rounded-none first:rounded-l-large last:rounded-r-large",
     },
     {
       isInGroup: true,
-      radius: "full",
+      isRounded: true,
       class: "rounded-none first:rounded-l-full last:rounded-r-full",
     },
     // isInGroup / bordered / ghost

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -1,7 +1,7 @@
 import type {VariantProps} from "tailwind-variants";
 
 import {tv} from "../utils/tv";
-import {colorVariants, dataFocusVisibleClasses} from "../utils";
+import {collapseAdjacentVariantBorders, colorVariants, dataFocusVisibleClasses} from "../utils";
 
 /**
  * Button wrapper **Tailwind Variants** component
@@ -346,43 +346,37 @@ const button = tv({
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "default",
-      className:
-        "nextui-adjacent-default [&+.nextui-adjacent-default]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.default,
     },
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "primary",
-      className:
-        "nextui-adjacent-primary [&+.nextui-adjacent-primary]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.primary,
     },
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "secondary",
-      className:
-        "nextui-adjacent-secondary [&+.nextui-adjacent-secondary]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.secondary,
     },
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "success",
-      className:
-        "nextui-adjacent-success [&+.nextui-adjacent-success]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.success,
     },
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "warning",
-      className:
-        "nextui-adjacent-warning [&+.nextui-adjacent-warning]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.warning,
     },
     {
       isInGroup: true,
       variant: ["ghost", "bordered"],
       color: "danger",
-      className:
-        "nextui-adjacent-danger [&+.nextui-adjacent-danger]:ml-[calc(theme(borderWidth.medium)*-1)]",
+      className: collapseAdjacentVariantBorders.danger,
     },
     {
       isIconOnly: true,

--- a/packages/core/theme/src/utils/classes.ts
+++ b/packages/core/theme/src/utils/classes.ts
@@ -60,10 +60,10 @@ export const absoluteFullClasses = ["absolute", "inset-0"];
  * It includes classes for different variants like default, primary, secondary, etc.
  */
 export const collapseAdjacentVariantBorders = {
-  default: ["[&+.border-medium.border-default]:ml-[calc(theme(borderWidth.medium)*-1)]"],
-  primary: ["[&+.border-medium.border-primary]:ml-[calc(theme(borderWidth.medium)*-1)]"],
-  secondary: ["[&+.border-medium.border-secondary]:ml-[calc(theme(borderWidth.medium)*-1)]"],
-  success: ["[&+.border-medium.border-success]:ml-[calc(theme(borderWidth.medium)*-1)]"],
-  warning: ["[&+.border-medium.border-warning]:ml-[calc(theme(borderWidth.medium)*-1)]"],
-  danger: ["[&+.border-medium.border-danger]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  default: ["[&+.border-medium.border-default]:ms-[calc(theme(borderWidth.medium)*-1)]"],
+  primary: ["[&+.border-medium.border-primary]:ms-[calc(theme(borderWidth.medium)*-1)]"],
+  secondary: ["[&+.border-medium.border-secondary]:ms-[calc(theme(borderWidth.medium)*-1)]"],
+  success: ["[&+.border-medium.border-success]:ms-[calc(theme(borderWidth.medium)*-1)]"],
+  warning: ["[&+.border-medium.border-warning]:ms-[calc(theme(borderWidth.medium)*-1)]"],
+  danger: ["[&+.border-medium.border-danger]:ms-[calc(theme(borderWidth.medium)*-1)]"],
 };

--- a/packages/core/theme/src/utils/classes.ts
+++ b/packages/core/theme/src/utils/classes.ts
@@ -54,3 +54,16 @@ export const translateCenterClasses = [
 ];
 
 export const absoluteFullClasses = ["absolute", "inset-0"];
+
+/**
+ * This object defines CSS classes for collapsing adjacent variant borders.
+ * It includes classes for different variants like default, primary, secondary, etc.
+ */
+export const collapseAdjacentVariantBorders = {
+  default: ["[&+.border-medium.border-default]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  primary: ["[&+.border-medium.border-primary]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  secondary: ["[&+.border-medium.border-secondary]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  success: ["[&+.border-medium.border-success]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  warning: ["[&+.border-medium.border-warning]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+  danger: ["[&+.border-medium.border-danger]:ml-[calc(theme(borderWidth.medium)*-1)]"],
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1626

## 📝 Description

The ```radius``` property does not work on the 'buttonGroup' component. The ```variant="bordered"``` option does not display the correct borders.

## ⛳️ Current behavior (updates)

The ```radius``` is always the same as ```md```.
The ```border-left``` is covered by  margin-left ```ml-[calc(theme(borderWidth.medium)*-1)]```.

```tsx
  <ButtonGroup color="success" radius="lg" variant="flat">
    <Button>One</Button>
    <Button>Two</Button>
    <Button variant="bordered">Three</Button>
    <Button>Four</Button>
    <Button>Five</Button>
    <Button>Six</Button>
  </ButtonGroup>
```

## 🚀 New behavior

The ```radius``` now works, and the border is displayed correctly in the ```buttonGroup```.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Please kindly let me know if any suggestions.
