### PR TITLE
fix(core): extend variants function, destructuring order changed

### DIFF
--- a/.changeset/moody-fans-stare.md
+++ b/.changeset/moody-fans-stare.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system-rsc": patch
+---
+
+Fix #1541 `extendVariants`function gives more priority to final component props over the `extendVariants` props

--- a/packages/core/system-rsc/src/extend-variants.js
+++ b/packages/core/system-rsc/src/extend-variants.js
@@ -43,7 +43,7 @@ export function extendVariants(BaseComponent, styles = {}, opts = {}) {
   const ForwardedComponent = React.forwardRef((originalProps, ref) => {
     const [baseProps, variantProps] = mapPropsVariants(originalProps, customTv.variantKeys, false);
 
-    const newProps = {...baseProps, ...defaultVariants, ref};
+    const newProps = {...defaultVariants, ...baseProps, ref};
 
     let classNames = {};
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1541 

## 📝 Description

When using `extendVariants` to inherit components, if `defaultVariants` is set, it cannot be overridden. 

## ⛳️ Current behavior (updates)

When using `extendVariants` to inherit components, if `defaultVariants` is set, it cannot be overridden. 

## 🚀 New behavior

`extendVariants` function gives more priority to final component props over the `extendVariants` props

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
