### PR TITLE
fix: add peer dependencies

### DIFF
--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -41,6 +41,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -34,7 +34,9 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18",
+    "framer-motion": ">=4.0.0"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -34,7 +34,9 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18",
+    "framer-motion": ">=4.0.0"
   },
   "dependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/chip/package.json
+++ b/packages/components/chip/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/shared-icons": "workspace:*",

--- a/packages/components/code/package.json
+++ b/packages/components/code/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/shared-utils": "workspace:*",

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/image/package.json
+++ b/packages/components/image/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/react-utils": "workspace:*",

--- a/packages/components/kbd/package.json
+++ b/packages/components/kbd/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/shared-utils": "workspace:*",

--- a/packages/components/listbox/package.json
+++ b/packages/components/listbox/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/react-utils": "workspace:*",

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/progress/package.json
+++ b/packages/components/progress/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/shared-utils": "workspace:*",

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/ripple/package.json
+++ b/packages/components/ripple/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/scroll-shadow/package.json
+++ b/packages/components/scroll-shadow/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/snippet/package.json
+++ b/packages/components/snippet/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/spacer/package.json
+++ b/packages/components/spacer/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -36,7 +36,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/shared-utils": "workspace:*",

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/checkbox": "workspace:*",

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/packages/components/user/package.json
+++ b/packages/components/user/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@nextui-org/system": "workspace:*",

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -81,6 +81,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "devDependencies": {

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/hooks/use-aria-modal-overlay/package.json
+++ b/packages/hooks/use-aria-modal-overlay/package.json
@@ -40,7 +40,8 @@
     "@react-aria/utils": "^3.20.0"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/hooks/use-aria-multiselect/package.json
+++ b/packages/hooks/use-aria-multiselect/package.json
@@ -49,7 +49,8 @@
     "@react-aria/utils": "^3.20.0"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/utilities/framer-transitions/package.json
+++ b/packages/utilities/framer-transitions/package.json
@@ -35,6 +35,7 @@
   },
   "peerDependencies": {
     "react": ">=18",
+    "react-dom": ">=18",
     "framer-motion": ">=4.0.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,6 +637,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -686,6 +689,9 @@ importers:
       '@react-aria/utils':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -714,6 +720,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -772,6 +781,12 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      framer-motion:
+        specifier: '>=4.0.0'
+        version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -818,6 +833,12 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      framer-motion:
+        specifier: '>=4.0.0'
+        version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -882,6 +903,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/chip':
         specifier: workspace:*
@@ -931,6 +955,9 @@ importers:
       '@react-types/checkbox':
         specifier: ^3.5.1
         version: 3.5.1(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -956,6 +983,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -981,6 +1011,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1024,6 +1057,9 @@ importers:
       '@react-types/menu':
         specifier: ^3.9.4
         version: 3.9.4(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -1064,6 +1100,9 @@ importers:
       '@nextui-org/use-image':
         specifier: workspace:*
         version: link:../../hooks/use-image
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1110,6 +1149,9 @@ importers:
       '@react-types/textfield':
         specifier: ^3.8.0
         version: 3.8.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-textarea-autosize:
         specifier: ^8.5.2
         version: 8.5.3(@types/react@18.2.8)(react@18.2.0)
@@ -1138,6 +1180,9 @@ importers:
       '@react-aria/utils':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1178,6 +1223,9 @@ importers:
       '@react-types/link':
         specifier: ^3.4.5
         version: 3.4.5(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1230,6 +1278,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -1288,6 +1339,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -1349,6 +1403,9 @@ importers:
       '@react-types/overlays':
         specifier: ^3.8.2
         version: 3.8.2(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-remove-scroll:
         specifier: ^2.5.6
         version: 2.5.6(@types/react@18.2.8)(react@18.2.0)
@@ -1422,6 +1479,9 @@ importers:
       framer-motion:
         specifier: '>=4.0.0'
         version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-remove-scroll:
         specifier: ^2.5.6
         version: 2.5.6(@types/react@18.2.8)(react@18.2.0)
@@ -1483,6 +1543,9 @@ importers:
       '@react-aria/utils':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed:
         specifier: 3.0.10
         version: 3.0.10
@@ -1544,6 +1607,9 @@ importers:
       '@react-types/overlays':
         specifier: ^3.8.2
         version: 3.8.2(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       react-remove-scroll:
         specifier: ^2.5.6
         version: 2.5.6(@types/react@18.2.8)(react@18.2.0)
@@ -1593,6 +1659,9 @@ importers:
       '@react-types/progress':
         specifier: ^3.4.3
         version: 3.4.3(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/card':
         specifier: workspace:*
@@ -1645,6 +1714,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -1670,6 +1742,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1698,6 +1773,9 @@ importers:
       '@nextui-org/use-data-scroll-overflow':
         specifier: workspace:*
         version: link:../../hooks/use-data-scroll-overflow
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1762,6 +1840,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -1802,6 +1883,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1845,6 +1929,9 @@ importers:
       framer-motion:
         specifier: '>=4.0.0'
         version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1867,6 +1954,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1889,6 +1979,9 @@ importers:
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -1932,6 +2025,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -1993,6 +2089,9 @@ importers:
       '@react-types/table':
         specifier: ^3.8.1
         version: 3.8.1(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -2075,6 +2174,9 @@ importers:
       '@react-types/tabs':
         specifier: ^3.3.2
         version: 3.3.2(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed:
         specifier: 3.0.10
         version: 3.0.10
@@ -2148,6 +2250,9 @@ importers:
       '@react-types/tooltip':
         specifier: ^3.4.4
         version: 3.4.4(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -2185,6 +2290,9 @@ importers:
       '@react-aria/utils':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       '@nextui-org/link':
         specifier: workspace:*
@@ -2312,6 +2420,9 @@ importers:
       framer-motion:
         specifier: '>=4.0.0'
         version: 10.16.4(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -2331,6 +2442,9 @@ importers:
       '@react-aria/overlays':
         specifier: ^3.17.0
         version: 3.17.0(react-dom@18.2.0)(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -2539,6 +2653,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -2588,6 +2705,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.20.0
         version: 3.20.0(react@18.2.0)
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -2896,6 +3016,9 @@ importers:
       '@nextui-org/system':
         specifier: workspace:*
         version: link:../../core/system
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0


### PR DESCRIPTION
## 📝 Description
<img width="1203" alt="Screenshot 2023-09-18 at 2 31 19 PM" src="https://github.com/nextui-org/nextui/assets/66503450/5e1c283b-f4e8-4b5b-81db-a31091035744">
I encountered an error starting a new Next 13 project. This was a problem with yarn PnP and there was no similar case. As a result of analyzing the error, it was an error that the react-dom package could not be found in the react-aria/overlay package. 

Looking for a little more, the peer dependency of the package used by next-ui was not declared as the peer dependency of next-ui.

The following solutions are being used temporarily.

Change peer dependency forced injection or pnpFallbackMode: "all" using packageExtensions option in yarnrc.yml

It is enough for me already, but I made a PR because I thought it would be nice if a more fundamental solution could be prepared in next-ui.

## ⛳️ Current behavior (updates)
Module not found because peer dependency does not have react-dom and framer-motion in nextui packages. (only yarn PnP , not node_modules)

## 🚀 New behavior
Add as peer dependency to packages requiring react-dom or framer-motion.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
