### PR TITLE
fix(radio): correct the style of radio in invalid and selected states

### DIFF
--- a/.changeset/hot-otters-laugh.md
+++ b/.changeset/hot-otters-laugh.md
@@ -2,4 +2,4 @@
 "@nextui-org/radio": patch
 ---
 
-correct the style of radio in invalid and selected states
+fix: when radio is selected in invalid state, the border of the radio controller should be danger color

--- a/.changeset/hot-otters-laugh.md
+++ b/.changeset/hot-otters-laugh.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/radio": patch
+---
+
+correct the style of radio in invalid and selected states

--- a/packages/core/theme/src/components/radio.ts
+++ b/packages/core/theme/src/components/radio.ts
@@ -117,7 +117,7 @@ const radio = tv({
     isInvalid: {
       true: {
         control: "bg-danger text-danger-foreground",
-        wrapper: "border-danger data-[selected=true]:border-danger",
+        wrapper: "border-danger group-data-[selected=true]:border-danger",
         label: "text-danger",
         description: "text-danger-300",
       },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

![radio-group](https://github.com/nextui-org/nextui/assets/5329193/23d8d4dc-eb7a-4a47-9daa-b010ea97471d)

When Radio is selected in invalid state, the border of the Radio controller should be danger color

````javascript
isInvalid: {
  true: {
    control: "bg-danger text-danger-foreground",
    // data-[selected=true]:border-danger -> group-data-[selected=true]:border-danger
    wrapper: "border-danger data-[selected=true]:border-danger", 
    label: "text-danger",
    description: "text-danger-300",
  },
},
````

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
