### PR TITLE
fix(select): setting padding top 0 if label and placeholder are both falsy

### DIFF
--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -463,7 +463,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
       return {
         ...props,
         className: slots.innerWrapper({
-          class: clsx(classNames?.innerWrapper, props?.className),
+          class: clsx(classNames?.innerWrapper, !label && "pt-0", props?.className),
         }),
       };
     },

--- a/packages/components/select/stories/select.stories.tsx
+++ b/packages/components/select/stories/select.stories.tsx
@@ -601,6 +601,23 @@ const LabelPlacementTemplate = ({color, variant, ...args}: SelectProps) => (
         </Select>
       </div>
     </div>
+    <div className="w-full max-w-2xl flex flex-col gap-3">
+      <h3>With falsy label</h3>
+      <div className="w-full flex flex-row items-end gap-4">
+        <Select
+          className="w-1/3"
+          color={color}
+          placeholder="Select an animal"
+          variant={variant}
+          {...args}
+        >
+          {items}
+        </Select>
+        <Select className="w-1/3" color={color} variant={variant} {...args}>
+          {items}
+        </Select>
+      </div>
+    </div>
   </div>
 );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

Adjust the padding of innerWrapper of select when `label` is undefined/falsy.

## ⛳️ Current behavior (updates)

Due to we set `innerWrapper: "pt-4",` if `label` and `placeholder` are both falsy, there will still have a padding top.

```
{
  isLabelPlaceholder: true,
  labelPlacement: "inside",
  size: "sm",
  class: {
    label: ["group-data-[filled=true]:-translate-y-[calc(50%_+_theme(fontSize.tiny)/2_-_3px)]"],
    innerWrapper: "pt-4",
  },
},
{
  isLabelPlaceholder: true,
  labelPlacement: "inside",
  size: "md",
  class: {
    label: [
      "group-data-[filled=true]:-translate-y-[calc(50%_+_theme(fontSize.small)/2_-_4px)]",
    ],
    innerWrapper: "pt-4",
  },
},
```

⬇️ In this case, both `placeholder` and `label` are not provided.

```
<Select classNames={{ label: 'hidden', popover: 'bg-white' }}>
 {animals.map(animal => (
    <SelectItem
      key={animal.value}
      value={animal.value}
    >
      {animal.label}
    </SelectItem>
  ))}
</Select>
```
<img width="265" alt="image" src="https://github.com/nextui-org/nextui/assets/22234622/260402ee-90c0-4d9d-92f8-23498c208da3">



## 🚀 New behavior

Remove the padding top of innerWrapper if `label` and `placeholder` are both falsy, as neither of them is required.

<img width="519" alt="image" src="https://github.com/nextui-org/nextui/assets/22234622/18d7bac1-59da-4b17-9044-d54f50fa36e5">


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No
