### PR TITLE
refactor(root): styles refactor

### DIFF
--- a/.changeset/fifty-snails-glow.md
+++ b/.changeset/fifty-snails-glow.md
@@ -1,0 +1,11 @@
+---
+"@nextui-org/listbox": patch
+"@nextui-org/tabs": patch
+"@nextui-org/theme": patch
+---
+
+Styles Changes
+
+- Spacing units changed to from `px` to `rem` this improves the mobile components sizes
+- Tabs/Tab new prop added `shouldSelectOnPressUp` which is enabled by default `true`, this prop defines whether the tabs selection should occur on press up instead of press down.
+- Chip font size changed to `text-tiny` on `sm` size.

--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -142,6 +142,7 @@ You can customize the `Tabs` component by passing custom Tailwind CSS classes to
 | selectedKey            | `React.Key`                                                                                            | The key for the currently selected item.                                                                     | -           |
 | defaultSelectedKey     | `React.Key`                                                                                            | The key for the initially selected item.                                                                     | -           |
 | disallowEmptySelection | `boolean`                                                                                              | Whether the tabs should allow empty selection.                                                               | `false`     |
+| shouldSelectOnPressUp  | `boolean`                                                                                              | Whether the tabs selection should occur on press up instead of press down.                                   | `true`      |
 | keyboardActivation     | `automatic` \| `manual`                                                                                | Whether tabs are activated automatically on focus or manually.                                               | `automatic` |
 | motionProps            | [MotionProps](#motion-props)                                                                           | The props to modify the cursor framer motion animation. Use the `variants` API to create your own animation. | -           |
 | disableCursorAnimation | `boolean`                                                                                              | Whether the cursor should be hidden.                                                                         | `false`     |
@@ -157,11 +158,12 @@ You can customize the `Tabs` component by passing custom Tailwind CSS classes to
 
 ### Tab Props
 
-| Attribute  | Type        | Description                                                                                | Default |
-| ---------- | ----------- | ------------------------------------------------------------------------------------------ | ------- |
-| children\* | `ReactNode` | The content of the tab.                                                                    | -       |
-| title      | `ReactNode` | The title of the tab.                                                                      | -       |
-| titleValue | `string`    | A string representation of the item's contents. Use this when the `title` is not readable. | -       |
+| Attribute             | Type        | Description                                                                                | Default |
+| --------------------- | ----------- | ------------------------------------------------------------------------------------------ | ------- |
+| children\*            | `ReactNode` | The content of the tab.                                                                    | -       |
+| title                 | `ReactNode` | The title of the tab.                                                                      | -       |
+| titleValue            | `string`    | A string representation of the item's contents. Use this when the `title` is not readable. | -       |
+| shouldSelectOnPressUp | `boolean`   | Whether the tab selection should occur on press up instead of press down.                  | -       |
 
 #### Motion Props
 

--- a/packages/components/listbox/stories/listbox.stories.tsx
+++ b/packages/components/listbox/stories/listbox.stories.tsx
@@ -499,7 +499,7 @@ const CustomWithClassNamesTemplate = ({color, variant, disableAnimation, ...args
         endContent={<ItemCounter number={82} />}
         startContent={
           <IconWrapper className="bg-default/50 text-foreground">
-            <WatchersIcon/>
+            <WatchersIcon />
           </IconWrapper>
         }
       >

--- a/packages/components/tabs/src/base/tab-item-base.ts
+++ b/packages/components/tabs/src/base/tab-item-base.ts
@@ -1,4 +1,5 @@
 import {BaseItem, ItemProps} from "@nextui-org/aria-utils";
+import {AriaTabProps} from "@react-types/tabs";
 import {ReactNode} from "react";
 interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "children" | "title"> {
   /**
@@ -16,7 +17,7 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "chi
   titleValue?: string;
 }
 
-export type TabItemProps<T extends object = {}> = Props<T>;
+export type TabItemProps<T extends object = {}> = Props<T> & AriaTabProps;
 
 const TabItemBase = BaseItem as <T extends object>(props: TabItemProps<T>) => JSX.Element;
 

--- a/packages/components/tabs/src/base/tab-item-base.ts
+++ b/packages/components/tabs/src/base/tab-item-base.ts
@@ -1,5 +1,4 @@
 import {BaseItem, ItemProps} from "@nextui-org/aria-utils";
-import {AriaTabProps} from "@react-types/tabs";
 import {ReactNode} from "react";
 interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "children" | "title"> {
   /**
@@ -15,9 +14,13 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "chi
    *  This will be used as native `title` attribute.
    * */
   titleValue?: string;
+  /** Whether the tab should be disabled. */
+  isDisabled?: boolean;
+  /** Whether the tab selection should occur on press up instead of press down. */
+  shouldSelectOnPressUp?: boolean;
 }
 
-export type TabItemProps<T extends object = {}> = Props<T> & AriaTabProps;
+export type TabItemProps<T extends object = {}> = Props<T>;
 
 const TabItemBase = BaseItem as <T extends object>(props: TabItemProps<T>) => JSX.Element;
 

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -42,6 +42,7 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
     motionProps,
     disableAnimation,
     disableCursorAnimation,
+    shouldSelectOnPressUp,
     onClick,
     ...otherProps
   } = props;
@@ -58,7 +59,7 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
     isSelected,
     isDisabled: isDisabledItem,
     isPressed,
-  } = useTab({key}, state, domRef);
+  } = useTab({key, isDisabled: isDisabledProp, shouldSelectOnPressUp}, state, domRef);
 
   const isDisabled = isDisabledProp || isDisabledItem;
 

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -26,11 +26,12 @@ function Tabs<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLDivElemen
     isDisabled: values.isDisabled,
     motionProps: values.motionProps,
     disableAnimation: values.disableAnimation,
+    shouldSelectOnPressUp: values.shouldSelectOnPressUp,
     disableCursorAnimation: values.disableCursorAnimation,
   };
 
   const tabs = [...state.collection].map((item) => (
-    <Tab key={item.key} item={item} {...item.props} {...tabsProps} />
+    <Tab key={item.key} item={item} {...tabsProps} {...item.props} />
   ));
 
   return (

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -23,6 +23,11 @@ export interface Props extends Omit<HTMLNextUIProps, "children"> {
    */
   motionProps?: HTMLMotionProps<"span">;
   /**
+   * Whether the tabs selection should occur on press up instead of press down.
+   * @default true
+   */
+  shouldSelectOnPressUp?: boolean;
+  /**
    * Whether the cursor should be hidden.
    * @default false
    */
@@ -50,11 +55,12 @@ export type UseTabsProps<T> = Props &
   Omit<AriaTabListProps<T>, "children" | "orientation"> &
   CollectionProps<T>;
 
-export type ValuesType<T = object> = {
+export type ValuesType<T extends object = object> = {
   state: TabListState<T>;
   slots: TabsReturnType;
   disableCursorAnimation?: boolean;
   listRef?: RefObject<HTMLElement>;
+  shouldSelectOnPressUp?: boolean;
   classNames?: SlotsToClasses<TabsSlots>;
   motionProps?: HTMLMotionProps<"span">;
   disableAnimation?: boolean;
@@ -71,6 +77,7 @@ export function useTabs<T extends object>(originalProps: UseTabsProps<T>) {
     children,
     classNames,
     disableCursorAnimation,
+    shouldSelectOnPressUp = true,
     motionProps,
     ...otherProps
   } = props;
@@ -104,6 +111,7 @@ export function useTabs<T extends object>(originalProps: UseTabsProps<T>) {
       classNames,
       motionProps,
       listRef: domRef,
+      shouldSelectOnPressUp,
       disableCursorAnimation,
       isDisabled: originalProps?.isDisabled,
       disableAnimation: originalProps?.disableAnimation,
@@ -114,6 +122,7 @@ export function useTabs<T extends object>(originalProps: UseTabsProps<T>) {
       domRef,
       motionProps,
       disableCursorAnimation,
+      shouldSelectOnPressUp,
       originalProps?.disableAnimation,
       originalProps?.isDisabled,
       classNames,

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -55,7 +55,7 @@ export type UseTabsProps<T> = Props &
   Omit<AriaTabListProps<T>, "children" | "orientation"> &
   CollectionProps<T>;
 
-export type ValuesType<T extends object = object> = {
+export type ValuesType<T = object> = {
   state: TabListState<T>;
   slots: TabsReturnType;
   disableCursorAnimation?: boolean;

--- a/packages/core/theme/src/components/chip.ts
+++ b/packages/core/theme/src/components/chip.ts
@@ -87,7 +87,7 @@ const chip = tv({
     },
     size: {
       sm: {
-        base: "px-1 h-6 text-small",
+        base: "px-1 h-6 text-tiny",
         content: "px-1",
         closeButton: "text-medium",
         avatar: "w-4 h-4",

--- a/packages/core/theme/src/utils/theme.ts
+++ b/packages/core/theme/src/utils/theme.ts
@@ -8,6 +8,7 @@ import {spacingScaleKeys, SpacingScaleKeys, SpacingScale} from "../types";
  */
 export const isBaseTheme = (theme: string) => theme === "light" || theme === "dark";
 
+const ROOT_FONT_SIZE = 16;
 const baseScale = [1, 2, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
 const extendedScale = [20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96];
 
@@ -32,8 +33,8 @@ export const generateSpacingScale = (spacingUnit: number) => {
 
   Object.entries(scaleLabels).forEach(([label, multiplier]) => {
     scale[label as SpacingScaleKeys] = multiplier
-      ? `${spacingUnit * multiplier}px`
-      : `${spacingUnit}px`;
+      ? `${(spacingUnit * multiplier) / ROOT_FONT_SIZE}rem`
+      : `${spacingUnit / ROOT_FONT_SIZE}rem`;
   });
 
   baseScale.forEach((i) => {
@@ -46,13 +47,13 @@ export const generateSpacingScale = (spacingUnit: number) => {
       key = `${first}_${second}`;
     }
 
-    scale[key] = `${spacingUnit * i}px`;
+    scale[key] = `${(spacingUnit * i) / ROOT_FONT_SIZE}rem`;
   });
 
   extendedScale.forEach((i) => {
     const key = `${i}` as SpacingScaleKeys;
 
-    scale[key] = `${spacingUnit * i}px`;
+    scale[key] = `${(spacingUnit * i) / ROOT_FONT_SIZE}rem`;
   });
 
   return scale;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1685 

## 📝 Description

- Spacing units changed to from `px` to `rem` this improves the mobile components' sizes
- Tabs/Tab new prop added `shouldSelectOnPressUp` which is enabled by default `true`, this prop defines whether the tabs selection should occur on press up instead of press down.
- Chip font size changed to `text-tiny` on `sm` size.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
