### PR TITLE
fix(docs): typo on props, classNames does not exist

### DIFF
--- a/apps/docs/content/docs/components/image.mdx
+++ b/apps/docs/content/docs/components/image.mdx
@@ -97,7 +97,7 @@ you can use it with NextUI `Image` component as well.
 | isZoomed        | `boolean`                                                            | Whether the image should be zoomed when hovered.                                                                                                                                                            | `false` |
 | removeWrapper   | `boolean`                                                            | Whether to remove the wrapper element. This will cause the image to be rendered as a direct child of the parent element. If you set this prop as `true` neither the skeleton nor the zoom effect will work. | `false` |
 | disableSkeleton | `boolean`                                                            | Whether the image should disable the skeleton animation while loading.                                                                                                                                      | `false` |
-| classNames      | `Record<"img"｜ "wrapper"｜ "zoomedWrapper"｜ "blurredImg", string>` | Allows to set custom class names for the image slots.                                                                                                                                                       | -       |
+| className      | `Record<"img"｜ "wrapper"｜ "zoomedWrapper"｜ "blurredImg", string>` | Allows to set custom class names for the image slots.                                                                                                                                                       | -       |
 
 ### Image Events
 


### PR DESCRIPTION
`classNames` does not exist in `<Image/>` component, probably just a typo in docs.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->
