### PR TITLE
docs: fix storybook link in ComponentLinks

### DIFF
--- a/apps/docs/components/docs/components/component-links.tsx
+++ b/apps/docs/components/docs/components/component-links.tsx
@@ -72,7 +72,9 @@ export const ComponentLinks = ({
   return (
     <div className="flex flex-wrap gap-3 mt-6">
       <ButtonLink
-        href={`https://storybook.nextui.org/?path=/story/components-${storybook || component}`}
+        href={`https://storybook.nextui.org/?path=/story/components-${
+          storybook || component
+        }--default`}
         startContent={<StorybookIcon className="text-lg text-[#ff4785]" />}
       >
         Storybook


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Currently, when you access the storybook link on the next UI component page, an error screen appears. So I fix link.


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

- https://storybook.nextui.org/?path=/story/components-skeleton

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

- https://storybook.nextui.org/?path=/story/components-skeleton--default

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
