### PR TITLE
fix(input): migrate inline styles in inputWrapperProps to tailwind

### DIFF
--- a/.changeset/brown-lions-love.md
+++ b/.changeset/brown-lions-love.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+migrated input cursor text from inline style to tailwind

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -296,7 +296,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "data-focus-visible": dataAttr(isFocusVisible),
         "data-focus": dataAttr(isFocused),
         className: slots.inputWrapper({
-          class: clsx(classNames?.inputWrapper, !!inputValue ? "is-filled" : ""),
+          class: clsx(classNames?.inputWrapper, !!inputValue ? "is-filled" : "", "cursor-text"),
         }),
         onClick: (e: React.MouseEvent) => {
           if (e.target === e.currentTarget) {
@@ -305,7 +305,6 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         },
         ...mergeProps(props, hoverProps),
         style: {
-          cursor: "text",
           ...props.style,
         },
       };


### PR DESCRIPTION
## 📝 Description

[Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/CSP) is important to guard your Next.js application against various security threats such as cross-site scripting (XSS), clickjacking, and other code injection attacks.  Next.js 13.5 has put in some work into making it practical to achieve a strict CSP through improved [documentation](https://nextjs.org/docs/pages/building-your-application/configuring/content-security-policy), updated [example](https://github.com/vercel/next.js/tree/canary/examples/with-strict-csp), and recent [bug fixes/code changes](https://github.com/vercel/next.js/discussions/54907).

Unfortunately Nextui uses some inline styles which force use of `style-src: unsafe-inline` in production and prevents users from configuring next.js with a strict CSP.   Although unsafe styles isn't as critical as script, nextui shouldn't be a blocker for security best practices if achievable with reasonable effort.

This PR fixes the first case I noticed.  I am hoping it can be a good before/after example to reference. and also start a conversation.  

What would take to get alignment that inline styles stop being added to new code and monitored during dev and code reviews?   

Could a nextui expert scan the remaining usages of `style:` for any that are not migratable with reasonable effort?  It would be interesting to know if there are any obvious hard stops to this initiative before digging in further.

Eventually
* nextui can brag on homepage about how it is compatible with security best practices because it uses tailwind.

## ⛳️ Current behavior (updates)

> inputWrapperProps adds a style attribute `cursor: text`

## 🚀 New behavior

> inputWrapperProps adds a tailwind equivalent class `cursor-text`

## 💣 Is this a breaking change (Yes/No):  No

## 📝 Additional Information
I believe things like `style: mergeProps(positionProps.style, otherProps.style, props.style)` are fine because it just passes through user attributes.    
