### PR TITLE
fix(slider): Place last dragged slider handle over the other handle

### DIFF
--- a/packages/components/slider/__tests__/drag.ts
+++ b/packages/components/slider/__tests__/drag.ts
@@ -1,0 +1,109 @@
+// ####################################################
+// ##                COPYED FROM HERE                ##
+// ##                WITH TYPES ADDED                ##
+// ## https://testing-library.com/docs/example-drag/ ##
+// ####################################################
+
+import { fireEvent } from '@testing-library/dom'
+
+// https://stackoverflow.com/a/53946549/1179377
+function isElement(
+  obj: HTMLElement | Record<string, unknown>
+): obj is HTMLElement {
+  if (typeof obj !== 'object') {
+    return false
+  }
+  let prototypeStr, prototype
+
+  do {
+    prototype = Object.getPrototypeOf(obj)
+    // to work in iframe
+    prototypeStr = Object.prototype.toString.call(prototype)
+    // '[object Document]' is used to detect document
+    if (
+      prototypeStr === '[object Element]' ||
+      prototypeStr === '[object Document]'
+    ) {
+      return true
+    }
+    obj = prototype
+    // null is the terminal of object
+  } while (prototype !== null)
+
+  return false
+}
+
+function getElementClientCenter(element: HTMLElement) {
+  const { left, top, width, height } = element.getBoundingClientRect()
+
+  return {
+    x: left + width / 2,
+    y: top + height / 2,
+  }
+}
+
+const getCoords = (
+  charlie:
+    | HTMLElement
+    | {
+        x: number
+        y: number
+      }
+) => (isElement(charlie) ? getElementClientCenter(charlie) : charlie)
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+export default async function drag(
+  element: HTMLElement,
+  {
+    to: inTo,
+    delta,
+    steps = 20,
+    duration = 500,
+  }: {
+    to?: HTMLElement | { x: number; y: number }
+    delta?: {
+      x: number
+      y: number
+    }
+    steps?: number
+    duration?: number
+  }
+) {
+  const from = getElementClientCenter(element)
+  const to = delta
+    ? {
+        x: from.x + delta.x,
+        y: from.y + delta.y,
+      }
+    : inTo
+    ? getCoords(inTo)
+    : null
+
+  if (to === null) throw new Error('You must provide either `delta` or `to`')
+
+  const step = {
+    x: (to.x - from.x) / steps,
+    y: (to.y - from.y) / steps,
+  }
+
+  const current = {
+    clientX: from.x,
+    clientY: from.y,
+  }
+
+  fireEvent.mouseEnter(element, current)
+  fireEvent.mouseOver(element, current)
+  fireEvent.mouseMove(element, current)
+  fireEvent.mouseDown(element, current)
+  for (let i = 0; i < steps; i++) {
+    current.clientX += step.x
+    current.clientY += step.y
+    await sleep(duration / steps)
+    fireEvent.mouseMove(element, current)
+  }
+  fireEvent.mouseUp(element, current)
+}

--- a/packages/components/slider/__tests__/slider.test.tsx
+++ b/packages/components/slider/__tests__/slider.test.tsx
@@ -3,6 +3,9 @@ import {render, act} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {Slider, SliderValue} from "../src";
+
+import drag from "./drag";
+
 describe("Slider", () => {
   it("should render correctly", () => {
     const wrapper = render(<Slider />);
@@ -136,5 +139,33 @@ describe("Slider", () => {
     expect(output).toHaveTextContent("55");
 
     expect(setValues).toStrictEqual([55]);
+  });
+
+  it("should not get stuck at the end when dragging", async function () {
+    const {getByRole, getAllByRole} = render(<Slider hasSingleThumb={false} />);
+
+    const [leftHandle, rightHandle] = getAllByRole("slider");
+    const output = getByRole("status");
+
+    const MORE_THAN_SLIDER_WIDTH = 600;
+
+    await drag(rightHandle, {
+      delta: {x: MORE_THAN_SLIDER_WIDTH, y: 0},
+    });
+    await drag(leftHandle, {
+      delta: {x: MORE_THAN_SLIDER_WIDTH, y: 0},
+    });
+    // It actually drags the leftHandle, because it's on top
+    await drag(rightHandle, {
+      delta: {x: -1 * MORE_THAN_SLIDER_WIDTH, y: 0},
+    });
+
+    expect(leftHandle).toHaveProperty("value", "0");
+    expect(leftHandle).toHaveAttribute("aria-valuetext", "0");
+    expect(output).toHaveTextContent("0");
+
+    expect(rightHandle).toHaveProperty("value", "100");
+    expect(rightHandle).toHaveAttribute("aria-valuetext", "100");
+    expect(output).toHaveTextContent("100");
   });
 });

--- a/packages/components/slider/src/use-slider-thumb.ts
+++ b/packages/components/slider/src/use-slider-thumb.ts
@@ -76,7 +76,7 @@ export function useSliderThumb(props: UseSliderThumbProps) {
 
   const numberFormatter = useNumberFormatter(formatOptions);
 
-  const {thumbProps, inputProps, isDragging} = useAriaSliderThumb(
+  const {thumbProps, inputProps, isDragging, isFocused} = useAriaSliderThumb(
     {
       index,
       trackRef,
@@ -102,6 +102,7 @@ export function useSliderThumb(props: UseSliderThumbProps) {
       "data-hover": dataAttr(isHovered),
       "data-pressed": dataAttr(isPressed),
       "data-dragging": dataAttr(isDragging),
+      "data-focused": dataAttr(isFocused),
       "data-focus-visible": dataAttr(isFocusVisible),
       ...mergeProps(thumbProps, pressProps, hoverProps, otherProps),
       className,

--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -62,6 +62,7 @@ const slider = tv({
       "after:shadow-small",
       "after:shadow-small",
       "after:bg-background",
+      "data-[focused=true]:z-10",
       dataFocusVisibleClasses,
     ],
     startContent: [],


### PR DESCRIPTION
## 📝 Description

Fixes https://github.com/nextui-org/nextui/pull/1686#issuecomment-1742695941

## ⛳️ Current behavior (updates)

There is a bug in the slider that if both handles are placed on the right side, then they can't be draged on to another position, leaving the user stuck. There's still a way to move the handles, using the kayboard or clicking on the track, but the user may not know that those inputs work. 

## 🚀 New behavior

Now, the last grabbed handle has the data attribute `data-focused`. Now, the user can't get stuch at an end. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

With this fix, it's still not possible to "swap" the handles by draging one over the other, wich would be a nice feature, but not important.

>  I came up with the solution looking at [the implementation](https://github.com/adobe/react-spectrum/blob/db43a95681e4e0f8d45d5fc6746ac3c1694bc331/packages/%40react-spectrum/slider/src/SliderThumb.tsx#L55) of the [react-spectrum's slider](https://react-spectrum.adobe.com/react-spectrum/Slider.html), that uses React Aria too.