### PR TITLE
fix(button): show only spinner if button isLoading & isIconOnly

### DIFF
--- a/.changeset/chatty-tools-invent.md
+++ b/.changeset/chatty-tools-invent.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/button": patch
+---
+
+The button with only the icon now displays only the spinner during loading

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -21,7 +21,19 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     disableRipple,
     getButtonProps,
     getRippleProps,
+    isIconOnly,
   } = useButton({...props, ref});
+
+  if (isIconOnly && isLoading) {
+    return (
+      <Component ref={domRef} className={styles} {...getButtonProps()}>
+        {startContent}
+        {isLoading && spinner}
+        {endContent}
+        {!disableRipple && <Ripple {...getRippleProps()} />}
+      </Component>
+    );
+  }
 
   return (
     <Component ref={domRef} className={styles} {...getButtonProps()}>

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -24,22 +24,11 @@ const Button = forwardRef<"button", ButtonProps>((props, ref) => {
     isIconOnly,
   } = useButton({...props, ref});
 
-  if (isIconOnly && isLoading) {
-    return (
-      <Component ref={domRef} className={styles} {...getButtonProps()}>
-        {startContent}
-        {isLoading && spinner}
-        {endContent}
-        {!disableRipple && <Ripple {...getRippleProps()} />}
-      </Component>
-    );
-  }
-
   return (
     <Component ref={domRef} className={styles} {...getButtonProps()}>
       {startContent}
       {isLoading && spinnerPlacement === "start" && spinner}
-      {children}
+      {isLoading && isIconOnly ? null : children}
       {isLoading && spinnerPlacement === "end" && spinner}
       {endContent}
       {!disableRipple && <Ripple {...getRippleProps()} />}

--- a/packages/components/button/src/use-button.ts
+++ b/packages/components/button/src/use-button.ts
@@ -229,6 +229,7 @@ export function useButton(props: UseButtonProps) {
     disableRipple,
     getButtonProps,
     getRippleProps,
+    isIconOnly,
   };
 }
 


### PR DESCRIPTION
## 📝 Description

The button with only icon doesn't look very good during loading, in my opinion. That's why I decided to suggest displaying only the spinner when loading is in progress.

## ⛳️ Current behavior (updates)

![before dark](https://i.imgur.com/JXP1Cnm.jpg)
![before light](https://i.imgur.com/zhmTuZi.jpg)

## 🚀 New behavior

![after dark](https://i.imgur.com/K8AfHRe.jpg)
![after light](https://i.imgur.com/PI6QahT.jpg)

## 💣 Is this a breaking change (Yes/No):

No
