### PR TITLE
fix(navbar): fixed the height of navbar menu

### DIFF
--- a/packages/components/navbar/src/navbar-menu-transitions.ts
+++ b/packages/components/navbar/src/navbar-menu-transitions.ts
@@ -2,7 +2,7 @@ import {Variants} from "framer-motion";
 
 export const menuVariants: Variants = {
   enter: {
-    height: "calc(100vh - var(--navbar-height) - 1px)",
+    height: "calc(100vh - var(--navbar-height))",
     transition: {
       duration: 0.3,
       easings: "easeOut",

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -51,6 +51,7 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
         style={{
           // @ts-expect-error
           "--navbar-height": height,
+          height: "calc(100vh - var(--navbar-height))",
         }}
         {...otherProps}
       >

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -51,7 +51,6 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
         style={{
           // @ts-expect-error
           "--navbar-height": height,
-          height: "calc(100vh - var(--navbar-height))",
         }}
         {...otherProps}
       >

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -230,7 +230,7 @@ const navbar = tv({
     },
     disableAnimation: {
       true: {
-        menu: ["hidden", "h-[calc(100vh_-_var(--navbar-height))]", "data-[open=true]:flex"],
+        menu: ["hidden", "h-[calc(100dvh_-_var(--navbar-height))]", "data-[open=true]:flex"],
       },
     },
   },

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -165,7 +165,6 @@ const navbar = tv({
       "flex",
       "max-w-full",
       "top-[var(--navbar-height)]",
-      "h-[calc(100vh_-_var(--navbar-height))]",
       "inset-x-0",
       "bottom-0",
       "w-screen",
@@ -231,7 +230,7 @@ const navbar = tv({
     },
     disableAnimation: {
       true: {
-        menu: ["hidden", "data-[open=true]:flex"],
+        menu: ["hidden", "h-[calc(100vh_-_var(--navbar-height))]", "data-[open=true]:flex"],
       },
     },
   },

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -231,7 +231,7 @@ const navbar = tv({
     },
     disableAnimation: {
       true: {
-        menu: ["hidden", "h-[calc(100dvh_-_var(--navbar-height))]", "data-[open=true]:flex"],
+        menu: ["hidden", "data-[open=true]:flex"],
       },
     },
   },

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -165,6 +165,7 @@ const navbar = tv({
       "flex",
       "max-w-full",
       "top-[var(--navbar-height)]",
+      "h-[calc(100vh_-_var(--navbar-height))]",
       "inset-x-0",
       "bottom-0",
       "w-screen",
@@ -230,7 +231,7 @@ const navbar = tv({
     },
     disableAnimation: {
       true: {
-        menu: ["hidden", "h-[calc(100dvh_-_var(--navbar-height)_-_1px)]", "data-[open=true]:flex"],
+        menu: ["hidden", "h-[calc(100dvh_-_var(--navbar-height))]", "data-[open=true]:flex"],
       },
     },
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

Modify the Navbar Menu modal styling when it's open.

## ⛳️ Current behavior (updates)

There's a slight gap between the bottom of the modal and the page.
Content behind the modal is visible through the gap.

## 🚀 New behavior

|before|after|
|--|--|
|![スクリーンショット 2023-10-25 12 50 13](https://github.com/nextui-org/nextui/assets/121233810/c8c175fb-1c49-4bb8-bcd0-7dc10152cccf)|![スクリーンショット 2023-10-25 12 49 47](https://github.com/nextui-org/nextui/assets/121233810/929ce0a7-cdc0-418f-94ca-59a996409b81)|

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Nothing special👍


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved height calculation for the navbar to better fit the viewport.
  - Corrected a typo in the menu height calculation when animation is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->