### PR TITLE
Fix blur/opaque Popover

### DIFF
--- a/packages/components/popover/src/use-popover.ts
+++ b/packages/components/popover/src/use-popover.ts
@@ -1,7 +1,7 @@
 import type {PopoverVariantProps, SlotsToClasses, PopoverSlots} from "@nextui-org/theme";
 import type {HTMLMotionProps} from "framer-motion";
 
-import {RefObject, Ref, useEffect, useState} from "react";
+import {RefObject, Ref, useEffect} from "react";
 import {ReactRef, useDOMRef} from "@nextui-org/react-utils";
 import {OverlayTriggerState, useOverlayTriggerState} from "@react-stately/overlays";
 import {useFocusRing} from "@react-aria/focus";
@@ -111,9 +111,9 @@ export function usePopover(originalProps: UsePopoverProps) {
   const Component = as || "div";
 
   const domRef = useDOMRef(ref);
-  const [wasTriggerPressed, setWasTriggerPressed] = useState(false);
 
   const domTriggerRef = useRef<HTMLElement>(null);
+  const wasTriggerPressedRef = useRef(false);
 
   const triggerRef = triggerRefProp || domTriggerRef;
 
@@ -218,10 +218,10 @@ export function usePopover(originalProps: UsePopoverProps) {
         (originalProps?.backdrop === "blur" || originalProps?.backdrop === "opaque")
       ) {
         pressTimer = setTimeout(() => {
-          setWasTriggerPressed(true);
+          wasTriggerPressedRef.current = true;
         }, 100);
       } else {
-        setWasTriggerPressed(true);
+        wasTriggerPressedRef.current = true;
       }
 
       triggerProps.onPress?.(e);
@@ -252,14 +252,14 @@ export function usePopover(originalProps: UsePopoverProps) {
       "data-slot": "backdrop",
       className: slots.backdrop({class: classNames?.backdrop}),
       onClick: (e) => {
-        if (!wasTriggerPressed) {
+        if (!wasTriggerPressedRef.current) {
           e.preventDefault();
 
           return;
         }
 
         state.close();
-        setWasTriggerPressed(false);
+        wasTriggerPressedRef.current = false;
       },
       ...underlayProps,
       ...props,

--- a/packages/components/popover/stories/popover.stories.tsx
+++ b/packages/components/popover/stories/popover.stories.tsx
@@ -344,6 +344,50 @@ const WithFormTemplate = (args: PopoverProps) => (
   </Popover>
 );
 
+const BackdropsTemplate = (args: PopoverProps) => {
+  const backdrops: PopoverProps["backdrop"][] = ["opaque", "blur", "transparent"];
+
+  const content = (
+    <PopoverContent className="w-[240px]">
+      {(titleProps) => (
+        <div className="px-1 py-2 w-full">
+          <p className="text-small font-bold text-foreground" {...titleProps}>
+            Dimensions
+          </p>
+          <div className="mt-2 flex flex-col gap-2 w-full">
+            <Input defaultValue="100%" label="Width" size="sm" variant="bordered" />
+            <Input defaultValue="300px" label="Max. width" size="sm" variant="bordered" />
+            <Input defaultValue="24px" label="Height" size="sm" variant="bordered" />
+            <Input defaultValue="30px" label="Max. height" size="sm" variant="bordered" />
+          </div>
+        </div>
+      )}
+    </PopoverContent>
+  );
+
+  return (
+    <div className="flex flex-wrap gap-4">
+      {backdrops.map((backdrop) => (
+        <Popover
+          key={backdrop}
+          showArrow
+          offset={10}
+          placement="bottom"
+          {...args}
+          backdrop={backdrop}
+        >
+          <PopoverTrigger>
+            <Button className="capitalize" color="warning" variant="flat">
+              {backdrop}
+            </Button>
+          </PopoverTrigger>
+          {content}
+        </Popover>
+      ))}
+    </div>
+  );
+};
+
 const WithBackdropTemplate = (args: PopoverProps) => (
   <Card isFooterBlurred className="w-[420px] h-[400px] col-span-12 sm:col-span-7">
     <CardHeader className="absolute z-10 top-1 flex-col items-start">
@@ -471,6 +515,17 @@ export const WithForm = {
     offset: 10,
     placement: "top",
     className: "w-[280px] bg-content1",
+  },
+};
+
+export const Backdrops = {
+  render: BackdropsTemplate,
+
+  args: {
+    ...defaultProps,
+    showArrow: true,
+    offset: 10,
+    placement: "bottom",
   },
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1737 
Closes #1650 

## 📝 Description

Fixing the Popover open state for blut/opaque backdrops

## ⛳️ Current behavior (updates)

The Popover doesn't open on mobile devices when the backdrop is `opaque` or `blur`

## 🚀 New behavior

The issue was fixed

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
