### PR TITLE
chore(docs): fix typo in progress component

### DIFF
--- a/apps/docs/content/components/progress/custom-styles.ts
+++ b/apps/docs/content/components/progress/custom-styles.ts
@@ -12,7 +12,7 @@ export default function App() {
         label: "tracking-wider font-medium text-default-600",
         value: "text-foreground/60",
       }}
-      label="Lose weight"
+      label="Loose weight"
       value={65}
       showValueLabel={true}
     />


### PR DESCRIPTION
## 📝 Description

> I fixed a typo in the custom styles section in the Progress component. Changed `Lose` to `Loose`

## ⛳️ Current behavior (updates)

> typo in the custom styles section in the Progress component

## 🚀 New behavior

> Fixed the typo

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Here is the link to that issue from the docs https://nextui.org/docs/components/progress#custom-styles