### PR TITLE
Autocomplete component (Multiple Selection) 

### DIFF
--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -29,6 +29,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
     getClearButtonProps,
     getListBoxWrapperProps,
     getEndContentWrapperProps,
+    getTagContainerProps,
   } = useAutocomplete<T>({...props, ref});
   const popoverContent = isOpen ? (
     <FreeSoloPopover {...getPopoverProps()} state={state}>
@@ -40,7 +41,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
 
   const multipleTagListContent =
     props.selectionMode === "multiple" && state.selectedKeys ? (
-      <React.Fragment>
+      <div {...getTagContainerProps()}>
         {Array.from(state.selectedKeys).map((key) => (
           <Chip
             key={key}
@@ -55,7 +56,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
             {state.collection.getItem(key)?.rendered}
           </Chip>
         ))}
-      </React.Fragment>
+      </div>
     ) : null;
 
   return (

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -30,7 +30,6 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
     getListBoxWrapperProps,
     getEndContentWrapperProps,
   } = useAutocomplete<T>({...props, ref});
-
   const popoverContent = isOpen ? (
     <FreeSoloPopover {...getPopoverProps()} state={state}>
       <ScrollShadow {...getListBoxWrapperProps()}>
@@ -40,7 +39,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
   ) : null;
 
   const multipleTagListContent =
-    props.selectionMode === "multiple" ? (
+    props.selectionMode === "multiple" && state.selectedKeys ? (
       <React.Fragment>
         {Array.from(state.selectedKeys).map((key) => (
           <Chip
@@ -53,7 +52,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
               return state.setSelectedKeys(cloneSet);
             }}
           >
-            {key}
+            {state.collection.getItem(key)?.rendered}
           </Chip>
         ))}
       </React.Fragment>

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -102,6 +102,10 @@ interface Props<T> extends Omit<HTMLNextUIProps<"input">, keyof ComboBoxProps<T>
    * Callback fired when the select menu is closed.
    */
   onClose?: () => void;
+  /**
+   *  Whether the autocomplete selection mode is single or multiple.
+   *  @default "single"
+   */
   selectionMode?: "single" | "multiple";
 }
 

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -398,6 +398,18 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     }),
   });
 
+  const getTagContainerProps: PropGetter = useCallback(
+    (props = {}) => {
+      return {
+        ...props,
+        className: slots.tagContainer({
+          class: clsx(classNames?.tagContainer, props?.className),
+        }),
+      };
+    },
+    [slots, classNames?.tagContainer],
+  );
+
   const getEndContentWrapperProps: PropGetter = (props: any = {}) => ({
     className: slots.endContentWrapper({
       class: clsx(classNames?.endContentWrapper, props?.className),
@@ -432,6 +444,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     getSelectorButtonProps,
     getListBoxWrapperProps,
     getEndContentWrapperProps,
+    getTagContainerProps,
   };
 }
 

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -364,8 +364,8 @@ const ItemStartContentTemplate = ({color, variant, ...args}: AutocompleteProps<A
 const ControlledTemplate = ({color, variant, ...args}: AutocompleteProps<Animal>) => {
   const [value, setValue] = React.useState<Key>("cat");
 
-  const handleSelectionChange = (key: Key) => {
-    setValue(key);
+  const handleSelectionChange = (keys: Selection) => {
+    setValue(keys[0]);
   };
 
   return (

--- a/packages/core/theme/src/components/autocomplete.ts
+++ b/packages/core/theme/src/components/autocomplete.ts
@@ -9,6 +9,7 @@ const autocomplete = tv({
     listbox: "",
     popoverContent: "w-full p-1 overflow-hidden",
     endContentWrapper: "relative flex h-full items-center -mr-2",
+    tagContainer: "flex flex-wrap gap-2",
     clearButton: [
       "text-medium",
       "translate-x-1",

--- a/packages/hooks/use-aria-multiselect/src/use-multicombo-box-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multicombo-box-state.ts
@@ -9,21 +9,21 @@ import {
 import {ComboBoxProps, MenuTriggerAction} from "@react-types/combobox";
 import {getChildNodes} from "@react-stately/collections";
 import {ListCollection} from "@react-stately/list";
-import {SelectState} from "@react-stately/select";
 import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {useControlledState} from "@react-stately/utils";
 import {useMenuTriggerState} from "@react-stately/menu";
 
 import {useMultiSelectListState} from "./use-multiselect-list-state";
+import {MultiSelectState} from "./use-multiselect-state";
 
-type SingleSelectionKeys =
-  | "selectedKey"
-  | "defaultSelectedKey"
+type MultiSelectionKeys =
+  | "selectedKeys"
+  | "defaultSelectedKeys"
   | "onSelectionChange"
   | keyof MultipleSelection;
 
 export interface ComboBoxState<T>
-  extends Omit<SelectState<T>, SingleSelectionKeys>,
+  extends Omit<MultiSelectState<T>, MultiSelectionKeys>,
     MultipleSelection {
   /** The current value of the combo box input. */
   inputValue: string;
@@ -42,7 +42,7 @@ export interface ComboBoxState<T>
 type FilterFn = (textValue: string, inputValue: string) => boolean;
 
 export interface ComboBoxStateOptions<T>
-  extends Omit<ComboBoxProps<T>, "children" | SingleSelectionKeys>,
+  extends Omit<ComboBoxProps<T>, "children" | MultiSelectionKeys>,
     CollectionStateBase<T>,
     MultipleSelection {
   /** The contents of the collection. */
@@ -55,6 +55,8 @@ export interface ComboBoxStateOptions<T>
   shouldCloseOnBlur?: boolean;
   /** Whether the combo box allows multiple selection. */
   selectionMode?: "single" | "multiple";
+  /** Set the selected keys. */
+  setSelectedKeys(keys: Set<string>): void;
 }
 
 /**


### PR DESCRIPTION
# 📝 Description
Add support for multiple selection via selectionMode "single" or "multiple" to the autocomplete component.

# ⛳️ Current behavior (updates)
The current behavior only allows single selection. This is because react-stately uses useComboStateProps, which only allows for single selection. The "multi" version in react-stately doesn't seem to be a complete project: https://github.com/adobe/react-spectrum/issues/2140.
What I propose is to create a new hook called "useMultiComboBoxState" and tweak the original behavior to allow for both multiple and single selection.

# 🚀 New behavior
Allow the user to select multiple elements using selectionMode.

# 💣 Is this a breaking change (Yes/No):
No

# 📝 Additional Information
This is a work in progress. Since this is my first PR, please don't hesitate to guide me through the coding and/or style.