### PR TITLE
fix(docs): fixed select state component on docs page

### DIFF
--- a/apps/docs/content/components/select/open-state.ts
+++ b/apps/docs/content/components/select/open-state.ts
@@ -47,7 +47,7 @@ export default function App() {
           </SelectItem>
         ))}
       </Select>
-      <Button aria-label="Open" aria-pressed={isOpen} onPress={() => setIsOpen(!isOpen)}>
+      <Button aria-label="Open" aria-pressed={isOpen} onClick={() => setIsOpen(!isOpen)}>
         {isOpen ? "Close" : "Open"}
       </Button>
     </div>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1762 

## 📝 Description

> Add a brief description

Component on docs page was using `onPress` hook instead of needed `onClick` hook.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

I am updating a controlled state component that currently only opens on click, but won't close no matter what.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Controlling the open state select component now functions properly (open and closes on each click) (https://nextui.org/docs/components/select#controlling-the-open-state)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
