### PR TITLE
Typo fix

### DIFF
--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -160,7 +160,7 @@ function AppTabs() {
 }
 ```
 
-> **Note**: See the [Routing guide](/docs/guides/routing) to learn how to set up the router for your framework.
+> **Note**: See the [Routing guide](/docs/guide/routing) to learn how to set up the router for your framework.
 
 ### With Form
 


### PR DESCRIPTION
 ## 📝 Description

The link was pointing to the wrong path.
 
  
