### PR TITLE
Fix/input select helper position

### DIFF
--- a/.changeset/quiet-hounds-teach.md
+++ b/.changeset/quiet-hounds-teach.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/input": patch
+"@nextui-org/theme": patch
+---
+
+Input, Textarea, Select, Autocomplete and Textarea helper wrapper styles fixed

--- a/packages/components/input/stories/input.stories.tsx
+++ b/packages/components/input/stories/input.stories.tsx
@@ -501,7 +501,7 @@ export const WithDescription = {
 
   args: {
     ...defaultProps,
-    description: "We'll never share your email with anyone else. ",
+    description: "We'll never share your email with anyone else.",
   },
 };
 

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -23,7 +23,7 @@ import {dataFocusVisibleClasses, groupDataFocusVisibleClasses} from "../utils";
  */
 const input = tv({
   slots: {
-    base: ["group flex relative flex-col", "data-[has-helper=true]:mb-4"],
+    base: "group flex flex-col",
     label: [
       "absolute",
       "z-10",
@@ -61,7 +61,7 @@ const input = tv({
       // focus ring
       ...dataFocusVisibleClasses,
     ],
-    helperWrapper: "flex absolute -bottom-[calc(theme(fontSize.tiny)*1.5)] flex-col gap-1.5 px-1",
+    helperWrapper: "p-1 flex relative flex-col gap-1.5",
     description: "text-tiny text-foreground-400",
     errorMessage: "text-tiny text-danger",
   },

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -5,7 +5,7 @@ import {tv} from "../utils/tv";
 
 const select = tv({
   slots: {
-    base: ["group inline-flex flex-col relative w-full", "data-[has-helper=true]:mb-4"],
+    base: ["group inline-flex flex-col relative w-full"],
     label: [
       "block",
       "absolute",
@@ -27,7 +27,7 @@ const select = tv({
     listboxWrapper: "scroll-py-6 max-h-64 w-full",
     listbox: "",
     popoverContent: "w-full p-1 overflow-hidden",
-    helperWrapper: "flex absolute -bottom-[calc(theme(fontSize.tiny)*1.5)] flex-col gap-1.5 px-1",
+    helperWrapper: "p-1 flex relative flex-col gap-1.5",
     description: "text-tiny text-foreground-400",
     errorMessage: "text-tiny text-danger",
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Helper wrapper absolute position breaks the `Input`, `Textarea`, `Select` and `Autocomplete` layout when having long descriptions/error messages.

## ⛳️ Current behavior (updates)

![CleanShot 2023-11-05 at 19 47 01](https://github.com/nextui-org/nextui/assets/30373425/d663657b-e70b-47ff-bc02-8c0693acb48e)

## 🚀 New behavior

`helperWrapper` is no longer absolute to its parent.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
