### PR TITLE
chore(textarea): refactor Textarea component props and add hasHelper prop

### DIFF
--- a/.changeset/happy-rice-walk.md
+++ b/.changeset/happy-rice-walk.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Texarea label validation added to avoid rendering the element when there is no label.

--- a/packages/components/input/src/textarea.tsx
+++ b/packages/components/input/src/textarea.tsx
@@ -18,9 +18,7 @@ type OmittedInputProps =
   | "isClearButtonFocusVisible"
   | "isLabelPlaceholder"
   | "isClearable"
-  | "isTextarea"
-  | "startContent"
-  | "endContent";
+  | "isTextarea";
 
 export type TextareaHeightChangeMeta = {
   rowHeight: number;
@@ -77,6 +75,7 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
       description,
       startContent,
       endContent,
+      hasHelper,
       shouldLabelBeOutside,
       shouldLabelBeInside,
       errorMessage,
@@ -92,7 +91,7 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
 
     const [hasMultipleRows, setIsHasMultipleRows] = useState(minRows > 1);
     const [isLimitReached, setIsLimitReached] = useState(false);
-    const labelContent = <label {...getLabelProps()}>{label}</label>;
+    const labelContent = label ? <label {...getLabelProps()}>{label}</label> : null;
     const inputProps = getInputProps();
 
     const handleHeightChange = (height: number, meta: TextareaHeightChangeMeta) => {
@@ -143,13 +142,15 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
           {shouldLabelBeInside ? labelContent : null}
           {innerWrapper}
         </div>
-        <div {...getHelperWrapperProps()}>
-          {errorMessage ? (
-            <div {...getErrorMessageProps()}>{errorMessage}</div>
-          ) : description ? (
-            <div {...getDescriptionProps()}>{description}</div>
-          ) : null}
-        </div>
+        {hasHelper ? (
+          <div {...getHelperWrapperProps()}>
+            {errorMessage ? (
+              <div {...getErrorMessageProps()}>{errorMessage}</div>
+            ) : description ? (
+              <div {...getDescriptionProps()}>{description}</div>
+            ) : null}
+          </div>
+        ) : null}
       </Component>
     );
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- [x] Validation added to not render the label when it is not passed.
- [x] `startContent` and `endContent` props were removed from the omitted ones. 

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
