### PR TITLE
fix(system): add "size" prop to HTMLNextUIProps

### DIFF
--- a/.changeset/hip-dingos-happen.md
+++ b/.changeset/hip-dingos-happen.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system-rsc": patch
+---
+
+Fix #1935 size prop added to the omitted HTMLNextUIProps

--- a/packages/core/system-rsc/src/types.ts
+++ b/packages/core/system-rsc/src/types.ts
@@ -70,7 +70,7 @@ export type Merge<M, N> = N extends Record<string, unknown> ? M : Omit<M, keyof 
 
 export type HTMLNextUIProps<T extends As = "div", OmitKeys extends keyof any = never> = Omit<
   PropsOf<T>,
-  "ref" | "color" | "slot" | "defaultChecked" | "defaultValue" | OmitKeys
+  "ref" | "color" | "slot" | "size" | "defaultChecked" | "defaultValue" | OmitKeys
 > & {
   as?: As;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1935 

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

The size prop is not beign recognized by the `Autocomplete` component.

## 🚀 New behavior

The `size` key was added to the omitted system HTML props.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
