### PR TITLE
fix(tabs): selected key prop duplicated type removed

### DIFF
--- a/.changeset/silent-lemons-mate.md
+++ b/.changeset/silent-lemons-mate.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": patch
+---
+
+Fix #1938 selectedKey duplicated declaration

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -51,7 +51,7 @@ export interface Props extends Omit<HTMLNextUIProps, "children"> {
 
 export type UseTabsProps<T> = Props &
   TabsVariantProps &
-  Omit<TabListStateOptions<T>, "children"> &
+  Omit<TabListStateOptions<T>, "children" | keyof AriaTabListProps<T>> &
   Omit<AriaTabListProps<T>, "children" | "orientation"> &
   CollectionProps<T>;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1938 

## 📝 Description

Selected key type fixed in `Tabs` component.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
