### PR TITLE
Fix/autocomplete ref

### DIFF
--- a/.changeset/lucky-chefs-remain.md
+++ b/.changeset/lucky-chefs-remain.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Autocomplete Reference aims to input instead of aiming to the wrapper element

--- a/.changeset/silent-lemons-mate.md
+++ b/.changeset/silent-lemons-mate.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": patch
+---
+
+Fix #1938 selectedKey duplicated declaration

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -177,10 +177,10 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   // Setup refs and get props for child elements.
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
   const inputWrapperRef = useRef<HTMLDivElement>(null);
   const listBoxRef = useRef<HTMLUListElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
+  const inputRef = useDOMRef<HTMLInputElement>(ref);
   const scrollShadowRef = useDOMRef<HTMLElement>(scrollRefProp);
 
   const slotsProps: {
@@ -293,8 +293,6 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   const Component = as || "div";
 
-  const domRef = useDOMRef(ref);
-
   const slots = useMemo(
     () =>
       autocomplete({
@@ -320,7 +318,6 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
   );
 
   const getBaseProps: PropGetter = () => ({
-    ref: domRef,
     "data-invalid": dataAttr(originalProps?.isInvalid),
     "data-open": dataAttr(state.isOpen),
     className: slots.base({class: baseStyles}),
@@ -419,7 +416,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   return {
     Component,
-    domRef,
+    inputRef,
     label,
     state,
     slots,

--- a/packages/components/tabs/src/use-tabs.ts
+++ b/packages/components/tabs/src/use-tabs.ts
@@ -51,7 +51,7 @@ export interface Props extends Omit<HTMLNextUIProps, "children"> {
 
 export type UseTabsProps<T> = Props &
   TabsVariantProps &
-  Omit<TabListStateOptions<T>, "children"> &
+  Omit<TabListStateOptions<T>, "children" | keyof AriaTabListProps<T>> &
   Omit<AriaTabListProps<T>, "children" | "orientation"> &
   CollectionProps<T>;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #

## ⛳️ Current behavior (updates)

Currently the autocomplete reference is passed to the wrapper instead of the input

## 🚀 New behavior

Reference passed to the input element

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
