### PR TITLE
fix(docs): wrong tooltip classNames type

### DIFF
--- a/apps/docs/content/docs/components/tooltip.mdx
+++ b/apps/docs/content/docs/components/tooltip.mdx
@@ -140,7 +140,7 @@ You can customize the `Tooltip` component by passing custom Tailwind CSS classes
 | updatePositionDeps        | `any[]`                                                                     | The dependencies to force the tooltip position update.                                                       | `[]`            |
 | isDisabled                | `boolean`                                                                   | Whether the tooltip is disabled.                                                                             | `false`         |
 | disableAnimation          | `boolean`                                                                   | Whether the tooltip is animated.                                                                             | `false`         |
-| classNames                | `Record<"base"｜"arrow", string>`                                           | Allows to set custom class names for the tooltip slots.                                                      | -               |
+| classNames                | `Record<"base"｜"content", string>`                                           | Allows to set custom class names for the tooltip slots.                                                      | -               |
 
 <Spacer y={1} />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

In version 2.2.x, the classNames prop for tooltips is not of type Record<"base"｜"arrow", string>, it should be of type Record<"base"｜"content", string>.
![image](https://github.com/nextui-org/nextui/assets/62697454/3dae89d8-b02c-4a7e-90c7-5c1ce59a3187)
