### PR TITLE
chore: remove `tsup`, use `tsc` instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ packages/**/.turbo
 
 # content layer
 .contentlayer
+
+cjs

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -14,7 +14,6 @@ Hello!, I am very excited that you are interested in contributing with Next UI. 
 ### Tooling
 
 - [PNPM](https://pnpm.io/) to manage packages and dependencies
-- [Tsup](https://tsup.egoist.sh/) to bundle packages
 - [Storybook](https://storybook.js.org/) for rapid UI component development and
   testing
 - [Testing Library](https://testing-library.com/) for testing components and

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "scripts": {
+    "dev": "rimraf .contentlayer && concurrently \"contentlayer dev\" \"next dev\"",
     "build": "contentlayer build && next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0",
   "private": true,
   "scripts": {
-    "dev": "rimraf .contentlayer && concurrently \"contentlayer dev\" \"next dev\"",
     "build": "contentlayer build && next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",

--- a/clean-package.config.json
+++ b/clean-package.config.json
@@ -7,8 +7,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
+        "import": "./dist/index.js",
+        "require": "./cjs/index.js"
       },
       "./package.json": "./package.json"
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "dev": "pnpm sb && pnpm dev:docs",
     "build": "turbo build --filter=!@nextui-org/docs --filter=!@nextui-org/storybook",
-    "build:fast": "turbo build:fast --filter=!@nextui-org/docs --filter=!@nextui-org/storybook",
     "dev:docs": "turbo dev --filter=@nextui-org/docs",
     "build:docs": "turbo build --filter=@nextui-org/docs",
     "build:docs-meta": "node ./scripts/update-index-docs.js",
@@ -129,7 +128,6 @@
     "react-dom": "^18.0.0",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.4",
-    "tsup": "6.4.0",
     "turbo": "1.6.3",
     "typescript": "^4.9.5",
     "webpack": "^5.53.0",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -17,7 +17,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -31,9 +32,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/accordion/src/index.ts
+++ b/packages/components/accordion/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import AccordionItem from "./base/accordion-item-base";
 import Accordion from "./accordion";
 

--- a/packages/components/accordion/tsup.config.ts
+++ b/packages/components/accordion/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/autocomplete/src/index.ts
+++ b/packages/components/autocomplete/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import type {ListboxItemProps, ListboxSectionProps} from "@nextui-org/listbox";
 import type {MenuTriggerAction as BaseMenuTriggerAction} from "@react-types/combobox";
 

--- a/packages/components/autocomplete/tsup.config.ts
+++ b/packages/components/autocomplete/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/avatar/package.json
+++ b/packages/components/avatar/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/avatar/src/index.ts
+++ b/packages/components/avatar/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Avatar from "./avatar";
 import AvatarGroup from "./avatar-group";
 

--- a/packages/components/avatar/tsup.config.ts
+++ b/packages/components/avatar/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/badge/package.json
+++ b/packages/components/badge/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/badge/src/index.ts
+++ b/packages/components/badge/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {BadgeProps} from "./badge";
 

--- a/packages/components/badge/tsup.config.ts
+++ b/packages/components/badge/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/breadcrumbs/package.json
+++ b/packages/components/breadcrumbs/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/breadcrumbs/package.json
+++ b/packages/components/breadcrumbs/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/breadcrumbs/src/index.ts
+++ b/packages/components/breadcrumbs/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Breadcrumbs from "./breadcrumbs";
 import BreadcrumbItem from "./breadcrumb-item";
 

--- a/packages/components/breadcrumbs/tsup.config.ts
+++ b/packages/components/breadcrumbs/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/button/src/index.ts
+++ b/packages/components/button/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Button from "./button";
 import ButtonGroup from "./button-group";
 

--- a/packages/components/button/tsup.config.ts
+++ b/packages/components/button/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/card/src/index.ts
+++ b/packages/components/card/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {CardProps} from "./card";
 export type {CardFooterProps} from "./card-footer";

--- a/packages/components/card/tsup.config.ts
+++ b/packages/components/card/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/checkbox/src/index.ts
+++ b/packages/components/checkbox/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Checkbox from "./checkbox";
 import CheckboxGroup from "./checkbox-group";
 

--- a/packages/components/checkbox/tsup.config.ts
+++ b/packages/components/checkbox/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/chip/package.json
+++ b/packages/components/chip/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/chip/package.json
+++ b/packages/components/chip/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/chip/src/index.ts
+++ b/packages/components/chip/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {ChipProps} from "./chip";
 

--- a/packages/components/chip/tsup.config.ts
+++ b/packages/components/chip/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/code/package.json
+++ b/packages/components/code/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/code/package.json
+++ b/packages/components/code/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/code/src/index.ts
+++ b/packages/components/code/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Code from "./code";
 
 // export types

--- a/packages/components/code/tsup.config.ts
+++ b/packages/components/code/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/divider/src/index.ts
+++ b/packages/components/divider/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Divider from "./divider";
 
 // export types

--- a/packages/components/divider/tsup.config.ts
+++ b/packages/components/divider/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/dropdown/src/index.ts
+++ b/packages/components/dropdown/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import type {MenuItemProps, MenuSectionProps} from "@nextui-org/menu";
 
 import {MenuItem, MenuSection} from "@nextui-org/menu";

--- a/packages/components/dropdown/tsup.config.ts
+++ b/packages/components/dropdown/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/image/package.json
+++ b/packages/components/image/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/image/package.json
+++ b/packages/components/image/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/image/src/index.ts
+++ b/packages/components/image/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Image from "./image";
 
 // export types

--- a/packages/components/image/tsup.config.ts
+++ b/packages/components/image/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/input/src/index.ts
+++ b/packages/components/input/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Input from "./input";
 import Textarea from "./textarea";
 

--- a/packages/components/input/tsup.config.ts
+++ b/packages/components/input/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/kbd/package.json
+++ b/packages/components/kbd/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/kbd/package.json
+++ b/packages/components/kbd/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/kbd/src/index.ts
+++ b/packages/components/kbd/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Kbd from "./kbd";
 
 // export types

--- a/packages/components/kbd/tsup.config.ts
+++ b/packages/components/kbd/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/link/package.json
+++ b/packages/components/link/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/link/src/index.ts
+++ b/packages/components/link/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Link from "./link";
 
 // export types

--- a/packages/components/link/tsup.config.ts
+++ b/packages/components/link/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/listbox/package.json
+++ b/packages/components/listbox/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/listbox/package.json
+++ b/packages/components/listbox/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/listbox/src/index.ts
+++ b/packages/components/listbox/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Listbox from "./listbox";
 
 // export types

--- a/packages/components/listbox/tsup.config.ts
+++ b/packages/components/listbox/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/menu/src/index.ts
+++ b/packages/components/menu/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Menu from "./menu";
 
 // export types

--- a/packages/components/menu/tsup.config.ts
+++ b/packages/components/menu/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/modal/package.json
+++ b/packages/components/modal/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/modal/src/index.ts
+++ b/packages/components/modal/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Modal from "./modal";
 import ModalContent from "./modal-content";
 import ModalHeader from "./modal-header";

--- a/packages/components/modal/tsup.config.ts
+++ b/packages/components/modal/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/navbar/src/index.ts
+++ b/packages/components/navbar/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {NavbarProps} from "./navbar";
 export type {NavbarBrandProps} from "./navbar-brand";

--- a/packages/components/navbar/tsup.config.ts
+++ b/packages/components/navbar/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/pagination/package.json
+++ b/packages/components/pagination/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/pagination/src/index.ts
+++ b/packages/components/pagination/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Pagination from "./pagination";
 import PaginationItem from "./pagination-item";
 import PaginationCursor from "./pagination-cursor";

--- a/packages/components/pagination/tsup.config.ts
+++ b/packages/components/pagination/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/popover/package.json
+++ b/packages/components/popover/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/popover/src/index.ts
+++ b/packages/components/popover/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Popover from "./popover";
 import PopoverTrigger from "./popover-trigger";
 import PopoverContent from "./popover-content";

--- a/packages/components/popover/tsup.config.ts
+++ b/packages/components/popover/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/progress/package.json
+++ b/packages/components/progress/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/progress/package.json
+++ b/packages/components/progress/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/progress/src/index.ts
+++ b/packages/components/progress/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Progress from "./progress";
 import CircularProgress from "./circular-progress";
 

--- a/packages/components/progress/tsup.config.ts
+++ b/packages/components/progress/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/radio/src/index.ts
+++ b/packages/components/radio/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Radio from "./radio";
 import RadioGroup from "./radio-group";
 

--- a/packages/components/radio/tsup.config.ts
+++ b/packages/components/radio/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/ripple/package.json
+++ b/packages/components/ripple/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/ripple/package.json
+++ b/packages/components/ripple/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/ripple/src/index.ts
+++ b/packages/components/ripple/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Ripple from "./ripple";
 
 // export types

--- a/packages/components/ripple/tsup.config.ts
+++ b/packages/components/ripple/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/scroll-shadow/package.json
+++ b/packages/components/scroll-shadow/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/scroll-shadow/package.json
+++ b/packages/components/scroll-shadow/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/scroll-shadow/src/index.ts
+++ b/packages/components/scroll-shadow/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import ScrollShadow from "./scroll-shadow";
 
 // export types

--- a/packages/components/scroll-shadow/tsup.config.ts
+++ b/packages/components/scroll-shadow/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/select/src/index.ts
+++ b/packages/components/select/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import type {ListboxItemProps, ListboxSectionProps} from "@nextui-org/listbox";
 
 import {ListboxItem, ListboxSection} from "@nextui-org/listbox";

--- a/packages/components/select/tsup.config.ts
+++ b/packages/components/select/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/skeleton/package.json
+++ b/packages/components/skeleton/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/skeleton/src/index.ts
+++ b/packages/components/skeleton/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Skeleton from "./skeleton";
 
 // export types

--- a/packages/components/skeleton/tsup.config.ts
+++ b/packages/components/skeleton/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/slider/package.json
+++ b/packages/components/slider/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/slider/package.json
+++ b/packages/components/slider/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/slider/src/index.ts
+++ b/packages/components/slider/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Slider from "./slider";
 
 // export types

--- a/packages/components/slider/tsup.config.ts
+++ b/packages/components/slider/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/snippet/package.json
+++ b/packages/components/snippet/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/snippet/package.json
+++ b/packages/components/snippet/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/snippet/src/index.ts
+++ b/packages/components/snippet/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {SnippetProps} from "./snippet";
 

--- a/packages/components/snippet/tsup.config.ts
+++ b/packages/components/snippet/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/spacer/package.json
+++ b/packages/components/spacer/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/spacer/package.json
+++ b/packages/components/spacer/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/spacer/src/index.ts
+++ b/packages/components/spacer/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Spacer from "./spacer";
 
 // export types

--- a/packages/components/spacer/tsup.config.ts
+++ b/packages/components/spacer/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -13,7 +13,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -27,11 +28,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/spinner/package.json
+++ b/packages/components/spinner/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/spinner/src/index.ts
+++ b/packages/components/spinner/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {SpinnerProps} from "./spinner";
 

--- a/packages/components/spinner/tsup.config.ts
+++ b/packages/components/spinner/tsup.config.ts
@@ -1,7 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-});

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/switch/src/index.ts
+++ b/packages/components/switch/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Switch from "./switch";
 
 // export types

--- a/packages/components/switch/tsup.config.ts
+++ b/packages/components/switch/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/table/package.json
+++ b/packages/components/table/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/table/src/base/index.ts
+++ b/packages/components/table/src/base/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export {default as TableBody} from "./table-body";
 export {default as TableCell} from "./table-cell";
 export {default as TableColumn} from "./table-column";

--- a/packages/components/table/src/index.ts
+++ b/packages/components/table/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {TableProps} from "./table";
 export type {

--- a/packages/components/table/tsup.config.ts
+++ b/packages/components/table/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/tabs/src/index.ts
+++ b/packages/components/tabs/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Tabs from "./tabs";
 
 // export types

--- a/packages/components/tabs/tsup.config.ts
+++ b/packages/components/tabs/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/components/tooltip/src/index.ts
+++ b/packages/components/tooltip/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import Tooltip from "./tooltip";
 
 // export types

--- a/packages/components/tooltip/tsup.config.ts
+++ b/packages/components/tooltip/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/components/user/package.json
+++ b/packages/components/user/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/components/user/package.json
+++ b/packages/components/user/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/components/user/src/index.ts
+++ b/packages/components/user/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // export types
 export type {UserProps} from "./user";
 

--- a/packages/components/user/tsup.config.ts
+++ b/packages/components/user/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -16,7 +16,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -31,12 +32,10 @@
   },
   "scripts": {
     "prebuild": "node src/scripts/prebuild.js",
-    "build": "tsup --dts",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "postbuild": "node src/scripts/postbuild.js",
-    "dev": "yarn build:fast -- --watch",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -34,7 +34,7 @@
     "prebuild": "node src/scripts/prebuild.js",
     "build": "tsc && tsc --module commonjs --outDir cjs",
     "postbuild": "node src/scripts/postbuild.js",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/core/react/src/index.ts
+++ b/packages/core/react/src/index.ts
@@ -1,4 +1,5 @@
 "use client";
+"use client";
 // only for developments, client directive  this is removed in production builds
 
 export * from "@nextui-org/system";

--- a/packages/core/react/tsup.config.ts
+++ b/packages/core/react/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  entry: ["src/index.ts", "!src/scripts"],
-  format: ["cjs", "esm"],
-});

--- a/packages/core/system-rsc/package.json
+++ b/packages/core/system-rsc/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/core/system-rsc/package.json
+++ b/packages/core/system-rsc/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -48,13 +47,5 @@
   "dependencies": {
     "clsx": "^1.2.1"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/core/system-rsc/src/index.ts
+++ b/packages/core/system-rsc/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./types";
 export * from "./utils";
 export * from "./extend-variants";

--- a/packages/core/system-rsc/src/index.ts
+++ b/packages/core/system-rsc/src/index.ts
@@ -1,4 +1,3 @@
-"use client";
 export * from "./types";
 export * from "./utils";
 export * from "./extend-variants";

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src !src/extend-variants.d.ts --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src !src/extend-variants.d.ts",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -43,14 +42,6 @@
     "react-dom": "^18.0.0"
   },
   "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  },
   "dependencies": {
     "@nextui-org/system-rsc": "workspace:*",
     "@react-aria/i18n": "^3.8.4",

--- a/packages/core/system/src/index.ts
+++ b/packages/core/system/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./provider";
 
 export * from "@nextui-org/system-rsc";

--- a/packages/core/theme/package.json
+++ b/packages/core/theme/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/core/theme/package.json
+++ b/packages/core/theme/package.json
@@ -18,6 +18,7 @@
   "sideEffects": false,
   "files": [
     "dist",
+    "src",
     "config.js",
     "config.d.ts",
     "plugin.js",
@@ -37,9 +38,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -70,13 +69,5 @@
     "@types/lodash.omit": "^4.5.7",
     "tailwindcss": "^3.3.5",
     "clean-package": "2.2.0"
-  },
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
   }
 }

--- a/packages/core/theme/src/animations/index.ts
+++ b/packages/core/theme/src/animations/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export const animations = {
   animation: {
     "drip-expand": "drip-expand 420ms linear",

--- a/packages/core/theme/src/colors/index.ts
+++ b/packages/core/theme/src/colors/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {commonColors} from "./common";
 import {semanticColors} from "./semantic";
 

--- a/packages/core/theme/src/components/index.ts
+++ b/packages/core/theme/src/components/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./avatar";
 export * from "./card";
 export * from "./link";

--- a/packages/core/theme/src/index.ts
+++ b/packages/core/theme/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./components";
 export * from "./utils";
 export * from "./colors";

--- a/packages/core/theme/src/utilities/index.ts
+++ b/packages/core/theme/src/utilities/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import transition from "./transition";
 import custom from "./custom";
 import scrollbarHide from "./scrollbar-hide";

--- a/packages/core/theme/src/utils/index.ts
+++ b/packages/core/theme/src/utils/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./classes";
 export * from "./types";
 export * from "./variants";

--- a/packages/hooks/use-aria-accordion-item/package.json
+++ b/packages/hooks/use-aria-accordion-item/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-accordion-item/package.json
+++ b/packages/hooks/use-aria-accordion-item/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -46,13 +45,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-accordion-item/src/index.ts
+++ b/packages/hooks/use-aria-accordion-item/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {
   useId,
   useCallback,

--- a/packages/hooks/use-aria-accordion/package.json
+++ b/packages/hooks/use-aria-accordion/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-accordion/package.json
+++ b/packages/hooks/use-aria-accordion/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -49,13 +48,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-accordion/src/index.ts
+++ b/packages/hooks/use-aria-accordion/src/index.ts
@@ -1,2 +1,3 @@
+"use client";
 export {useReactAriaAccordion} from "./use-accordion";
 export {useReactAriaAccordionItem} from "./use-accordion-item";

--- a/packages/hooks/use-aria-button/package.json
+++ b/packages/hooks/use-aria-button/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-button/package.json
+++ b/packages/hooks/use-aria-button/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -48,13 +47,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-button/src/index.ts
+++ b/packages/hooks/use-aria-button/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 // We had to copy this file from @react-aria/button because of the console.warn
 // once they fix it we can remove this file and use the original one
 

--- a/packages/hooks/use-aria-link/package.json
+++ b/packages/hooks/use-aria-link/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-link/package.json
+++ b/packages/hooks/use-aria-link/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -48,13 +47,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-link/src/index.ts
+++ b/packages/hooks/use-aria-link/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {AriaLinkProps} from "@react-types/link";
 import {DOMAttributes, FocusableElement} from "@react-types/shared";
 import {filterDOMProps, mergeProps, useRouter, shouldClientNavigate} from "@react-aria/utils";

--- a/packages/hooks/use-aria-modal-overlay/package.json
+++ b/packages/hooks/use-aria-modal-overlay/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-modal-overlay/package.json
+++ b/packages/hooks/use-aria-modal-overlay/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -48,13 +47,5 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-modal-overlay/src/index.ts
+++ b/packages/hooks/use-aria-modal-overlay/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {
   ariaHideOutside,
   AriaModalOverlayProps,

--- a/packages/hooks/use-aria-multiselect/package.json
+++ b/packages/hooks/use-aria-multiselect/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-multiselect/package.json
+++ b/packages/hooks/use-aria-multiselect/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -57,13 +56,5 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-multiselect/src/index.ts
+++ b/packages/hooks/use-aria-multiselect/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./use-multiselect";
 export * from "./use-multiselect-list-state";
 export {useMultiSelectState} from "./use-multiselect-state";

--- a/packages/hooks/use-aria-press/package.json
+++ b/packages/hooks/use-aria-press/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-press/package.json
+++ b/packages/hooks/use-aria-press/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -46,13 +45,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-press/src/index.ts
+++ b/packages/hooks/use-aria-press/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 /**
  * TODO: Remove this package once the react-aria team publishes a new version
  * with the fix https://github.com/adobe/react-spectrum/pull/5291

--- a/packages/hooks/use-aria-toggle-button/package.json
+++ b/packages/hooks/use-aria-toggle-button/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-aria-toggle-button/package.json
+++ b/packages/hooks/use-aria-toggle-button/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -47,13 +46,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-aria-toggle-button/src/index.ts
+++ b/packages/hooks/use-aria-toggle-button/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");

--- a/packages/hooks/use-callback-ref/package.json
+++ b/packages/hooks/use-callback-ref/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-callback-ref/package.json
+++ b/packages/hooks/use-callback-ref/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-callback-ref/src/index.ts
+++ b/packages/hooks/use-callback-ref/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 /**
  * Part of this code is taken from @chakra-ui/system ❤️
  */

--- a/packages/hooks/use-clipboard/package.json
+++ b/packages/hooks/use-clipboard/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-clipboard/package.json
+++ b/packages/hooks/use-clipboard/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useState} from "react";
 
 export interface UseClipboardProps {

--- a/packages/hooks/use-data-scroll-overflow/package.json
+++ b/packages/hooks/use-data-scroll-overflow/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-data-scroll-overflow/package.json
+++ b/packages/hooks/use-data-scroll-overflow/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-data-scroll-overflow/src/index.ts
+++ b/packages/hooks/use-data-scroll-overflow/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {capitalize} from "@nextui-org/shared-utils";
 import {useEffect, useRef} from "react";
 

--- a/packages/hooks/use-disclosure/package.json
+++ b/packages/hooks/use-disclosure/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-disclosure/package.json
+++ b/packages/hooks/use-disclosure/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -45,13 +44,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-disclosure/src/index.ts
+++ b/packages/hooks/use-disclosure/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {chain} from "@react-aria/utils";
 import {useControlledState} from "@react-stately/utils";
 import {useCallbackRef} from "@nextui-org/use-callback-ref";

--- a/packages/hooks/use-image/package.json
+++ b/packages/hooks/use-image/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-image/package.json
+++ b/packages/hooks/use-image/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 /**
  * Part of this code is taken from @chakra-ui/react package ❤️
  */

--- a/packages/hooks/use-infinite-scroll/package.json
+++ b/packages/hooks/use-infinite-scroll/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-infinite-scroll/package.json
+++ b/packages/hooks/use-infinite-scroll/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -44,13 +43,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-infinite-scroll/src/index.ts
+++ b/packages/hooks/use-infinite-scroll/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import debounce from "lodash.debounce";
 import {useLayoutEffect, useRef} from "react";
 

--- a/packages/hooks/use-is-mobile/package.json
+++ b/packages/hooks/use-is-mobile/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-is-mobile/package.json
+++ b/packages/hooks/use-is-mobile/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-is-mobile/src/index.ts
+++ b/packages/hooks/use-is-mobile/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useIsSSR} from "@react-aria/ssr";
 
 const MOBILE_SCREEN_WIDTH = 700;

--- a/packages/hooks/use-is-mounted/package.json
+++ b/packages/hooks/use-is-mounted/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-is-mounted/package.json
+++ b/packages/hooks/use-is-mounted/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-is-mounted/src/index.ts
+++ b/packages/hooks/use-is-mounted/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useCallback, useEffect, useRef, useState} from "react";
 
 export type UseIsMountedProps = {

--- a/packages/hooks/use-pagination/package.json
+++ b/packages/hooks/use-pagination/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-pagination/package.json
+++ b/packages/hooks/use-pagination/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-pagination/src/index.ts
+++ b/packages/hooks/use-pagination/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useMemo, useCallback, useState, useEffect} from "react";
 import {range} from "@nextui-org/shared-utils";
 

--- a/packages/hooks/use-real-shape/package.json
+++ b/packages/hooks/use-real-shape/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -43,13 +42,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-real-shape/package.json
+++ b/packages/hooks/use-real-shape/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-real-shape/src/index.ts
+++ b/packages/hooks/use-real-shape/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {RefObject, useState, useEffect} from "react";
 import {ShapeType, getRealShape} from "@nextui-org/react-utils";
 

--- a/packages/hooks/use-ref-state/package.json
+++ b/packages/hooks/use-ref-state/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-ref-state/package.json
+++ b/packages/hooks/use-ref-state/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-ref-state/src/index.ts
+++ b/packages/hooks/use-ref-state/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {Dispatch, MutableRefObject, SetStateAction, useEffect, useRef, useState} from "react";
 
 export type CurrentStateType<S> = [S, Dispatch<SetStateAction<S>>, MutableRefObject<S>];

--- a/packages/hooks/use-resize/package.json
+++ b/packages/hooks/use-resize/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-resize/package.json
+++ b/packages/hooks/use-resize/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-resize/src/index.ts
+++ b/packages/hooks/use-resize/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useEffect} from "react";
 
 export function useResize(callback: Function, immediatelyInvoke: boolean = true) {

--- a/packages/hooks/use-safe-layout-effect/package.json
+++ b/packages/hooks/use-safe-layout-effect/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-safe-layout-effect/package.json
+++ b/packages/hooks/use-safe-layout-effect/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-safe-layout-effect/src/index.ts
+++ b/packages/hooks/use-safe-layout-effect/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useEffect, useLayoutEffect} from "react";
 
 export const useSafeLayoutEffect = Boolean(globalThis?.document) ? useLayoutEffect : useEffect;

--- a/packages/hooks/use-scroll-position/package.json
+++ b/packages/hooks/use-scroll-position/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-scroll-position/package.json
+++ b/packages/hooks/use-scroll-position/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useRef, useEffect} from "react";
 
 const isBrowser = typeof window !== "undefined";

--- a/packages/hooks/use-ssr/package.json
+++ b/packages/hooks/use-ssr/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-ssr/package.json
+++ b/packages/hooks/use-ssr/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-ssr/src/index.ts
+++ b/packages/hooks/use-ssr/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useEffect, useState} from "react";
 
 const isBrowser = (): boolean => {

--- a/packages/hooks/use-update-effect/package.json
+++ b/packages/hooks/use-update-effect/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/hooks/use-update-effect/package.json
+++ b/packages/hooks/use-update-effect/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/hooks/use-update-effect/src/index.ts
+++ b/packages/hooks/use-update-effect/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {useEffect, useRef} from "react";
 
 /**

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": true,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -52,13 +53,5 @@
     "storybook-dark-mode": "^3.0.1",
     "tailwindcss": "^3.3.5",
     "vite": "^4.4.7"
-  },
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
   }
 }

--- a/packages/utilities/aria-utils/package.json
+++ b/packages/utilities/aria-utils/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/aria-utils/package.json
+++ b/packages/utilities/aria-utils/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },

--- a/packages/utilities/aria-utils/src/collections/index.ts
+++ b/packages/utilities/aria-utils/src/collections/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./item";
 export * from "./section";
 export * from "./types";

--- a/packages/utilities/aria-utils/src/index.ts
+++ b/packages/utilities/aria-utils/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./collections";
 export * from "./utils";
 export * from "./type-utils";

--- a/packages/utilities/aria-utils/src/overlays/index.ts
+++ b/packages/utilities/aria-utils/src/overlays/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./types";
 export * from "./utils";
 export * from "./ariaHideOutside";

--- a/packages/utilities/aria-utils/src/type-utils/index.ts
+++ b/packages/utilities/aria-utils/src/type-utils/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {Node} from "@react-types/shared";
 
 export type NodeWithProps<T extends object, P = {}> = Omit<Node<T>, "props"> & {props?: P};

--- a/packages/utilities/aria-utils/src/utils/index.ts
+++ b/packages/utilities/aria-utils/src/utils/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {isAppleDevice} from "@react-aria/utils";
 import {isMac} from "@react-aria/utils";
 

--- a/packages/utilities/aria-utils/tsup.config.ts
+++ b/packages/utilities/aria-utils/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/utilities/framer-transitions/package.json
+++ b/packages/utilities/framer-transitions/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/framer-transitions/package.json
+++ b/packages/utilities/framer-transitions/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/utilities/framer-transitions/src/index.ts
+++ b/packages/utilities/framer-transitions/src/index.ts
@@ -1,1 +1,2 @@
+"use client";
 export * from "./transition-utils";

--- a/packages/utilities/framer-transitions/tsup.config.ts
+++ b/packages/utilities/framer-transitions/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/utilities/react-rsc-utils/package.json
+++ b/packages/utilities/react-rsc-utils/package.json
@@ -12,6 +12,7 @@
   "sideEffects": false,
   "files": [
     "dist",
+    "src",
     "children.d.ts",
     "children.js",
     "filter-dom-props.d.ts",
@@ -29,9 +30,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -40,13 +39,5 @@
   "devDependencies": {
     "clean-package": "2.2.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/react-rsc-utils/package.json
+++ b/packages/utilities/react-rsc-utils/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/react-rsc-utils/src/index.ts
+++ b/packages/utilities/react-rsc-utils/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./children";
 export * from "./filter-dom-props";
 export * from "./dom-props";

--- a/packages/utilities/react-rsc-utils/src/index.ts
+++ b/packages/utilities/react-rsc-utils/src/index.ts
@@ -1,4 +1,3 @@
-"use client";
 export * from "./children";
 export * from "./filter-dom-props";
 export * from "./dom-props";

--- a/packages/utilities/react-utils/package.json
+++ b/packages/utilities/react-utils/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/react-utils/package.json
+++ b/packages/utilities/react-utils/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/packages/utilities/react-utils/src/index.ts
+++ b/packages/utilities/react-utils/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./context";
 export * from "./refs";
 export * from "./dom";

--- a/packages/utilities/react-utils/tsup.config.ts
+++ b/packages/utilities/react-utils/tsup.config.ts
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/packages/utilities/shared-icons/package.json
+++ b/packages/utilities/shared-icons/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/shared-icons/package.json
+++ b/packages/utilities/shared-icons/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/shared-icons/src/bold/index.ts
+++ b/packages/utilities/shared-icons/src/bold/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./align-top";
 export * from "./align-bottom";
 export * from "./align-left";

--- a/packages/utilities/shared-icons/src/bulk/index.ts
+++ b/packages/utilities/shared-icons/src/bulk/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./add-note";
 export * from "./copy-document";
 export * from "./delete-document";

--- a/packages/utilities/shared-icons/src/index.ts
+++ b/packages/utilities/shared-icons/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./icons";
 export * from "./copy";
 export * from "./check";

--- a/packages/utilities/shared-icons/src/linear/index.ts
+++ b/packages/utilities/shared-icons/src/linear/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./check";
 export * from "./copy";
 export * from "./chevron-circle-top";

--- a/packages/utilities/shared-utils/package.json
+++ b/packages/utilities/shared-utils/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/shared-utils/package.json
+++ b/packages/utilities/shared-utils/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,11 +26,9 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
-    "build:fast": "tsup src",
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
@@ -40,13 +39,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/shared-utils/src/index.ts
+++ b/packages/utilities/shared-utils/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./assertion";
 export * from "./clsx";
 export * from "./object";

--- a/packages/utilities/shared-utils/src/index.ts
+++ b/packages/utilities/shared-utils/src/index.ts
@@ -1,4 +1,3 @@
-"use client";
 export * from "./assertion";
 export * from "./clsx";
 export * from "./object";

--- a/packages/utilities/stories-utils/package.json
+++ b/packages/utilities/stories-utils/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -36,13 +35,5 @@
   "devDependencies": {
     "clean-package": "2.2.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/stories-utils/package.json
+++ b/packages/utilities/stories-utils/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/stories-utils/src/hooks/index.ts
+++ b/packages/utilities/stories-utils/src/hooks/index.ts
@@ -1,1 +1,2 @@
+"use client";
 export * from "./use-pokemon-list";

--- a/packages/utilities/stories-utils/src/index.ts
+++ b/packages/utilities/stories-utils/src/index.ts
@@ -1,3 +1,2 @@
-"use client";
 export * from "./hooks";
 export * from "./mocks/data";

--- a/packages/utilities/stories-utils/src/index.ts
+++ b/packages/utilities/stories-utils/src/index.ts
@@ -1,2 +1,3 @@
+"use client";
 export * from "./hooks";
 export * from "./mocks/data";

--- a/packages/utilities/test-utils/package.json
+++ b/packages/utilities/test-utils/package.json
@@ -11,7 +11,8 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "publishConfig": {
     "access": "public"
@@ -25,9 +26,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -36,13 +35,5 @@
   "devDependencies": {
     "clean-package": "2.2.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/utilities/test-utils/package.json
+++ b/packages/utilities/test-utils/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/packages/utilities/test-utils/src/index.ts
+++ b/packages/utilities/test-utils/src/index.ts
@@ -1,3 +1,4 @@
+"use client";
 export * from "./mocks";
 export * from "./focus";
 export * from "./tabbable";

--- a/packages/utilities/test-utils/src/index.ts
+++ b/packages/utilities/test-utils/src/index.ts
@@ -1,4 +1,3 @@
-"use client";
 export * from "./mocks";
 export * from "./focus";
 export * from "./tabbable";

--- a/packages/utilities/test-utils/src/mocks/index.ts
+++ b/packages/utilities/test-utils/src/mocks/index.ts
@@ -1,3 +1,4 @@
+"use client";
 import {mockImage} from "./image";
 
 export const mocks = {

--- a/plop/component/package.json.hbs
+++ b/plop/component/package.json.hbs
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/plop/component/package.json.hbs
+++ b/plop/component/package.json.hbs
@@ -25,9 +25,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",

--- a/plop/component/tsup.config.ts.hbs
+++ b/plop/component/tsup.config.ts.hbs
@@ -1,8 +1,0 @@
-import {defineConfig} from "tsup";
-
-export default defineConfig({
-  clean: true,
-  target: "es2019",
-  format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
-});

--- a/plop/hook/package.json.hbs
+++ b/plop/hook/package.json.hbs
@@ -25,9 +25,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -40,13 +38,5 @@
     "clean-package": "2.2.0",
     "react": "^18.0.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/plop/hook/package.json.hbs
+++ b/plop/hook/package.json.hbs
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/plop/package/package.json.hbs
+++ b/plop/package/package.json.hbs
@@ -25,9 +25,7 @@
     "url": "https://github.com/nextui-org/nextui/issues"
   },
   "scripts": {
-    "build": "tsup src --dts",
-    "build:fast": "tsup src",
-    "dev": "yarn build:fast -- --watch",
+    "build": "tsc && tsc --module commonjs --outDir cjs",
     "clean": "rimraf dist .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
@@ -36,13 +34,5 @@
   "devDependencies": {
     "clean-package": "2.2.0"
   },
-  "clean-package": "../../../clean-package.config.json",
-  "tsup": {
-    "clean": true,
-    "target": "es2019",
-    "format": [
-      "cjs",
-      "esm"
-    ]
-  }
+  "clean-package": "../../../clean-package.config.json"
 }

--- a/plop/package/package.json.hbs
+++ b/plop/package/package.json.hbs
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "tsc && tsc --module commonjs --outDir cjs",
-    "clean": "rimraf dist .turbo",
+    "clean": "rimraf dist cjs .turbo",
     "typecheck": "tsc --noEmit",
     "prepack": "clean-package",
     "postpack": "clean-package restore"

--- a/plop/package/src/index.ts.hbs
+++ b/plop/package/src/index.ts.hbs
@@ -1,0 +1,1 @@
+"use client";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       shelljs:
         specifier: ^0.8.4
         version: 0.8.5
-      tsup:
-        specifier: 6.4.0
-        version: 6.4.0(@swc/core@1.3.96)(ts-node@10.9.1)(typescript@4.9.5)
       tsx:
         specifier: ^3.8.2
         version: 3.14.0
@@ -257,7 +254,7 @@ importers:
         version: 4.9.5
       webpack:
         specifier: ^5.53.0
-        version: 5.89.0(@swc/core@1.3.96)(esbuild@0.15.18)(webpack-cli@3.3.12)
+        version: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)(webpack-cli@3.3.12)
       webpack-bundle-analyzer:
         specifier: ^4.4.2
         version: 4.9.1
@@ -5813,15 +5810,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@esbuild/android-arm@0.15.18:
-    resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@esbuild/android-arm@0.18.20:
     resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
@@ -5973,15 +5961,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.15.18:
-    resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -13495,16 +13474,6 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /bundle-require@3.1.2(esbuild@0.15.18):
-    resolution: {integrity: sha512-Of6l6JBAxiyQ5axFxUM6dYeP/W7X2Sozeo/4EYB9sJhL+dqL7TKjg+shwxp6jlu/6ZSERfsYtIpSJ1/x3XkAEA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.13'
-    dependencies:
-      esbuild: 0.15.18
-      load-tsconfig: 0.2.5
-    dev: true
-
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -13519,11 +13488,6 @@ packages:
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-    dev: true
-
-  /cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
     dev: true
 
   /cacache@16.1.3:
@@ -15200,150 +15164,6 @@ packages:
       ext: 1.7.0
     dev: false
 
-  /esbuild-android-64@0.15.18:
-    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-android-arm64@0.15.18:
-    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-64@0.15.18:
-    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-darwin-arm64@0.15.18:
-    resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-64@0.15.18:
-    resolution: {integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-freebsd-arm64@0.15.18:
-    resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-32@0.15.18:
-    resolution: {integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-64@0.15.18:
-    resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm64@0.15.18:
-    resolution: {integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-arm@0.15.18:
-    resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-mips64le@0.15.18:
-    resolution: {integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-ppc64le@0.15.18:
-    resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-riscv64@0.15.18:
-    resolution: {integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-linux-s390x@0.15.18:
-    resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-netbsd-64@0.15.18:
-    resolution: {integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-openbsd-64@0.15.18:
-    resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /esbuild-plugin-alias@0.2.1:
     resolution: {integrity: sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==}
     dev: true
@@ -15357,72 +15177,6 @@ packages:
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /esbuild-sunos-64@0.15.18:
-    resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-32@0.15.18:
-    resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-64@0.15.18:
-    resolution: {integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild-windows-arm64@0.15.18:
-    resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /esbuild@0.15.18:
-    resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/android-arm': 0.15.18
-      '@esbuild/linux-loong64': 0.15.18
-      esbuild-android-64: 0.15.18
-      esbuild-android-arm64: 0.15.18
-      esbuild-darwin-64: 0.15.18
-      esbuild-darwin-arm64: 0.15.18
-      esbuild-freebsd-64: 0.15.18
-      esbuild-freebsd-arm64: 0.15.18
-      esbuild-linux-32: 0.15.18
-      esbuild-linux-64: 0.15.18
-      esbuild-linux-arm: 0.15.18
-      esbuild-linux-arm64: 0.15.18
-      esbuild-linux-mips64le: 0.15.18
-      esbuild-linux-ppc64le: 0.15.18
-      esbuild-linux-riscv64: 0.15.18
-      esbuild-linux-s390x: 0.15.18
-      esbuild-netbsd-64: 0.15.18
-      esbuild-openbsd-64: 0.15.18
-      esbuild-sunos-64: 0.15.18
-      esbuild-windows-32: 0.15.18
-      esbuild-windows-64: 0.15.18
-      esbuild-windows-arm64: 0.15.18
     dev: true
 
   /esbuild@0.18.20:
@@ -15731,7 +15485,7 @@ packages:
       loader-utils: 2.0.4
       object-hash: 2.2.0
       schema-utils: 2.7.1
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.15.18)(webpack-cli@3.3.12)
+      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)(webpack-cli@3.3.12)
     dev: true
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
@@ -19131,11 +18885,6 @@ packages:
       '@sideway/pinpoint': 2.0.0
     dev: true
 
-  /joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-    dev: true
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -19603,11 +19352,6 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
-  /load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
-
   /load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -19739,10 +19483,6 @@ packages:
 
   /lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-    dev: true
-
-  /lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
     dev: true
 
   /lodash.startcase@4.4.0:
@@ -22213,23 +21953,6 @@ packages:
       camelcase-css: 2.0.1
       postcss: 8.4.31
 
-  /postcss-load-config@3.1.4(ts-node@10.9.1):
-    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.1.0
-      ts-node: 10.9.1(@swc/core@1.3.96)(@types/node@15.14.9)(typescript@4.9.5)
-      yaml: 1.10.2
-    dev: true
-
   /postcss-load-config@4.0.1(postcss@8.4.31)(ts-node@10.9.1):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
@@ -24265,13 +23988,6 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
-  /source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    dependencies:
-      whatwg-url: 7.1.0
-    dev: true
-
   /sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
@@ -24974,7 +24690,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.96)(esbuild@0.15.18)(webpack@5.89.0):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.96)(esbuild@0.18.20)(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -24992,12 +24708,12 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
       '@swc/core': 1.3.96
-      esbuild: 0.15.18
+      esbuild: 0.18.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.15.18)(webpack-cli@3.3.12)
+      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)(webpack-cli@3.3.12)
     dev: true
 
   /terser-webpack-plugin@5.3.9(@swc/core@1.3.96)(esbuild@0.19.5)(webpack@5.89.0):
@@ -25190,12 +24906,6 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
-  /tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-    dependencies:
-      punycode: 2.3.1
-    dev: true
-
   /tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
@@ -25282,43 +24992,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-
-  /tsup@6.4.0(@swc/core@1.3.96)(ts-node@10.9.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-4OlbqIK/SF+cJp0mMqPM2pKULvgj/1S2Gm3I1aFoFGIryUOyIqPZBoqKkqVQT6uFtWJ5AHftIv0riXKfHox1zQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: ^4.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@swc/core': 1.3.96
-      bundle-require: 3.1.2(esbuild@0.15.18)
-      cac: 6.7.14
-      chokidar: 3.5.3
-      debug: 4.3.4
-      esbuild: 0.15.18
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
-      resolve-from: 5.0.0
-      rollup: 3.29.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.34.0
-      tree-kill: 1.2.2
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
-    dev: true
 
   /tsutils@3.21.0(typescript@3.9.10):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -26247,10 +25920,6 @@ packages:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
 
-  /webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-    dev: true
-
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -26319,7 +25988,7 @@ packages:
       loader-utils: 1.4.2
       supports-color: 6.1.0
       v8-compile-cache: 2.4.0
-      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.15.18)(webpack-cli@3.3.12)
+      webpack: 5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)(webpack-cli@3.3.12)
       yargs: 13.3.2
     dev: true
 
@@ -26341,7 +26010,7 @@ packages:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
     dev: true
 
-  /webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.15.18)(webpack-cli@3.3.12):
+  /webpack@5.89.0(@swc/core@1.3.96)(esbuild@0.18.20)(webpack-cli@3.3.12):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -26372,7 +26041,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(esbuild@0.15.18)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.96)(esbuild@0.18.20)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-cli: 3.3.12(webpack@5.89.0)
       webpack-sources: 3.2.3
@@ -26456,14 +26125,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
-
-  /whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
     dev: true
 
   /which-boxed-primitive@1.0.2:
@@ -26724,11 +26385,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  /yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
-    dev: true
 
   /yaml@2.3.1:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2019",
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "declaration": true,
@@ -15,7 +15,9 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "outDir": "dist",
+    "declarationMap": true
   },
   "include": ["packages"],
   "exclude": ["**/node_modules", "**/dist", "**/.turbo"]

--- a/turbo.json
+++ b/turbo.json
@@ -5,11 +5,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "dist/**", "lib/**", "storybook-static/**"]
-    },
-    "build:fast": {
-      "outputs": ["dist/**"],
-      "dependsOn": ["^build:fast"]
+      "outputs": [".next/**", "dist/**", "cjs/**", "lib/**", "storybook-static/**"]
     },
     "typecheck": {
       "cache": false,
@@ -29,9 +25,6 @@
     },
     "lint": {
       "outputs": []
-    },
-    "dev": {
-      "cache": false
     },
     "sb": {
       "cache": false

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
     "lint": {
       "outputs": []
     },
+    "dev": {
+      "cache": false
+    },
     "sb": {
       "cache": false
     }


### PR DESCRIPTION
I wanted to open a PR to enable `declarationMap` to make cmd+click navigate to the source code instead of the `.d.ts` files but i noticed that [tsup doesn't support it](https://github.com/egoist/tsup/issues/488)

Tsup has a lot of other problems and unnecessary bloat

So i opened a PR to use `tsc` instead of `tsup`

## Description
- Replaced all build scripts with `tsc` 
- Removed `dev` scripts given that in development the packages `"main"` is set to the `index.ts` files for all packages, making it unnecessary
- Removed `build:fast` scripts for the same reason
- Removed `tsup.config.ts`
- Added `src` to npm files
- Added "use client" to all packages `index.ts` files given that tsc doesn't have a banner option
