### PR TITLE
Fix Autocomplete & Select docs with correct reference to `disableSelectorIconRotation`

### DIFF
--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -126,7 +126,7 @@ customize this icon by passing a custom one to the `selectorIcon` property.
   files={autocompleteContent.customSelectorIcon}
 />
 
-> **Note**: Use the `disableSelectionIconRotation` property to disable the rotation of the icon.
+> **Note**: Use the `disableSelectorIconRotation` property to disable the rotation of the icon.
 
 ### Without Scroll Shadow
 

--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -112,7 +112,7 @@ customize this icon by passing a custom one to the `selectorIcon` property.
 
 <CodeDemo title="Custom Selector Icon" files={selectContent.customSelectorIcon} />
 
-> **Note**: Use the `disableSelectionIconRotation` property to disable the rotation of the icon.
+> **Note**: Use the `disableSelectorIconRotation` property to disable the rotation of the icon.
 
 ### Without Scroll Shadow
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1989 

## 📝 Description

Fix `disableSelectionIconRotation` to `disableSelectorIconRotation`.

## ⛳️ Current behavior (updates)

> Incorrect attribute referenced.

## 🚀 New behavior

> Correct attribute referenced.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
