### PR TITLE
fix(input): label placement outside when label is missing

### DIFF
--- a/.changeset/metal-weeks-vanish.md
+++ b/.changeset/metal-weeks-vanish.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/select": patch
+"@nextui-org/input": patch
+---
+
+Fix #1979 labelPlacement is outside when not having a label for input, autocomplete and select components.

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -135,12 +135,9 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const handleClear = useCallback(() => {
     setInputValue("");
 
-    if (domRef.current) {
-      domRef.current.value = "";
-      domRef.current.focus();
-    }
     onClear?.();
-  }, [domRef, setInputValue, onClear]);
+    domRef.current?.focus();
+  }, [setInputValue, onClear]);
 
   const {labelProps, inputProps, descriptionProps, errorMessageProps} = useTextField(
     {
@@ -211,9 +208,10 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       input({
         ...variantProps,
         isInvalid,
+        labelPlacement,
         isClearable,
       }),
-    [...Object.values(variantProps), isInvalid, isClearable, hasStartContent],
+    [...Object.values(variantProps), isInvalid, labelPlacement, isClearable, hasStartContent],
   );
 
   const getBaseProps: PropGetter = useCallback(

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -280,9 +280,10 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
       select({
         ...variantProps,
         isInvalid,
+        labelPlacement,
         className,
       }),
-    [...Object.values(variantProps), isInvalid, className],
+    [...Object.values(variantProps), isInvalid, labelPlacement, className],
   );
 
   // scroll the listbox to the selected item


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1979 

## 📝 Description

Input, Autocomplete and Select label placement adjusted

## ⛳️ Current behavior (updates)

Input, Autocomplete and Select height are not proportional when not having a label.

## 🚀 New behavior

Label placement set to "outside" if the label property is not passed.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
