### PR TITLE
fix(hooks): incorrect attribute names in clearOverflow

### DIFF
--- a/.changeset/fuzzy-panthers-hear.md
+++ b/.changeset/fuzzy-panthers-hear.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-data-scroll-overflow": patch
+---
+
+fixed incorrect attribute names in clearOverflow (#2010)

--- a/packages/hooks/use-data-scroll-overflow/src/index.ts
+++ b/packages/hooks/use-data-scroll-overflow/src/index.ts
@@ -126,7 +126,7 @@ export function useDataScrollOverflow(props: UseDataScrollOverflowProps = {}) {
     };
 
     const clearOverflow = () => {
-      ["top", "bottom", "topBottom", "left", "right", "leftRight"].forEach((attr) => {
+      ["top", "bottom", "top-bottom", "left", "right", "left-right"].forEach((attr) => {
         el.removeAttribute(`data-${attr}-scroll`);
       });
     };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2010

## 📝 Description

change `topBottom` and `leftRight` to `top-bottom` and `left-right`

## ⛳️ Current behavior (updates)

Using `data-top-bottom-scroll="true"` as an example. 

Before triggering `clearOverflow`, we can see `data-top-bottom-scroll` which is expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/a5e8a629-c17e-4919-8c77-9336abd1de3d)

After triggering `clearOverflow`, `data-top-bottom-scroll` is still here, which is not expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/6c13c105-7f95-41b7-ac74-e9a58f5c81f6)

## 🚀 New behavior

Before triggering `clearOverflow`, we can see `data-top-bottom-scroll` which is expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/66c5ea31-e7ba-44a6-95f4-a043861e6613)

After triggering `clearOverflow`, with the fix in this PR, `data-top-bottom-scroll="true"` is removed as expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/8c3234be-e45e-4d35-a8d6-b7881fb77d9a)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information



