### PR TITLE
docs: Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ We use [Turbo Repo](https://turborepo.org/) for the project management.
 
 ```bash
 ## Start the dev babel server of NextUI core components
-pnpm dev:nextui
+pnpm dev
 
 ## optional
 pnpm dev:docs ## this will start the documentation next.js server and it will automatically detect the changes in the components.


### PR DESCRIPTION
## 📝 Description

> There is no `pmpm dev:nextui` command that the contribution guide mentions. I assume it meant `pmpm dev`.

## ⛳️ Current behavior (updates)

> Contribution doc out of date.

## 🚀 New behavior

> Docs fixed.

## 💣 Is this a breaking change (Yes/No): No
