### PR TITLE
fix(input): keep input component's position in innerWrapper steady

### DIFF
--- a/.changeset/two-bananas-dance.md
+++ b/.changeset/two-bananas-dance.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fix #2069 keep input component's position steady

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -63,19 +63,11 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
   ]);
 
   const innerWrapper = useMemo(() => {
-    if (startContent || end) {
-      return (
-        <div {...getInnerWrapperProps()}>
-          {startContent}
-          <input {...getInputProps()} />
-          {end}
-        </div>
-      );
-    }
-
     return (
       <div {...getInnerWrapperProps()}>
-        <input {...getInputProps()} />
+        {startContent}
+        <input key="nextui-input" {...getInputProps()} />
+        {end}
       </div>
     );
   }, [startContent, end, getInputProps, getInnerWrapperProps]);

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -66,7 +66,7 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
     return (
       <div {...getInnerWrapperProps()}>
         {startContent}
-        <input key="nextui-input" {...getInputProps()} />
+        <input {...getInputProps()} />
         {end}
       </div>
     );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2069  <!-- Github issue # here -->

## 📝 Description

When `startContent` or `endContent` becomes truthy, it will change the position of `<input />` and React will re-mount `<input />`. This makes it losing focus. So we can remove the condition and just let `startContent` or `endContent` be in `innerWrapper` to make the position of `<input />` steady.

## ⛳️ Current behavior (updates)

When `endContent` becomes truthy while user focusing input, input will lose focus.

## 🚀 New behavior

Now input won't lose focus.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information