### PR TITLE
Fix(tooltip): allow non-ReactElement children

### DIFF
--- a/.changeset/spotty-pens-stare.md
+++ b/.changeset/spotty-pens-stare.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tooltip": patch
+---
+
+Fix #1840 let Tooltip allow non-ReactElement children

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -3,7 +3,7 @@ import {OverlayContainer} from "@react-aria/overlays";
 import {AnimatePresence, motion} from "framer-motion";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-transitions";
 import {warn} from "@nextui-org/shared-utils";
-import {Children, cloneElement} from "react";
+import {Children, cloneElement, isValidElement} from "react";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {mergeProps} from "@react-aria/utils";
 
@@ -35,11 +35,19 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
     /**
      * Ensure tooltip has only one child node
      */
-    const child = Children.only(children) as React.ReactElement & {
-      ref?: React.Ref<any>;
-    };
+    const childrenNum = Children.count(children);
 
-    trigger = cloneElement(child, getTriggerProps(child.props, child.ref));
+    if (childrenNum !== 1) throw new Error();
+
+    if (!isValidElement(children)) {
+      trigger = <p {...getTriggerProps()}>{children}</p>;
+    } else {
+      const child = children as React.ReactElement & {
+        ref?: React.Ref<any>;
+      };
+
+      trigger = cloneElement(child, getTriggerProps(child.props, child.ref));
+    }
   } catch (error) {
     trigger = <span />;
     warn("Tooltip must have only one child node. Please, check your code.");


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1840 <!-- Github issue # here -->

## 📝 Description

Add a condition to check if `children` is valid ReactElement.

## ⛳️ Current behavior (updates)

When Tooltip gets string or number as children, they are not rendered.

## 🚀 New behavior

Now they will show on the screen normally.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
