### PR TITLE
fix(listbox): pass `shouldHighlightOnFocus` to `ListboxSection` and its children items

### DIFF
--- a/.changeset/fuzzy-cats-crash.md
+++ b/.changeset/fuzzy-cats-crash.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/listbox": patch
+---
+
+Fix #1908 pass `shouldHighlightOnFocus` to `ListboxSection` and its children items

--- a/packages/components/listbox/src/listbox-section.tsx
+++ b/packages/components/listbox/src/listbox-section.tsx
@@ -27,6 +27,11 @@ export interface ListboxSectionProps<T extends object = object> extends ListboxS
    * @default false
    */
   disableAnimation?: boolean;
+  /**
+   * Whether the listbox items should be highlighted on focus.
+   * @default false
+   */
+  shouldHighlightOnFocus?: ListboxItemProps["shouldHighlightOnFocus"];
 }
 
 /**
@@ -51,6 +56,7 @@ const ListboxSection = forwardRef<"li", ListboxSectionProps>(
       // the title props is already inside the rendered prop
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       title,
+      shouldHighlightOnFocus,
       ...otherProps
     },
     _,
@@ -100,6 +106,7 @@ const ListboxSection = forwardRef<"li", ListboxSectionProps>(
                 disableAnimation={disableAnimation}
                 hideSelectedIcon={hideSelectedIcon}
                 item={node}
+                shouldHighlightOnFocus={shouldHighlightOnFocus}
                 state={state}
                 variant={variant}
                 {...nodeProps}

--- a/packages/components/listbox/src/listbox.tsx
+++ b/packages/components/listbox/src/listbox.tsx
@@ -45,7 +45,14 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
         };
 
         if (item.type === "section") {
-          return <ListboxSection key={item.key} {...itemProps} itemClasses={itemClasses} />;
+          return (
+            <ListboxSection
+              key={item.key}
+              {...itemProps}
+              itemClasses={itemClasses}
+              shouldHighlightOnFocus={shouldHighlightOnFocus}
+            />
+          );
         }
         let listboxItem = (
           <ListboxItem


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1908 <!-- Github issue # here -->

## 📝 Description

Inside `Listbox`, pass prop `shouldHighlightOnFocus` to `ListboxSection` and its children items to enable highlighting.

## ⛳️ Current behavior (updates)

When navigating with keys on `Autocomplete` with sections, it does not highlight the currently selected item.

## 🚀 New behavior

The focused item will be highlighted.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
