### PR TITLE
fix(use-autocomplete): overwrite `onKeyDown` to prevent meaningless error msg

### DIFF
--- a/.changeset/poor-years-help.md
+++ b/.changeset/poor-years-help.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Fix #1909 overwrite `onKeyDown` to prevent meaningless error msg

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -291,6 +291,21 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     state,
   );
 
+  // to prevent the error message:
+  // stopPropagation is now the default behavior for events in React Spectrum.
+  // You can use continuePropagation() to revert this behavior.
+  if (inputProps.onKeyDown) {
+    const originalOnKeyDown = inputProps.onKeyDown;
+
+    inputProps.onKeyDown = (e) => {
+      if ("continuePropagation" in e) {
+        e.stopPropagation = () => {};
+      }
+
+      return originalOnKeyDown(e);
+    };
+  }
+
   const Component = as || "div";
 
   const slots = useMemo(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes: #1909
- Closes: #2460

## 📝 Description

Inside `useAutocomplete`, `useComboBox().inputProps.onKeyDown` causes following error message when user presses key:

>   stopPropagation is now the default behavior for events in React Spectrum. You can use continuePropagation() to revert this behavior.

Since `useComboBox` is imported from third-party dependency and has nothing to do with NextUI users, we can hide the error message by overwriting `inputProps.onKeyDown`.

## ⛳️ Current behavior (updates)

When focus Autocomplete and press keys, error messages appear in the console.

## 🚀 New behavior

Can't see such error messages anymore.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
