### PR TITLE
fix(theme): use data-hover instead of hover

### DIFF
--- a/.changeset/eleven-eels-fix.md
+++ b/.changeset/eleven-eels-fix.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fix(theme): use data-hover instead of hover (#2095)

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -289,32 +289,44 @@ const button = tv({
     {
       variant: "ghost",
       color: "default",
-      class: colorVariants.ghost.default,
+      class: [colorVariants.ghost.default, "data-[hover=true]:!bg-default"],
     },
     {
       variant: "ghost",
       color: "primary",
-      class: colorVariants.ghost.primary,
+      class: [
+        colorVariants.ghost.primary,
+        "data-[hover=true]:!bg-primary data-[hover=true]:!text-primary-foreground",
+      ],
     },
     {
       variant: "ghost",
       color: "secondary",
-      class: colorVariants.ghost.secondary,
+      class: [
+        colorVariants.ghost.secondary,
+        "data-[hover=true]:!bg-secondary data-[hover=true]:!text-secondary-foreground",
+      ],
     },
     {
       variant: "ghost",
       color: "success",
-      class: colorVariants.ghost.success,
+      class: [
+        colorVariants.ghost.success,
+        "data-[hover=true]:!bg-success data-[hover=true]:!text-success-foreground",
+      ],
     },
     {
       variant: "ghost",
       color: "warning",
-      class: colorVariants.ghost.warning,
+      class: [
+        colorVariants.ghost.warning,
+        "data-[hover=true]:!bg-warning data-[hover=true]:!text-warning-foreground",
+      ],
     },
     {
       variant: "ghost",
       color: "danger",
-      class: colorVariants.ghost.danger,
+      class: [colorVariants.ghost.danger, "data-[hover=true]:!bg-danger !text-danger-foreground"],
     },
     // isInGroup / radius / size <-- radius not provided
     {

--- a/packages/core/theme/src/utils/variants.ts
+++ b/packages/core/theme/src/utils/variants.ts
@@ -59,12 +59,12 @@ const light = {
 };
 
 const ghost = {
-  default: "border-default text-default-foreground hover:!bg-default",
-  primary: "border-primary text-primary hover:!text-primary-foreground hover:!bg-primary",
-  secondary: "border-secondary text-secondary hover:text-secondary-foreground hover:!bg-secondary",
-  success: "border-success text-success hover:!text-success-foreground hover:!bg-success",
-  warning: "border-warning text-warning hover:!text-warning-foreground hover:!bg-warning",
-  danger: "border-danger text-danger hover:!text-danger-foreground hover:!bg-danger",
+  default: "border-default text-default-foreground",
+  primary: "border-primary text-primary",
+  secondary: "border-secondary text-secondary",
+  success: "border-success text-success",
+  warning: "border-warning text-warning",
+  danger: "border-danger text-danger",
   foreground: "border-foreground text-foreground hover:!bg-foreground",
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2095 <!-- Github issue # here -->

## 📝 Description

`colorVariants.ghost` uses pseudo-class hover

## ⛳️ Current behavior (updates)

When touch ghost button on mobile, it will show hovering style and keep it until you touch elsewhere.

## 🚀 New behavior

Now ghost button won't show hovering style on mobile.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

I removed hover style from `colorVariants.ghost` since currently it's used only in `Button` theme.