### PR TITLE
docs(accordion): fix typo

### DIFF
--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -184,7 +184,7 @@ Here's an example of how to customize the accordion styles:
 | selectionBehavior         | `toggle` \| `replace`                           | The accordion selection behavior.                                                                       | `toggle` |
 | isCompact                 | `boolean`                                       | Whether all Accordion items should be smaller.                                                          | `false`  |
 | isDisabled                | `boolean`                                       | Whether the Accordion items are disabled.                                                               |          |
-| showDivider               | `boolean`                                       | WWhether to display a divider at the bottom of the each accordion item.                                 | `true`   |
+| showDivider               | `boolean`                                       | Whether to display a divider at the bottom of the each accordion item.                                  | `true`   |
 | DividerProps              | [DividerProps](/docs/components/divider)        | The divider component props.                                                                            | -        |
 | hideIndicator             | `boolean`                                       | Whether the Accordion items indicator is hidden.                                                        |          |
 | disableAnimation          | `boolean`                                       | Whether the Accordion items open/close animation is disabled.                                           |          |


### PR DESCRIPTION
## 📝 Description

> This pull request fixes the typo in the accordion API documentation. `WWhether --> Whether`.

## ⛳️ Current behavior (updates)

> The current documentation for the accordion contains a typographical error. In the "API" section, the word `WWhether` is used instead of the correct spelling, which is `Whether`.

## 🚀 New behavior

> Documentation without typo.

## 💣 Is this a breaking change (Yes/No):

> Definitely no.

## 📝 Additional Information
