### PR TITLE
Fixed vertical overflow on modal container

### DIFF
--- a/packages/core/theme/src/components/modal.ts
+++ b/packages/core/theme/src/components/modal.ts
@@ -165,7 +165,7 @@ const modal = tv({
         base: "overflow-y-hidden",
       },
       inside: {
-        base: "max-h-[calc(100%_-_7.5rem)]",
+        base: "max-h-[calc(100%_-_8rem)]",
         body: "overflow-y-auto",
       },
       outside: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

There is a small vertical scrollbar when using `scrollBehaviour: inside` with the `Modal` component. This is caused by the margins top and bottom adding up to `8rem` but the `max-height` of the container only deducting `7.5rem`.

You can try this out yourself with the official [example in the docs](https://nextui.org/docs/components/modal#overflow-scroll)

Tested on:

- Firefox version 120.0.1
- Chromium version 120.0.6099.71
Both on Ubuntu 20.04.6

Changing the `7.5rem` to `8rem` fixes this.

## ⛳️ Current behavior (updates)

In the current version there is a small vertical scrollbar outside the modal when using `scrollBehaviour: inside`.

## 🚀 New behavior

After the changes there is no longer an unintended scrollbar outside the modal.

## 💣 Is this a breaking change (Yes/No):

This is not a breaking change.

## 📝 Additional Information

No additional Information.
