### PR TITLE
docs(modal): fix radius property

### DIFF
--- a/apps/docs/content/components/modal/custom-styles.ts
+++ b/apps/docs/content/components/modal/custom-styles.ts
@@ -6,11 +6,11 @@ export default function App() {
   return (
     <>
       <Button onPress={onOpen} color="secondary">Open Modal</Button>
-      <Modal 
-        backdrop="opaque" 
-        isOpen={isOpen} 
+      <Modal
+        backdrop="opaque"
+        isOpen={isOpen}
         onOpenChange={onOpenChange}
-        radius="2xl"
+        radius="xl"
         classNames={{
           body: "py-6",
           backdrop: "bg-[#292f46]/50 backdrop-opacity-40",
@@ -25,7 +25,7 @@ export default function App() {
             <>
               <ModalHeader className="flex flex-col gap-1">Modal Title</ModalHeader>
               <ModalBody>
-                <p> 
+                <p>
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                   Nullam pulvinar risus non risus hendrerit venenatis.
                   Pellentesque sit amet hendrerit risus, sed porttitor quam.
@@ -37,9 +37,9 @@ export default function App() {
                 </p>
                 <p>
                   Magna exercitation reprehenderit magna aute tempor cupidatat consequat elit
-                  dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt cillum quis. 
-                  Velit duis sit officia eiusmod Lorem aliqua enim laboris do dolor eiusmod. 
-                  Et mollit incididunt nisi consectetur esse laborum eiusmod pariatur 
+                  dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt cillum quis.
+                  Velit duis sit officia eiusmod Lorem aliqua enim laboris do dolor eiusmod.
+                  Et mollit incididunt nisi consectetur esse laborum eiusmod pariatur
                   proident Lorem eiusmod et. Culpa deserunt nostrud ad veniam.
                 </p>
               </ModalBody>

--- a/apps/docs/content/components/modal/custom-styles.ts
+++ b/apps/docs/content/components/modal/custom-styles.ts
@@ -10,7 +10,7 @@ export default function App() {
         backdrop="opaque"
         isOpen={isOpen}
         onOpenChange={onOpenChange}
-        radius="xl"
+        radius="lg"
         classNames={{
           body: "py-6",
           backdrop: "bg-[#292f46]/50 backdrop-opacity-40",

--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -184,7 +184,7 @@ Here's an example of how to customize the accordion styles:
 | selectionBehavior         | `toggle` \| `replace`                           | The accordion selection behavior.                                                                       | `toggle` |
 | isCompact                 | `boolean`                                       | Whether all Accordion items should be smaller.                                                          | `false`  |
 | isDisabled                | `boolean`                                       | Whether the Accordion items are disabled.                                                               |          |
-| showDivider               | `boolean`                                       | WWhether to display a divider at the bottom of the each accordion item.                                 | `true`   |
+| showDivider               | `boolean`                                       | Whether to display a divider at the bottom of the each accordion item.                                  | `true`   |
 | DividerProps              | [DividerProps](/docs/components/divider)        | The divider component props.                                                                            | -        |
 | hideIndicator             | `boolean`                                       | Whether the Accordion items indicator is hidden.                                                        |          |
 | disableAnimation          | `boolean`                                       | Whether the Accordion items open/close animation is disabled.                                           |          |


### PR DESCRIPTION
## 📝 Description

> This fix corrects the property type of the custom-styled modal. The radius `2xl`, which is not even listed in the API documentation for the modal, is replaced with `lg`.

## ⛳️ Current behavior (updates)

> The behavior should be changed since `2xl` is not even implemented. I believe the modal in the example is displayed with a radius of `lg`.

## 🚀 New behavior

> Modal code snipped fits to displayed modal in the example.

## 💣 Is this a breaking change (Yes/No):

No

