### PR TITLE
docs(modal): fix radius property

### DIFF
--- a/apps/docs/content/components/modal/custom-styles.ts
+++ b/apps/docs/content/components/modal/custom-styles.ts
@@ -10,7 +10,7 @@ export default function App() {
         backdrop="opaque" 
         isOpen={isOpen} 
         onOpenChange={onOpenChange}
-        radius="2xl"
+        radius="lg"
         classNames={{
           body: "py-6",
           backdrop: "bg-[#292f46]/50 backdrop-opacity-40",


### PR DESCRIPTION
## 📝 Description

> This fix corrects the property type of the custom-styled modal. The radius `2xl`, which is not even listed in the API documentation for the modal, is replaced with `lg`.

## ⛳️ Current behavior (updates)

> The behavior should be changed since `2xl` is not even implemented. I believe the modal in the example is displayed with a radius of `lg`.

## 🚀 New behavior

> Modal code snipped fits to displayed modal in the example.

## 💣 Is this a breaking change (Yes/No):

No

