### PR TITLE
fix:missing names added in the import statement

### DIFF
--- a/apps/docs/content/components/navbar/with-menu.ts
+++ b/apps/docs/content/components/navbar/with-menu.ts
@@ -9,7 +9,7 @@ const AcmeLogo = `export const AcmeLogo = () => (
   </svg>
 );`;
 
-const App = `import {Navbar, NavbarBrand, NavbarContent, NavbarItem, Link, Button} from "@nextui-org/react";
+const App = `import {Navbar, NavbarBrand, NavbarContent, NavbarItem, Link, Button, NavbarMenuToggle, NavbarMenu, NavbarMenuItem} from "@nextui-org/react";
 import {AcmeLogo} from "./AcmeLogo.jsx";
 
 export default function App() {


### PR DESCRIPTION
## 📝 Description

The following dependencies were missing in the import statement of the *Code* of the Navbar component with menu. Added them so that a user is not shown any error when they use it in their project.
*  NavbarMenuToggle
*  NavbarMenu
*  NavbarMenuItem

## ⛳️ Current behavior (updates)

The Code of the Navbar component with menu  is throwing errors displaying:
* Cannot find name 'NavbarMenuToggle'.
* Cannot find name 'NavbarMenu'.
* Cannot find name 'NavbarMenuItem'. Did you mean 'NavbarItem'?

## 🚀 New behavior

No errors are shown now. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
None