### PR TITLE
docs(autocomplete): fix missing defaultItems property

### DIFF
--- a/apps/docs/content/components/autocomplete/controlled.ts
+++ b/apps/docs/content/components/autocomplete/controlled.ts
@@ -37,6 +37,7 @@ export default function App() {
       <Autocomplete
         label="Favorite Animal"
         variant="bordered"
+        defaultItems={animals}
         placeholder="Search an animal"
         className="max-w-xs"
         selectedKey={value}


### PR DESCRIPTION
## 📝 Description

> This adds the missing `defaultItems` property to the Controlled Autocomplete for the typescript snippet.

## ⛳️ Current behavior (updates)

> The example doens't work correctly when copy & pasted. --> Could mislead the user.

## 🚀 New behavior

> The example works now.

## 💣 Is this a breaking change (Yes/No):

No.
