### PR TITLE
fix: added missing ChipProps import

### DIFF
--- a/packages/components/chip/stories/chip.stories.tsx
+++ b/packages/components/chip/stories/chip.stories.tsx
@@ -4,7 +4,7 @@ import {chip} from "@nextui-org/theme";
 import {Avatar} from "@nextui-org/avatar";
 import {CheckIcon} from "@nextui-org/shared-icons";
 
-import {Chip} from "../src";
+import {Chip, ChipProps} from "../src";
 
 export default {
   title: "Components/Chip",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

> Added `ChipProps` import to resolve TypeScript error.

## ⛳️ Current behavior (updates)

> `Cannot find name 'ChipProps'.ts(2304)` due to missing import.

## 🚀 New behavior

> `ChipProps` imported alongside `Chip` component, resolving the error.

## 💣 Is this a breaking change (Yes/No):

> No