### PR TITLE
docs(modal): update documentation to include dismiss properties

### DIFF
--- a/apps/docs/content/components/modal/non-dismissable.ts
+++ b/apps/docs/content/components/modal/non-dismissable.ts
@@ -6,7 +6,7 @@ export default function App() {
   return (
     <>
       <Button onPress={onOpen}>Open Modal</Button>
-      <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={false}>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={false} isKeyboardDismissDisabled={true}>
         <ModalContent>
           {(onClose) => (
             <>

--- a/apps/docs/content/docs/components/modal.mdx
+++ b/apps/docs/content/docs/components/modal.mdx
@@ -60,8 +60,11 @@ When the modal opens:
 
 ### Non-dissmissable
 
-By default the modal can be closed by clicking on the overlay or pressing the <Kbd>Esc</Kbd> key.
-You can disable this behavior by setting the `isDismissable` prop to `false`.
+By default, the modal can be closed by clicking on the overlay or pressing the <Kbd>Esc</Kbd> key. 
+You can disable this behavior by setting the following properties:
+
+- Set the `isDismissable` property to `false` to prevent the modal from closing when clicking on the overlay.
+- Set the `isKeyboardDismissDisabled` property to `true` to prevent the modal from closing when pressing the Esc key.
 
 <CodeDemo title="Non-dissmissible" files={modalContent.nonDismissable} />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/2214

## 📝 Description

Corrected a mistake in the documentation regarding non-dismissable modals.

## ⛳️ Current behavior (updates)

Behavior was not correct for the description.
The demo modal was being closed with the Esc key.

## 🚀 New behavior

`isKeyboardDismissDisabled` props had to be set to true to prevent the modal from closing with the Esc key.


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information
