### PR TITLE
fix: update dev script to only run pnpm sb

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/nextui-org/nextui"
   },
   "scripts": {
-    "dev": "pnpm sb && pnpm dev:docs",
+    "dev": "pnpm sb",
     "build": "turbo build --filter=!@nextui-org/docs --filter=!@nextui-org/storybook",
     "build:fast": "turbo build:fast --filter=!@nextui-org/docs --filter=!@nextui-org/storybook",
     "dev:docs": "turbo dev --filter=@nextui-org/docs",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR updates the dev script in package.json to only execute pnpm sb.

## ⛳️ Current behavior (updates)

Currently, the dev script is set to pnpm sb && pnpm dev:docs, which causes an issue where pnpm dev:docs does not execute because pnpm sb runs indefinitely.

## 🚀 New behavior

With this update, running pnpm dev will only start the Storybook server.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information
