### PR TITLE
fix: dup // fix on a link for edit this page on github

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -83,7 +83,7 @@ export default async function DocPage({params}: DocPageProps) {
   if (!doc) {
     notFound();
   }
-  const editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/${TAG}/${CONTENT_PATH}${currentRoute?.path}`;
+  const editUrl = `${GITHUB_URL}/${REPO_NAME}/edit/${TAG}${CONTENT_PATH}${currentRoute?.path}`;
 
   return (
     <>


### PR DESCRIPTION

## 📝 Description
 
![Screenshot from 2024-01-12 11-12-08](https://github.com/nextui-org/nextui/assets/65047246/bc4913c1-17a6-432e-bcc6-a6bf7a044445)
there was duplicate url // on the route caused from ```CONTENT_PATH ``` 
> 


## 🚀 New behavior

>  I just fixed the // to have a / that comes from the ```CONTENT_PATH``` instead of adding a new one

## 💣 Is this a breaking change (Yes/No):

<! It does not break any changes at all

## 📝 Additional Information

there are a couple of ways to implement this kind of approach .. lemme know what you think 