### PR TITLE
docs(modal): Update documentation's default backdrop value

### DIFF
--- a/apps/docs/content/docs/components/modal.mdx
+++ b/apps/docs/content/docs/components/modal.mdx
@@ -103,7 +103,7 @@ form elements without any problem. the focus returns to the trigger when the mod
 ### Backdrop
 
 The `Modal` component has a `backdrop` prop to show a backdrop behind the modal. The backdrop can be
-either `transparent`, `opaque` or `blur`. The default value is `transparent`.
+either `transparent`, `opaque` or `blur`. The default value is `opaque`.
 
 <CodeDemo title="Backdrop" files={modalContent.backdrop} />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2284 

## 📝 Description

Corrected an error in documentation where the default `backdrop` value for the `Modal` component.

## ⛳️ Current behavior (updates)

The documentation currently lists the default `backdrop` value for the `Modal` component to be `transparent`, while it's `opaque`.

## 🚀 New behavior

The correct value (`opaque`) was set as the listed default value.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
