### PR TITLE
fix(spinner): pass classNames.label to slot

### DIFF
--- a/.changeset/pretty-mice-suffer.md
+++ b/.changeset/pretty-mice-suffer.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/spinner": patch
+---
+
+allow styling Spinner's label by passing classNames to the slot

--- a/packages/components/spinner/src/spinner.tsx
+++ b/packages/components/spinner/src/spinner.tsx
@@ -13,7 +13,7 @@ const Spinner = forwardRef<"div", SpinnerProps>((props, ref) => {
         <i className={slots.circle1({class: classNames?.circle1})} />
         <i className={slots.circle2({class: classNames?.circle2})} />
       </div>
-      {label && <span className={slots.label()}>{label}</span>}
+      {label && <span className={slots.label({class: classNames?.label})}>{label}</span>}
     </div>
   );
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

Fixes the issue with `classNames.label` not being passed to spinner's label slot

## ⛳️ Current behavior (updates)

The `<span>` rendered when `label` is defined cannot be styled using `classNames.label`

## 🚀 New behavior

The classes defined in `classNames.label` are passed down to the slot, which allows styling the element

## 💣 Is this a breaking change (Yes/No):

No
