### PR TITLE
docs(components): error in selecting all

### DIFF
--- a/apps/docs/app/examples/table/use-case/page.tsx
+++ b/apps/docs/app/examples/table/use-case/page.tsx
@@ -409,10 +409,45 @@ export default function Page() {
     setPage(1);
   }, []);
 
+  const bulkUpdateSelectedKeys = useCallback(
+    (
+      updatedSelectedKeys: {
+        [key: number]: Selection;
+      },
+      newSelectedKeys: Selection,
+    ) => {
+      for (let i = 1; i <= pages; i++) {
+        updatedSelectedKeys[i] = newSelectedKeys;
+      }
+    },
+    [pages],
+  );
+
+  const isUnselectAllRows = useCallback(
+    (prevSelectedKeys: Selection, newSelectedKeys: Selection) => {
+      return (
+        newSelectedKeys !== "all" &&
+        newSelectedKeys.size === 0 &&
+        prevSelectedKeys &&
+        (prevSelectedKeys === "all" || prevSelectedKeys.size === rowsPerPage)
+      );
+    },
+    [rowsPerPage],
+  );
+
   const onSelectionChange = (keys: Selection) => {
     let updatedSelectedKeys = {...selectedKeys};
 
-    updatedSelectedKeys[page] = keys;
+    if (keys === "all") {
+      bulkUpdateSelectedKeys(updatedSelectedKeys, "all");
+    } else {
+      if (isUnselectAllRows(updatedSelectedKeys[page], keys)) {
+        bulkUpdateSelectedKeys(updatedSelectedKeys, new Set([]));
+      } else {
+        updatedSelectedKeys[page] = keys;
+      }
+    }
+
     setSelectedKeys(updatedSelectedKeys);
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2313

## 📝 Description

When I select all in the table with 100 data(10 rows per page), go to the next page and uncheck one of the rows.
It says "9 items are selected", however, it should say "99" not "9".

https://nextui.org/docs/components/table

## ⛳️ Current behavior (old)

https://github.com/nextui-org/nextui/assets/62743644/c9519d2e-0637-4e89-b0eb-90296f255d6e


## 🚀 New behavior

https://github.com/nextui-org/nextui/assets/62743644/e172c7fe-6f3f-4cfc-a190-aaca2773884a

- When users select the "All" checkbox select all rows in the current table instead of selecting all rows table throughout the pages.

## 💣 Is this a breaking change (Yes/No):

No, Never touched the table component itself.

## 📝 Additional Information

No.
