### PR TITLE
docs(components): radioGroup component link for Storybook does not work

### DIFF
--- a/apps/docs/content/docs/components/radio-group.mdx
+++ b/apps/docs/content/docs/components/radio-group.mdx
@@ -9,7 +9,7 @@ import {radioGroupContent} from "@/content/components/radio-group";
 
 Radio Group allow users to select a single option from a list of mutually exclusive options.
 
-<ComponentLinks component="radio" reactAriaHook="useRadioGroup" />
+<ComponentLinks component="radiogroup" reactAriaHook="useRadioGroup" />
 
 ---
 


### PR DESCRIPTION
Closes #2334

## 📝 Description

The Radio component's URL link for Storybook was configured wrongly.
Updated that to the correct URL.

old: https://storybook.nextui.org/?path=/story/components-radio--default
new: https://storybook.nextui.org/?path=/story/components-radiogroup--default

## ⛳️ Current behavior (updates)

The Storybook throws the error. (the pic below)
![sb_error](https://github.com/nextui-org/nextui/assets/62743644/de7bc2ee-14c8-4f93-8671-1be5ea42969d)

## 🚀 New behavior

No error.


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
