### PR TITLE
docs(components): table component link for storybook does not work

### DIFF
--- a/packages/components/table/stories/table.stories.tsx
+++ b/packages/components/table/stories/table.stories.tsx
@@ -871,7 +871,7 @@ const InfinitePaginationTemplate = (args: TableProps) => {
   );
 };
 
-export const Static = {
+export const Default = {
   render: StaticTemplate,
 
   args: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2341

## 📝 Description

If you go to the Table component Storybook through the link in the documentation. The Storybook throws the error.(the pic below)

## ⛳️ Current behavior (updates)

The Storybook throws the error. (the pic below)

![Screenshot 2024-02-11 at 9 57 39 PM](https://github.com/nextui-org/nextui/assets/62743644/8acad46e-202e-4a8c-832d-aca23745461f)

## 🚀 New behavior

No error. 

old: https://storybook.nextui.org/?path=/story/components-table--static
new: https://storybook.nextui.org/?path=/story/components-table--default

Any other component has "--default" suffix for its URL uniformly. So I conformed this one to the standard.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
