### PR TITLE
docs(components): tabs component link for storybook does not work

### DIFF
--- a/packages/components/tabs/stories/tabs.stories.tsx
+++ b/packages/components/tabs/stories/tabs.stories.tsx
@@ -265,7 +265,7 @@ const WithFormTemplate = (args: TabsProps) => {
   );
 };
 
-export const Static = {
+export const Default = {
   render: StaticTemplate,
 
   args: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2343

## 📝 Description

If you go to the Tabs component Storybook through the link in the documentation. The Storybook throws the error.

## ⛳️ Current behavior (updates)

The Storybook throws the error. (the pic below)

![Screenshot 2024-02-11 at 10 09 59 PM](https://github.com/nextui-org/nextui/assets/62743644/e57d01a4-7d20-4535-8508-c9d3fd66031b)

## 🚀 New behavior

No error.

old: https://storybook.nextui.org/?path=/story/components-tabs--static
new: https://storybook.nextui.org/?path=/story/components-tabs--default
![new](https://github.com/nextui-org/nextui/assets/62743644/206fab7a-8a84-4f22-a658-09d66335b7c3)

Any other component has "--default" suffix for its URL uniformly. So I conformed this one to the standard.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
