### PR TITLE
Added note for installing React.

### DIFF
--- a/apps/docs/content/docs/frameworks/astro.mdx
+++ b/apps/docs/content/docs/frameworks/astro.mdx
@@ -19,7 +19,13 @@ To use NextUI in your Astro project, you need to follow the following steps:
 
 <Steps>
 
-### Installation
+### Install React
+
+NextUI is built on top of React, so you need to install React first. You can follow the official
+[integration guide](https://docs.astro.build/en/guides/integrations-guide/react/) to install React.
+
+
+### Install NextUI
 
 In your Astro project, run one of the following command to install NextUI:
 


### PR DESCRIPTION
## 📝 Description

If you are trying to add NextUI to a brand new Astro project, you might forget to install React first.
As a result, this PR adds that step -- with a link to the Astro documentation, similar to the Tailwind advice.

## ⛳️ Current behavior (updates)

The current documentation assumes the Astro project already has React installed, but a fresh Astro project will not.

## 🚀 New behavior

This revised documentation is simply more explicit about integrating React in Astro before installing NextUI.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
