### PR TITLE
fix(components): input label overlapping issue

### DIFF
--- a/.changeset/itchy-shirts-build.md
+++ b/.changeset/itchy-shirts-build.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+fixed input label overlapping issue (#2255)

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -87,6 +87,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const {
     ref,
     as,
+    type,
     label,
     baseRef,
     wrapperRef,
@@ -122,7 +123,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
 
   const Component = as || "div";
 
-  const isFilled = !!inputValue;
+  const isFilledByDefault = ["date", "time", "month", "week", "range"].includes(type!);
+  const isFilled = !!inputValue || isFilledByDefault;
   const isFilledWithin = isFilled || isFocusWithin;
   const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "");
   const isMultiline = originalProps.isMultiline;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2255

## 📝 Description

Set Date, Time, Month, Week and Range as `isFilled` as well.

## ⛳️ Current behavior (updates)

Currently the labels would overlap in Date, Time, Month, Week and Range. Screenshot retrieved from the original issue post.

![image](https://github.com/nextui-org/nextui/assets/35857179/25fa02f7-3283-46c6-9254-430125c45bda)

## 🚀 New behavior

<img width="606" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/de7da617-b8c3-4d92-8eed-4a5a9d034a49">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information
