### PR TITLE
fix(components): autocomplete, tabIndex is not passed on input

### DIFF
--- a/.changeset/metal-gorillas-dress.md
+++ b/.changeset/metal-gorillas-dress.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": major
+---
+
+autocomplete, tabIndex is not passed on input

--- a/.changeset/metal-gorillas-dress.md
+++ b/.changeset/metal-gorillas-dress.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/autocomplete": major
+"@nextui-org/autocomplete": patch
 ---
 
 autocomplete, tabIndex is not passed on input

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -356,9 +356,9 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   const getInputProps = () =>
     ({
-      ...slotsProps.inputProps,
       ...otherProps,
       ...inputProps,
+      ...slotsProps.inputProps,
       onClick: chain(slotsProps.inputProps.onClick, otherProps.onClick),
     } as unknown as InputProps);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2372

## 📝 Description

Autocomplete, tabIndex is not passed on input

## ⛳️ Current behavior (updates)

`inputProps` don't get passed down to the input element.

## 🚀 New behavior

It is used to `otherProps` override `slotsProps.inputProps`. Now `slotsProps.inputProps`(user input) takes precedence over.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information
