### PR TITLE
fix(components): chip storyboard missing some import

### DIFF
--- a/.changeset/silly-rocks-pull.md
+++ b/.changeset/silly-rocks-pull.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/chip": major
+---
+
+Chip storyboard missing some import

--- a/packages/components/chip/stories/chip.stories.tsx
+++ b/packages/components/chip/stories/chip.stories.tsx
@@ -4,7 +4,7 @@ import {chip} from "@nextui-org/theme";
 import {Avatar} from "@nextui-org/avatar";
 import {CheckIcon} from "@nextui-org/shared-icons";
 
-import {Chip} from "../src";
+import {Chip, ChipProps} from "../src";
 
 export default {
   title: "Components/Chip",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2384

## 📝 Description

In chip.stories.tsx, we have the ChipProps import missing.

## ⛳️ Current behavior (updates)

Missing import

## 🚀 New behavior

No missing imports

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
