### PR TITLE
fix(theme): chip with dot variant is not properly padded when having …

### DIFF
--- a/.changeset/fast-phones-fail.md
+++ b/.changeset/fast-phones-fail.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": major
+---
+
+Chip with dot variant is not properly styled

--- a/packages/core/theme/src/components/chip.ts
+++ b/packages/core/theme/src/components/chip.ts
@@ -449,6 +449,15 @@ const chip = tv({
         base: "w-auto",
       },
     },
+    // isOneChar / dot
+    {
+      isOneChar: true,
+      variant: "dot",
+      class: {
+        base: "w-auto h-7 px-1 items-center",
+        content: "px-2",
+      },
+    },
     // hasStartContent / size
     {
       hasStartContent: true,


### PR DESCRIPTION
…a 1-char text

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2383

## 📝 Description

Chip is not properly padded when using the "dot" variant and using a 1-char string as children.

## ⛳️ Current behavior (updates)

Here is the previous style for the Chip component.

![prev](https://github.com/nextui-org/nextui/assets/62743644/184719bb-f0a4-4d58-a842-b511ae0f4f93)


## 🚀 New behavior

Here is the updated style for the Chip component.

![curr2](https://github.com/nextui-org/nextui/assets/62743644/2a2b92e4-b444-4389-93ae-838f4f02060f)

![curr](https://github.com/nextui-org/nextui/assets/62743644/a5b608e7-2b48-4738-b2ca-ab99e6ee7c0d)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
