### PR TITLE
chore (Spinner): Fixed Typo In Core Component Script spinner.ts

### DIFF
--- a/packages/core/theme/src/components/spinner.ts
+++ b/packages/core/theme/src/components/spinner.ts
@@ -5,7 +5,7 @@ import {tv} from "../utils/tv";
 /**
  * Spinner wrapper **Tailwind Variants** component
  *
- * const {base, line1, line2, label } = spinner({...})
+ * const {base, circle1, circle2, label } = spinner({...})
  *
  * @example
  * <div className={base())}>


### PR DESCRIPTION
Fixed a typo where in example it was importing `line1` and `line1` instead of `circle1` and `circle2`.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2399

## 📝 Description

A typo in commented example, while assigning spinner function objects, currently importing line1 and line2 which misleads developer.

## ⛳️ Current behavior (updates)
Importing `line1` and `line2` in example snippet.

## 🚀 New behavior
Should import `circle1` and `circle2`

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
No