### PR TITLE
fix(docs): mistakes in tabs examples

### DIFF
--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -99,7 +99,7 @@ function ExampleClientRouterWithTabs() {
 
   return (
     <Tabs aria-label="Options" selectedKey={pathname}>
-      <Tab key="photos" title="Photos" href="/photos">
+      <Tab key="/photos" title="Photos" href="/photos">
         <Card>
           <CardBody>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -108,7 +108,7 @@ function ExampleClientRouterWithTabs() {
           </CardBody>
         </Card>
       </Tab>
-      <Tab key="music" title="Music" href="/music">
+      <Tab key="/music" title="Music" href="/music">
         <Card>
           <CardBody>
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -117,7 +117,7 @@ function ExampleClientRouterWithTabs() {
           </CardBody>
         </Card>
       </Tab>
-      <Tab key="videos" title="Videos" href="/videos">
+      <Tab key="/videos" title="Videos" href="/videos">
         <Card>
           <CardBody>
             Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
@@ -144,10 +144,10 @@ function AppTabs() {
   return (
     <div className="flex flex-col gap-2">
       <Tabs selectedKey={pathname} aria-label="Tabs">
-        <Tab id="/" href="/" title="Home" />
-        <Tab id="/photos" href="/photos" title="Photos" />
-        <Tab id="/music" href="/music" title="Music" />
-        <Tab id="/videos" href="/videos" title="Videos" />
+        <Tab key="/" href="/" title="Home" />
+        <Tab key="/photos" href="/photos" title="Photos" />
+        <Tab key="/music" href="/music" title="Music" />
+        <Tab key="/videos" href="/videos" title="Videos" />
       </Tabs>
       <Routes>
         <Route path="/" element={<HomePage />} />


### PR DESCRIPTION
## 📝 Description

Fix mistakes in tabs examples with Next.js and React Router.

## ⛳️ Current behavior (updates)

### Next.js example:
```js
<Tabs aria-label="Options" selectedKey={pathname}>
      <Tab key="photos" title="Photos" href="/photos">
        <Card>
          <CardBody>
            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
          </CardBody>
        </Card>
      </Tab>
...
```

Accroding to [Next.js App router - usePathname#returns](https://nextjs.org/docs/app/api-reference/functions/use-pathname#returns), `key` should be corresponding url path, that is, missing `/` in this example.

### React Router example:
Prop `id` of `<Tab/>` doesn't work, but `key` does.
```js
<Tabs selectedKey={pathname} aria-label="Tabs">
    <Tab id="/" href="/" title="Home" />
    <Tab id="/photos" href="/photos" title="Photos" />
    <Tab id="/music" href="/music" title="Music" />
    <Tab id="/videos" href="/videos" title="Videos" />
</Tabs>
```



## 💣 Is this a breaking change (Yes/No):

No


