### PR TITLE
fix(docs): accordion itemClasses

### DIFF
--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -132,7 +132,7 @@ Accordion is a controlled component, which means you need to control the `select
 You can customize the accordion and accordion items styles by using any of the following properties:
 
 - `className`: The class name of the accordion. Modify the accordion wrapper styles.(Accordion)
-- `itemStyles`: The styles of the accordion item. Modify all accordion items styles at once. (Accordion)
+- `itemClasses`: The class names of the accordion items. Modify all accordion items styles at once. (Accordion)
 - `classNames`: The class names of the accordion items. Modify each accordion item styles separately. (AccordionItem)
 
 Here's an example of how to customize the accordion styles:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2107

## 📝 Description

There is no`itemStyles` prop in `Accordion` It should be `itemClasses` instead.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information
