### PR TITLE
fix(components): incorrect strokeWidth

### DIFF
--- a/.changeset/tricky-moons-obey.md
+++ b/.changeset/tricky-moons-obey.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/progress": patch
+---
+
+fix incorrect strokeWidth in circular progress (#1790)

--- a/packages/components/progress/src/use-circular-progress.ts
+++ b/packages/components/progress/src/use-circular-progress.ts
@@ -112,7 +112,8 @@ export function useCircularProgress(originalProps: UseCircularProgressProps) {
   const selfMounted = originalProps.disableAnimation ? true : isMounted;
 
   const center = 16;
-  const strokeWidth = strokeWidthProp || originalProps.size === "sm" ? 2 : 3;
+  const strokeWidth = strokeWidthProp || (originalProps.size === "sm" ? 2 : 3);
+
   const radius = 16 - strokeWidth;
   const circumference = 2 * radius * Math.PI;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1790

## 📝 Description

the logic for setting `strokeWidth` is incorrect in circular progres

## ⛳️ Current behavior (updates)

if we set the top one with `strokeWidth={2}` and the bottom one with `strokeWidth={3}`, the width is same due to the incorrect logic.

![image](https://github.com/nextui-org/nextui/assets/35857179/9b28d8e5-3b3a-4fd1-8304-87b94721f0d3)

## 🚀 New behavior

Here's the expected width.

![image](https://github.com/nextui-org/nextui/assets/35857179/78aa7047-3cc7-493d-a07a-b7d01d0b51ed)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
