### PR TITLE
fix: #2382 typo in modal transition CSS variable access

### DIFF
--- a/.changeset/five-panthers-dress.md
+++ b/.changeset/five-panthers-dress.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/modal": patch
+---
+
+Fix typo in CSS variable accessor for modal transition

--- a/packages/components/modal/src/modal-transition.ts
+++ b/packages/components/modal/src/modal-transition.ts
@@ -3,7 +3,7 @@ import {TRANSITION_EASINGS} from "@nextui-org/framer-transitions";
 export const scaleInOut = {
   enter: {
     scale: "var(--scale-enter)",
-    y: "var(--slide-enter))",
+    y: "var(--slide-enter)",
     opacity: 1,
     transition: {
       scale: {


### PR DESCRIPTION
Closes #2382 

## 📝 Description

Fixes typo in CSS variable access syntax

## ⛳️ Current behavior (updates)

Console shows a warning and transition of modal doesn't complete as expected.

## 🚀 New behavior

No more warnings, transition works as expected.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
