### PR TITLE
fix: isReadOnly in Autocomplete

### DIFF
--- a/.changeset/thirty-bugs-beg.md
+++ b/.changeset/thirty-bugs-beg.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+fixed isReadOnly logic in Autocomplete (#2420)

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -154,6 +154,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     classNames,
     onOpenChange,
     onClose,
+    isReadOnly = false,
     ...otherProps
   } = props;
 
@@ -166,6 +167,9 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     menuTrigger,
     shouldCloseOnBlur,
     allowsEmptyCollection,
+    ...(isReadOnly && {
+      disabledKeys: (children as unknown as Record<string, any>[]).map((o) => o.key),
+    }),
     defaultFilter: defaultFilter && typeof defaultFilter === "function" ? defaultFilter : contains,
     onOpenChange: (open, menuTrigger) => {
       onOpenChange?.(open, menuTrigger);

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -123,6 +123,8 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
   const isClearable =
     originalProps.disableClearable !== undefined
       ? !originalProps.disableClearable
+      : originalProps.isReadOnly
+      ? false
       : originalProps.isClearable;
 
   const {

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -55,6 +55,11 @@ export default {
         type: "boolean",
       },
     },
+    isReadonly: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   decorators: [
     (Story) => (
@@ -651,6 +656,16 @@ export const Required = {
 
   args: {
     ...defaultProps,
+  },
+};
+
+export const ReadOnly = {
+  render: Template,
+
+  args: {
+    ...defaultProps,
+    selectedKey: "cat",
+    isReadOnly: true,
   },
 };
 

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -666,7 +666,6 @@ export const ReadOnly = {
     ...defaultProps,
     selectedKey: "cat",
     isReadOnly: true,
-    isClearable: false,
   },
 };
 

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -666,6 +666,7 @@ export const ReadOnly = {
     ...defaultProps,
     selectedKey: "cat",
     isReadOnly: true,
+    isClearable: false,
   },
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2420

## 📝 Description

- revised the isReadOnly logic in Autocomplete
- created `isReadOnly` example in storybook

## ⛳️ Current behavior (updates)

when `isReadOnly` is set, users 
- cannot edit the input
- can open the listbox
- can select the menu option

## 🚀 New behavior

when `isReadOnly` is set, users 
- cannot edit the input
- can open the listbox
- cannot select the menu option

![image](https://github.com/nextui-org/nextui/assets/35857179/31617019-abbb-4785-ac84-4bbdad518706)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

When someone prefer to not open the listbox, then they should use `isDisabled` instead.
