### PR TITLE
fix:(docs) capital city of Australia in Ratio Group - With Description page

### DIFF
--- a/apps/docs/content/components/radio-group/with-description.ts
+++ b/apps/docs/content/components/radio-group/with-description.ts
@@ -9,8 +9,8 @@ export default function App() {
       <Radio value="buenos-aires" description="The capital of Argentina">
         Buenos Aires
       </Radio>
-      <Radio value="sydney" description="The capital of Australia">
-        Sydney
+      <Radio value="canberra" description="The capital of Australia">
+        Canberra
       </Radio>
       <Radio value="london" description="The capital of England">
         London


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2430

## 📝 Description

The capital city of Australia on the https://nextui.org/docs/components/radio-group#with-description (Ratio Group - With Description) page is displayed as "Sydney" when the capital city of Australia is "Canberra".

## ⛳️ Current behavior (updates)

The capital city of Australia https://nextui.org/docs/components/radio-group#with-description (Ratio Group - With Description) page is displayed as "Sydney"

## 🚀 New behavior

The capital city of Australia https://nextui.org/docs/components/radio-group#with-description (Ratio Group - With Description) page is displayed as "Canberra"

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
