### PR TITLE
fix(components): isdisabled does not disable dropdown

### DIFF
--- a/.changeset/two-lobsters-sip.md
+++ b/.changeset/two-lobsters-sip.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/dropdown": major
+---
+
+Fixed the bug: isDisabled does not disable dropdown

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -119,7 +119,7 @@ export function useDropdown(props: UseDropdownProps) {
   });
 
   const getMenuTriggerProps: PropGetter = (
-    props = {},
+    originalProps = {},
     _ref: Ref<any> | null | undefined = null,
   ) => {
     // These props are not needed for the menu trigger since it is handled by the popover trigger.
@@ -127,7 +127,7 @@ export function useDropdown(props: UseDropdownProps) {
     const {onKeyDown, onPress, onPressStart, ...otherMenuTriggerProps} = menuTriggerProps;
 
     return {
-      ...mergeProps(otherMenuTriggerProps, props),
+      ...mergeProps(otherMenuTriggerProps, {isDisabled: props.isDisabled, originalProps}),
       ref: mergeRefs(_ref, triggerRef),
     };
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2276

## 📝 Description

[Based on the docs](https://nextui.org/docs/components/dropdown#dropdown-props), adding an isDisabled prop and setting it to true does not disable a dropdown

## ⛳️ Current behavior (updates)

The `isDisabled` prop does not work, because the Dropdown component does not pass the `isDisabled` prop to the PopoverTrigger component.

## 🚀 New behavior

It disables the trigger when `isDisabled` prop gets passed.

https://github.com/nextui-org/nextui/assets/62743644/268482fe-6a70-461f-8981-81d8cd3f559f


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

N/A