### PR TITLE
fix: sidebar & toc spacing on nextui docs

### DIFF
--- a/apps/docs/components/docs/sidebar.tsx
+++ b/apps/docs/components/docs/sidebar.tsx
@@ -261,7 +261,7 @@ export const DocsSidebar: FC<DocsSidebarProps> = ({routes, slug, tag, className}
   }, [] as string[]);
 
   return (
-    <div className={clsx("lg:fixed lg:top-20 mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
+    <div className={clsx("lg:fixed lg:top-[121px] mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
       <Tree defaultExpandedKeys={expandedKeys} items={routes || []}>
         {(route) => (
           <Item

--- a/apps/docs/components/docs/sidebar.tsx
+++ b/apps/docs/components/docs/sidebar.tsx
@@ -261,7 +261,7 @@ export const DocsSidebar: FC<DocsSidebarProps> = ({routes, slug, tag, className}
   }, [] as string[]);
 
   return (
-    <div className={clsx("lg:fixed lg:top-[121px] mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
+    <div className={clsx("fixed lg:top-[121px] mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
       <Tree defaultExpandedKeys={expandedKeys} items={routes || []}>
         {(route) => (
           <Item

--- a/apps/docs/components/docs/sidebar.tsx
+++ b/apps/docs/components/docs/sidebar.tsx
@@ -261,7 +261,7 @@ export const DocsSidebar: FC<DocsSidebarProps> = ({routes, slug, tag, className}
   }, [] as string[]);
 
   return (
-    <div className={clsx("fixed lg:top-[121px] mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
+    <div className={clsx("fixed top-[121px] mt-2 z-0 lg:h-[calc(100vh-121px)]", className)}>
       <Tree defaultExpandedKeys={expandedKeys} items={routes || []}>
         {(route) => (
           <Item

--- a/apps/docs/components/docs/toc.tsx
+++ b/apps/docs/components/docs/toc.tsx
@@ -54,7 +54,7 @@ export const DocsToc: FC<DocsTocProps> = ({headings}) => {
   return (
     <div
       ref={tocRef}
-      className="fixed w-full max-w-[12rem] flex flex-col gap-4 text-left top-20 pb-20 h-[calc(100vh-121px)] scrollbar-hide overflow-y-scroll"
+      className="fixed w-full max-w-[12rem] flex flex-col gap-4 text-left top-[121px] pb-20 h-[calc(100vh-121px)] scrollbar-hide overflow-y-scroll"
       style={{
         WebkitMaskImage: `linear-gradient(to top, transparent 0%, #000 100px, #000 ${
           scrollPosition > 30 ? "90%" : "100%"

--- a/apps/docs/components/navbar.tsx
+++ b/apps/docs/components/navbar.tsx
@@ -350,7 +350,12 @@ export const Navbar: FC<NavbarProps> = ({children, routes, mobileRoutes = [], sl
       </NavbarContent>
 
       <NavbarMenu>
-        <DocsSidebar className="mt-4" routes={[...mobileRoutes, ...routes]} slug={slug} tag={tag} />
+        <DocsSidebar
+          className={clsx({"w-full top-[40px]": isMenuOpen}, "mt-4")}
+          routes={[...mobileRoutes, ...routes]}
+          slug={slug}
+          tag={tag}
+        />
         {children}
       </NavbarMenu>
     </NextUINavbar>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- revised spacing for sidebar and toc to show the blocked content

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

![image](https://github.com/nextui-org/nextui/assets/35857179/40855c7c-2c9c-40bd-a79b-9f887bd20217)

![image](https://github.com/nextui-org/nextui/assets/35857179/e48bf56f-4487-4d11-9fff-ac071b9c9c26)

> Please describe the behavior or changes this PR adds

![image](https://github.com/nextui-org/nextui/assets/35857179/48d96a6f-7dec-449f-9b43-7e57e00ead9e)

![image](https://github.com/nextui-org/nextui/assets/35857179/30ed2ab0-09be-4328-a3ad-c80a3fd95e30)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
