### PR TITLE
fix(utils): include enterKeyHint in dom-props

### DIFF
--- a/.changeset/metal-peas-act.md
+++ b/.changeset/metal-peas-act.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/react-rsc-utils": patch
+---
+
+include enterKeyHint in dom-props (#2432)

--- a/packages/utilities/react-rsc-utils/src/dom-props.ts
+++ b/packages/utilities/react-rsc-utils/src/dom-props.ts
@@ -47,6 +47,7 @@ export const DOMPropNames = new Set([
   "draggable",
   "dropzone",
   "encType",
+  "enterKeyHint",
   "for",
   "form",
   "formAction",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2432

## 📝 Description

- currently `enterKeyHint` in `otherProps` got filtered out since it is not considered as a dom prop.
- e.g. `<Input {...args} enterKeyHint="search" />`, `enterKeyHint` will be ignored.

## ⛳️ Current behavior (updates)

It shows `return`, which is not expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/083225c2-d47d-4d51-85dd-8fb517afcc4e)

## 🚀 New behavior

It shows `search`, which is not expected.

![image](https://github.com/nextui-org/nextui/assets/35857179/c481abf0-89cf-406e-bad6-4a2c066085ac)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
