### PR TITLE
chore (pnpm clean) - `rimraf` Instead of `rm` for Windows OS Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "turbo:clean": "turbo clean && rimraf ./node_modules/.cache/turbo",
     "turbo:graph": "pnpm build --graph=dependency-graph.png",
     "clean": "pnpm turbo:clean && pnpm clean:jest && pnpm clean:node-modules && pnpm clean:lock && pnpm install --hoist",
-    "clean:node-modules": "rimraf ./apps/**/node_modules && rimraf ./packages/**/**/node_modules && rm -rf ./node_modules",
+    "clean:node-modules": "rimraf ./apps/**/node_modules && rimraf ./packages/**/**/node_modules && rimraf ./node_modules",
     "clean:changelogs": "rimraf ./packages/**/**/CHANGELOG.md",
     "clean:lock": "rm ./pnpm-lock.yaml",
     "clean:jest": "jest --clearCache",


### PR DESCRIPTION
replace `rm` with rimraf while deleting node_modules during `pnpm clean` to support in both Windows and Linux.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2442

## 📝 Description
Replace `rm -rf` with `rimraf` in `[pnpm clean](clean:node-modules)` in root package.json scripts.

## ⛳️ Current behavior (updates)
`[pnpm clean](clean:node-modules)` script used for `node_modules` cleaning doesn't work in Windows OS as `rm` command is not internal.

## 🚀 New behavior
Deletes root `node_modules` in Windows OS as well with `rimraf`.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
NA