### PR TITLE
fix(components): getMenuTriggerProps in use-dropdown.ts returns origi…

### DIFF
--- a/.changeset/lemon-elephants-shout.md
+++ b/.changeset/lemon-elephants-shout.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/dropdown": major
+---
+
+a small support fix for getMenuTriggerProps in use-dropdown.ts returns originalProps as Object

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -127,7 +127,7 @@ export function useDropdown(props: UseDropdownProps) {
     const {onKeyDown, onPress, onPressStart, ...otherMenuTriggerProps} = menuTriggerProps;
 
     return {
-      ...mergeProps(otherMenuTriggerProps, {isDisabled}, originalProps),
+      ...mergeProps(otherMenuTriggerProps, {isDisabled: props.isDisabled}, originalProps),
       ref: mergeRefs(_ref, triggerRef),
     };
   };


### PR DESCRIPTION
…nalProps as Object

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2448

## 📝 Description

As per request from @wingkwong for the review of [this PR](https://github.com/nextui-org/nextui/pull/2450), since my last change was affecting this matter.

## ⛳️ Current behavior (updates)

`isDisabled` does not disable dropdown.

## 🚀 New behavior

- To fix this, we intentionally use `props.isDisabled` to take the `isDisabled` prop from the Dropdown component in effect as well.
- No more appear in HTML as `originalProps=[Object Object]`.


https://github.com/nextui-org/nextui/assets/62743644/cbbc7e18-0e24-488e-83c7-c8dfd968a0a4


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

No.