### PR TITLE
chore(pnpm:lock script): `rimraf` for windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "clean": "pnpm turbo:clean && pnpm clean:jest && pnpm clean:node-modules && pnpm clean:lock && pnpm install --hoist",
     "clean:node-modules": "rimraf ./apps/**/node_modules && rimraf ./packages/**/**/node_modules && rimraf ./node_modules",
     "clean:changelogs": "rimraf ./packages/**/**/CHANGELOG.md",
-    "clean:lock": "rm ./pnpm-lock.yaml",
+    "clean:lock": "rimraf ./pnpm-lock.yaml",
     "clean:jest": "jest --clearCache",
     "create:cmp": "plop component",
     "create:pkg": "plop package",


### PR DESCRIPTION
replaced `rm` with `rimraf` in `pnpm:lock` in root package.json to support windows

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2453

## 📝 Description
Replace `rm` with rimraf in [pnpm clean](clean:lock) in root package.json script.

## ⛳️ Current behavior (updates)
`[pnpm clean](clean:lock)` script used for `pnpm-lock.yaml` cleaning doesn't work in Windows OS as rm command is not internal.

## 🚀 New behavior
Deletes root `pnpm-lock.yaml` in Windows OS as well with rimraf.

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
No