### PR TITLE
fix(autocomplete): support isReadOnly for dynamic collections in Autocomplete

### DIFF
--- a/.changeset/tough-spies-tease.md
+++ b/.changeset/tough-spies-tease.md
@@ -1,0 +1,8 @@
+---
+"@nextui-org/autocomplete": patch
+"@nextui-org/dropdown": patch
+"@nextui-org/popover": patch
+"@nextui-org/tooltip": patch
+---
+
+fix(autocomplete): support isReadOnly for dynamic collections in Autocomplete

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -163,15 +163,12 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
   // Setup filter function and state.
   const {contains} = useFilter(filterOptions);
 
-  const state = useComboBoxState({
+  let state = useComboBoxState({
     ...originalProps,
     children,
     menuTrigger,
     shouldCloseOnBlur,
     allowsEmptyCollection,
-    ...(isReadOnly && {
-      disabledKeys: (children as unknown as Record<string, any>[]).map((o) => o.key),
-    }),
     defaultFilter: defaultFilter && typeof defaultFilter === "function" ? defaultFilter : contains,
     onOpenChange: (open, menuTrigger) => {
       onOpenChange?.(open, menuTrigger);
@@ -180,6 +177,13 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       }
     },
   });
+
+  state = {
+    ...state,
+    ...(isReadOnly && {
+      disabledKeys: new Set([...state.collection.getKeys()].map((k) => k)),
+    }),
+  };
 
   // Setup refs and get props for child elements.
   const buttonRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2457

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

<img width="744" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/c0d6aaa6-3e8c-4f53-8365-eb9d7a81cfe8">


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
