### PR TITLE
fix(breadcrumbs): add RTL support to the breadcrumbs component (#2486)

### DIFF
--- a/.changeset/red-terms-rule.md
+++ b/.changeset/red-terms-rule.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/breadcrumbs": patch
+---
+
+Add RTL support to the breadcrumbs component

--- a/packages/components/breadcrumbs/src/breadcrumbs.tsx
+++ b/packages/components/breadcrumbs/src/breadcrumbs.tsx
@@ -14,7 +14,11 @@ const Breadcrumbs = forwardRef<"div", BreadcrumbsProps>((props, ref) => {
     children,
     childCount,
     itemProps,
-    separator = <ChevronRightIcon />,
+    separator = (
+      <div className="rtl:transform rtl:rotate-180">
+        <ChevronRightIcon />
+      </div>
+    ),
     maxItems,
     itemsBeforeCollapse,
     itemsAfterCollapse,

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React  , { useEffect }from "react";
 import {themes} from "@storybook/theming";
 import {NextUIProvider} from "@nextui-org/system/src/provider";
 import type {Preview} from "@storybook/react";
@@ -10,6 +10,10 @@ const decorators: Preview["decorators"] = [
     const direction =
       // @ts-ignore
       locale && new Intl.Locale(locale)?.textInfo?.direction === "rtl" ? "rtl" : undefined;
+      
+    useEffect(() => {
+      document.documentElement.style.setProperty("--direction", direction || "ltr");
+    }, [direction]);
 
     return (
       <NextUIProvider locale={locale}>

--- a/packages/storybook/.storybook/style.css
+++ b/packages/storybook/.storybook/style.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --direction: ltr;
+}
+
+body {
+  direction: var(--direction);
+}
+
 h1 {
   @apply text-4xl font-bold !text-foreground;
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2486

## 📝 Description

Add RTL support to the breadcrumbs component.

## ⛳️ Current behavior (updates)

he breadcrumbs component currently lacks support for right-to-left (RTL) direction.

## 🚀 New behavior

This PR addresses the RTL support issue in the breadcrumbs component, ensuring correct rendering in RTL environments.

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
