### PR TITLE
fix(table): hide empty content if isLoading is true (#2470)

### DIFF
--- a/packages/components/table/src/table-body.tsx
+++ b/packages/components/table/src/table-body.tsx
@@ -105,7 +105,7 @@ const TableBody = forwardRef<"tbody", TableBodyProps>((props, ref) => {
           colSpan={collection.columnCount}
           role="gridcell"
         >
-          {bodyProps.emptyContent}
+          {!isLoading && bodyProps.emptyContent}
         </td>
       </tr>
     );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2470

## 📝 Description

This change ensures that `emptyContent` is hidden if `isLoading` is `true`

## ⛳️ Current behavior (updates)

Currently, if `loadingContent` and `emptyContent` are both provided, and `isLoading` is true, NextUI will render both of them on top of each other.

## 🚀 New behavior

This change suppresses the rendering of `emptyContent` if `isLoading` is true.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

Note that there's an existing issue with `loadingContent` where if `emptyContent` is **not** provided, NextUI will render `loadingContent` on top of the columns (instead of inside the table). This change doesn't fix that, but rather make `isLoading`/`loadingContent` play nice with a provided `emptyContent`. A separate fix is still needed for when `emptyContent` is not provided.
