### PR TITLE
fix(components): popover closing issue in autocomplete with open modal

### DIFF
--- a/.changeset/four-turtles-move.md
+++ b/.changeset/four-turtles-move.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/popover": patch
+---
+
+fixed popover closing issue in autocomplete with open modal (#2475, #2082, #1987)

--- a/packages/components/popover/src/free-solo-popover.tsx
+++ b/packages/components/popover/src/free-solo-popover.tsx
@@ -75,7 +75,7 @@ const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>((props, ref) => 
   } = usePopover({
     ...props,
     // avoid closing the popover when navigating with the keyboard
-    shouldCloseOnInteractOutside: undefined,
+    shouldCloseOnInteractOutside: () => false,
     ref,
   });
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- closes: #2475
- closes: #2082
- closes: #1987

## 📝 Description

- revised `shouldCloseOnInteractOutside` in FreeSoloPopover
- some people suggested to set `allowsCustomValue` to `true`. This could temporarily make the popover close because it makes the `inputRef.current` not to blur so that Autocomplete won't be re-rendered with `isOpen = true`. However, this won't blur the input if the selection is empty (i.e. it'll stay focused).

https://github.com/nextui-org/nextui/blob/2894aecca1a2ef0dfb3066b9b8df24ce48c99dae/packages/components/autocomplete/src/use-autocomplete.ts#L287-L291

## ⛳️ Current behavior (updates)

The popover can't be closed with open modal. See the above issue #2475 for the demo.

## 🚀 New behavior

[nextui-pr2494-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/95f446cf-740e-4117-bc91-a33ffde0203d)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue in the "@nextui-org/popover" package where the popover would incorrectly close when using autocomplete with an open modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->