### PR TITLE
feat(table spinner): Fixed Spinner without emptyContent prop in Table

### DIFF
--- a/.changeset/nice-rockets-watch.md
+++ b/.changeset/nice-rockets-watch.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/table": major
+"@nextui-org/table": patch
 ---
 
 fixed Spinner loading on top of columns instead of inside table in case of emptyContent prop not passed to Table body

--- a/.changeset/nice-rockets-watch.md
+++ b/.changeset/nice-rockets-watch.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": major
+---
+
+fixed Spinner loading on top of columns instead of inside table in case of emptContent prop not passed to Table body

--- a/.changeset/nice-rockets-watch.md
+++ b/.changeset/nice-rockets-watch.md
@@ -2,4 +2,4 @@
 "@nextui-org/table": patch
 ---
 
-fixed Spinner loading on top of columns instead of inside table in case of emptyContent prop not passed to Table body
+fixed `Spinner` loading on top of columns instead of inside `Table` in case of `emptyContent` prop not passed to `Table` body

--- a/.changeset/nice-rockets-watch.md
+++ b/.changeset/nice-rockets-watch.md
@@ -2,4 +2,4 @@
 "@nextui-org/table": major
 ---
 
-fixed Spinner loading on top of columns instead of inside table in case of emptContent prop not passed to Table body
+fixed Spinner loading on top of columns instead of inside table in case of emptyContent prop not passed to Table body

--- a/packages/components/table/src/table-body.tsx
+++ b/packages/components/table/src/table-body.tsx
@@ -121,6 +121,7 @@ const TableBody = forwardRef<"tbody", TableBodyProps>((props, ref) => {
         >
           {bodyProps.loadingContent}
         </td>
+        {!emptyContent && <td className={slots?.emptyWrapper({class: classNames?.emptyWrapper})} />}
       </tr>
     );
   }


### PR DESCRIPTION
Fixed Spinner loading on top of columns in case of `emptyContent` prop not passed to Table.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2499

## 📝 Description
Fixed the Spinner loading on top of columns instead of inside table in case of `emptyContent` prop not passed to Table.

## ⛳️ Current behavior (updates)
Spinner loading on top of columns instead of inside table in case of `emptyContent` prop not passed to Table.

## 🚀 New behavior
Spinner loading inside Table in case of `emptyContent` prop not passed to Table.

Test:
```
<Table aria-label="Example empty table" {...args}>
  <TableHeader>
    <TableColumn>NAME</TableColumn>
    <TableColumn>ROLE</TableColumn>
    <TableColumn>STATUS</TableColumn>
  </TableHeader>
  <TableBody isLoading loadingContent={<Spinner label="Loading..." />}>
    {[]}
  </TableBody>
</Table>
```
Test Visual:
![tableLoader1](https://github.com/nextui-org/nextui/assets/116849110/4081f703-2fc3-4959-8529-679ae73c73a4)

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed the Spinner loading issue in `TableBody` when `emptyContent` prop is not provided, ensuring an empty table cell is displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->