### PR TITLE
fix(disabled table rows): fixed cursor for disabled rows in Table

### DIFF
--- a/.changeset/mighty-hornets-destroy.md
+++ b/.changeset/mighty-hornets-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/table": major
+"@nextui-org/table": patch
 ---
 
 Fixed normal cursor to cursor-not-allowed for disabled rows in Table

--- a/.changeset/mighty-hornets-destroy.md
+++ b/.changeset/mighty-hornets-destroy.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": major
+---
+
+Fixed normal cursor to cursor-not-allowed for disabled rows in Table

--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -102,6 +102,7 @@ const table = tv({
       "data-[selected=true]:before:opacity-100",
       // disabled
       "group-data-[disabled=true]:text-foreground-300",
+      "group-data-[disabled=true]:cursor-not-allowed",
     ],
     tfoot: "",
     sortIcon: [


### PR DESCRIPTION
Fixed cursor for disabled rows in Table rows .

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2501

## 📝 Description
Fixed the normal cursor to `cursor-not-allowed` for `disabled` rows in Table.

## ⛳️ Current behavior (updates)
Normal cursor shows for disabled rows in Table.

![tableCursor](https://github.com/nextui-org/nextui/assets/116849110/bd63b50f-4c17-4054-9e08-aabad51c8754)

## 🚀 New behavior
`cursor-not-allowed` shows for disabled rows in Table.

![tableCursor1](https://github.com/nextui-org/nextui/assets/116849110/36d46643-9950-4b50-a4c3-795b7d9cdb98)


## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced user experience by updating the cursor style for disabled rows in the Table component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->