### PR TITLE
fix(table striped): isStriped prop fix for multiple computed values in `td` 

### DIFF
--- a/.changeset/empty-eels-compare.md
+++ b/.changeset/empty-eels-compare.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/table": minor
+"@nextui-org/table": patch
 ---
 
 Fixed the `Table` rendering the contents of the cell beneath the stripe in case of multiple computed values provided in `td`

--- a/.changeset/empty-eels-compare.md
+++ b/.changeset/empty-eels-compare.md
@@ -2,4 +2,4 @@
 "@nextui-org/table": patch
 ---
 
-Fixed the `Table` rendering the contents of the cell beneath the stripe in case of multiple computed values provided in `td`
+Fixed an issue where the `Table` component incorrectly rendered cell contents beneath the stripe when multiple computed values were provided in a `td` (table cell) element.

--- a/.changeset/empty-eels-compare.md
+++ b/.changeset/empty-eels-compare.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": minor
+---
+
+Fixed `Table` rendering the contents of the cell beneath the stripe for the multiple computed values in `td`

--- a/.changeset/empty-eels-compare.md
+++ b/.changeset/empty-eels-compare.md
@@ -2,4 +2,4 @@
 "@nextui-org/table": minor
 ---
 
-Fixed `Table` rendering the contents of the cell beneath the stripe for the multiple computed values in `td`
+Fixed the `Table` rendering the contents of the cell beneath the stripe in case of multiple computed values provided in `td`

--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -185,6 +185,7 @@ const table = tv({
         td: [
           "group-data-[odd=true]:before:bg-default-100",
           "group-data-[odd=true]:before:opacity-100",
+          "group-data-[odd=true]:before:-z-10",
         ],
       },
     },


### PR DESCRIPTION
Fixed `Table` rendering the contents of the cell beneath the stripe for the multiple computed values

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2506

## 📝 Description
Fixed `Table` rendering the contents of the cell beneath the stripe (isStriped) instead of above the stripe in case of multiple computed values provided in `td`.

## ⛳️ Current behavior (updates)
`Table` rendering the contents of the cell beneath the stripe (isStriped) in case of multiple computed values provided in `td`.

![image](https://github.com/nextui-org/nextui/assets/116849110/8a9cb53d-d70b-4336-b459-6e3385c6ec5a)


## 🚀 New behavior
`Table` rendering the contents of the cell above the stripe (isStriped) for the multiple computed values in `td`.

![image](https://github.com/nextui-org/nextui/assets/116849110/43b37f53-2176-4133-863b-cdb4db87f3d8)

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Fixed an issue where table cell contents were displayed incorrectly under stripes for rows with multiple computed values.
    - Improved styling for odd rows in tables to enhance visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->