### PR TITLE
fix(navbar): lazy motion forwardRef issue

### DIFF
--- a/.changeset/dirty-beans-repair.md
+++ b/.changeset/dirty-beans-repair.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/navbar": patch
+---
+
+fixed LazyMotion ForwardRef issue

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -60,8 +60,8 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
   ) : (
     <AnimatePresence mode="wait">
       {isMenuOpen ? (
-        <MenuWrapper>
-          <LazyMotion features={domAnimation}>
+        <LazyMotion features={domAnimation}>
+          <MenuWrapper>
             <m.ul
               ref={domRef}
               layoutScroll
@@ -80,8 +80,8 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
             >
               {children}
             </m.ul>
-          </LazyMotion>
-        </MenuWrapper>
+          </MenuWrapper>
+        </LazyMotion>
       ) : null}
     </AnimatePresence>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2521

## 📝 Description

swapped the level of `LazyMotion` and `MenuWrapper` 

## ⛳️ Current behavior (updates)

currently we can't scroll mobile sidebar due to the latest lazy motion changes

## 🚀 New behavior

[pr-2527-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/9f763497-b268-4308-bdf9-21773a0867ee)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue in the navigation bar related to the LazyMotion ForwardRef, improving stability and potentially animation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->