### PR TITLE
fix(docs): added ts example for infinite pagination

### DIFF
--- a/apps/docs/components/docs/components/code-demo/code-demo.tsx
+++ b/apps/docs/components/docs/components/code-demo/code-demo.tsx
@@ -59,7 +59,7 @@ export const CodeDemo: React.FC<CodeDemoProps> = ({
   isPreviewCentered = false,
   // when false .js files will be used
   typescriptStrict = false,
-  showOpenInCodeSandbox,
+  showOpenInCodeSandbox = true,
   isGradientBox = false,
   defaultExpanded = false,
   previewHeight = "auto",
@@ -142,7 +142,7 @@ export const CodeDemo: React.FC<CodeDemoProps> = ({
         files={files}
         highlightedLines={highlightedLines}
         showEditor={showEditor}
-        showOpenInCodeSandbox={showOpenInCodeSandbox || showPreview}
+        showOpenInCodeSandbox={showOpenInCodeSandbox}
         showPreview={showSandpackPreview}
         typescriptStrict={typescriptStrict}
       />

--- a/apps/docs/content/components/table/infinite-pagination.ts
+++ b/apps/docs/content/components/table/infinite-pagination.ts
@@ -67,10 +67,98 @@ export default function App() {
   );
 }`;
 
+const AppTs = `import {Table, TableHeader, TableColumn, TableBody, TableRow, TableCell, Pagination, Spinner, getKeyValue} from "@nextui-org/react";
+import { useInfiniteScroll } from "@nextui-org/use-infinite-scroll";
+import { useAsyncList } from "@react-stately/data";
+
+interface SWCharacter {
+  name: string;
+  height: string;
+  mass: string;
+  birth_year: string;
+}
+
+export default function App() {
+  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [hasMore, setHasMore] = React.useState<boolean>(false);
+
+  let list = useAsyncList<SWCharacter>({
+    async load({ signal, cursor }) {
+      if (cursor) {
+        setIsLoading(false);
+      }
+
+      // If no cursor is available, then we're loading the first page.
+      // Otherwise, the cursor is the next URL to load, as returned from the previous page.
+      const res = await fetch(
+        cursor || "https://swapi.py4e.com/api/people/?search=",
+        { signal }
+      );
+      let json = await res.json();
+
+      setHasMore(json.next !== null);
+
+      return {
+        items: json.results,
+        cursor: json.next,
+      };
+    },
+  });
+
+  const [loaderRef, scrollerRef] = useInfiniteScroll({
+    hasMore,
+    onLoadMore: list.loadMore,
+  });
+
+  return (
+    <Table
+      isHeaderSticky
+      aria-label="Example table with infinite pagination"
+      baseRef={scrollerRef}
+      bottomContent={
+        hasMore ? (
+          <div className="flex w-full justify-center">
+            <Spinner ref={loaderRef} color="white" />
+          </div>
+        ) : null
+      }
+      classNames={{
+        base: "max-h-[520px] overflow-scroll",
+        table: "min-h-[400px]",
+      }}
+    >
+      <TableHeader>
+        <TableColumn key="name">Name</TableColumn>
+        <TableColumn key="height">Height</TableColumn>
+        <TableColumn key="mass">Mass</TableColumn>
+        <TableColumn key="birth_year">Birth year</TableColumn>
+      </TableHeader>
+      <TableBody
+        isLoading={isLoading}
+        items={list.items}
+        loadingContent={<Spinner color="white" />}
+      >
+        {(item: SWCharacter) => (
+          <TableRow key={item.name}>
+            {(columnKey) => (
+              <TableCell>{getKeyValue(item, columnKey)}</TableCell>
+            )}
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}`;
+
 const react = {
   "/App.jsx": App,
 };
 
+const reactTs = {
+  "/App.tsx": AppTs,
+};
+
 export default {
   ...react,
+  ...reactTs,
 };

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -205,6 +205,7 @@ import {useFilter} from "@react-aria/i18n";
 <CodeDemo
   title="Fully Controlled"
   showPreview={false}
+  showOpenInCodeSandbox={false}
   highlightedLines="63-64,67,69-71"
   files={autocompleteContent.fullyControlled}
 />
@@ -254,6 +255,7 @@ import {useAsyncList} from "@react-stately/data";
   typescriptStrict={true}
   title="Asynchronous Filtering"
   showPreview={false}
+  showOpenInCodeSandbox={false}
   highlightedLines="27-29,33"
   files={autocompleteContent.asyncFiltering}
 />
@@ -280,6 +282,7 @@ import {useInfiniteScroll} from "@nextui-org/use-infinite-scroll";
 
 <CodeDemo
   showPreview={false}
+  showOpenInCodeSandbox={false}
   typescriptStrict={true}
   title="Asynchronous Loading"
   highlightedLines="21-22,25,27"

--- a/apps/docs/content/docs/components/avatar.mdx
+++ b/apps/docs/content/docs/components/avatar.mdx
@@ -76,7 +76,8 @@ You can also provide a custom fallback component to be displayed when the `src` 
 
 In case you need to customize the avatar even further, you can use the `useAvatar` hook to create your own implementation.
 
-<CodeDemo showPreview={false} title="Custom implementation" files={avatarContent.customImpl} />
+<CodeDemo showPreview={false} showOpenInCodeSandbox={false} title="Custom implementation" files={avatarContent.customImpl} />
+  
 
 ### Custom initials logic
 
@@ -120,7 +121,7 @@ By passing the `isGrid` prop to the `AvatarGroup` component, the avatars will be
 In case you need to customize the avatar group even further, you can use the `useAvatarGroup` hook and the
 `AvatarGroupProvider` to create your own implementation.
 
-<CodeDemo showPreview={false} title="Custom implementation" files={avatarContent.groupCustomImpl} />
+<CodeDemo showPreview={false} showOpenInCodeSandbox={false} title="Custom implementation" files={avatarContent.groupCustomImpl} />
 
 ## Slots
 

--- a/apps/docs/content/docs/components/button.mdx
+++ b/apps/docs/content/docs/components/button.mdx
@@ -88,7 +88,7 @@ You can customize the `Button` component by passing custom Tailwind CSS classes 
 
 You can also use the `useButton` hook to create your own button component.
 
-<CodeDemo showPreview={false} title="Custom Implementation" files={buttonContent.customImpl} />
+<CodeDemo showPreview={false} showOpenInCodeSandbox={false} title="Custom Implementation" files={buttonContent.customImpl} />
 
 ## Button Group
 

--- a/apps/docs/content/docs/components/image.mdx
+++ b/apps/docs/content/docs/components/image.mdx
@@ -65,7 +65,7 @@ You can use the `fallbackSrc` prop to display a fallback image when:
 Next.js provides an optimized [Image](https://nextjs.org/docs/app/api-reference/components/image) component,
 you can use it with NextUI `Image` component as well.
 
-<CodeDemo showPreview={false} title="With Next.js Image" files={imageContent.nextjs} />
+<CodeDemo showPreview={false} showOpenInCodeSandbox={false} title="With Next.js Image" files={imageContent.nextjs} />
 
 > **Note**: NextUI's `Image` component is `client-side`, using hooks like `useState` for loading states
 > and animations. Use Next.js `Image` alone if these features aren't required.

--- a/apps/docs/content/docs/components/link.mdx
+++ b/apps/docs/content/docs/components/link.mdx
@@ -89,7 +89,7 @@ function App() {
 
 In case you need to customize the link even further, you can use the `useLink` hook to create your own implementation.
 
-<CodeDemo showPreview={false} title="Custom implementation" files={linkContent.customImpl} />
+<CodeDemo showPreview={false} showOpenInCodeSandbox={false} title="Custom implementation" files={linkContent.customImpl} />
 
 <Spacer y={4} />{" "}
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -274,6 +274,22 @@ It is also possible to use the [Pagination](/components/pagination) component to
 Table also supports infinite pagination. To do so, you can use the `useAsyncList` hook from [@react-stately/data](https://react-spectrum.adobe.com/react-stately/useAsyncList.html) and
 [@nextui-org/use-infinite-scroll](https://www.npmjs.com/package/@nextui-org/use-infinite-scroll) hook.
 
+<PackageManagers
+  commands={{
+    npm: "npm install @react-stately/data @nextui-org/use-infinite-scroll",
+    yarn: "yarn add @react-stately/data @nextui-org/use-infinite-scroll",
+    pnpm: "pnpm add @react-stately/data @nextui-org/use-infinite-scroll",
+  }}
+/>
+
+```jsx
+import { useInfiniteScroll } from "@nextui-org/use-infinite-scroll";
+
+import { useAsyncList } from "@react-stately/data";
+```
+
+<Spacer y={2} />
+
 <CodeDemo
   asIframe
   title="Infinite Paginated Table"
@@ -281,6 +297,8 @@ Table also supports infinite pagination. To do so, you can use the `useAsyncList
   files={tableContent.infinitePagination}
   previewHeight="620px"
   displayMode="visible"
+  showPreview={true}
+  showOpenInCodeSandbox={false}
   iframeSrc="/examples/table/infinite-pagination"
 />
 


### PR DESCRIPTION
Closes #2517

## 📝 Description

1. Added TS code example to [Infinite Pagination](https://nextui.org/docs/components/table#infinite-pagination) in the Table component.

https://github.com/nextui-org/nextui/assets/62743644/34de4f3f-4558-4db4-8038-53f44a37092d

<br/><br/>

2. I covered all these examples used to not show its preview and “Open In Sandbox” button. Make sure that keeping these as they were. This is the reason I set `showOpenInCodeSandbox` to `false` for them. 


- [Avator - Custom Implemetation](https://nextui.org/docs/components/avatar#custom-implementation)
<img width="900" alt="313408574-c37448df-0f52-44a4-8c1d-8bb15d24aeeb" src="https://github.com/nextui-org/nextui/assets/62743644/4b7a8d9f-33ef-4a1b-9085-12b198af37ad">
<br/><br/>

- [Avator - Group Custom Implementation](https://nextui.org/docs/components/avatar#group-custom-implementation)
<img width="912" alt="313408626-a275e43d-24ac-4847-b7e5-75cc87fb9322" src="https://github.com/nextui-org/nextui/assets/62743644/35f44ead-be0d-4437-81bd-023a510cfa03">
<br/><br/>

- [Autocomplete - Fully Controlled](https://nextui.org/docs/components/autocomplete#fully-controlled)
<img width="889" alt="313408644-673bfea8-9b5d-4ebe-9b01-d1c4bd54c1c7" src="https://github.com/nextui-org/nextui/assets/62743644/306460d0-9b3f-4115-9118-d1518bcd0b36">
<br/><br/>

- [Autocomplete - Asynchronous Filtering](https://nextui.org/docs/components/autocomplete#asynchronous-filtering)
<img width="886" alt="313408683-d9ef8fdf-6731-474a-8971-b55aa2694f98" src="https://github.com/nextui-org/nextui/assets/62743644/6283546f-2d19-4609-b391-337dad4b6d85">
<br/><br/>

- [Autocomplete - Asynchronous Loading](https://nextui.org/docs/components/autocomplete#asynchronous-loading)
<img width="893" alt="Screenshot 2024-03-16 at 10 55 54 PM" src="https://github.com/nextui-org/nextui/assets/62743644/452004ac-2af6-47f2-a35b-2faf8a56c0ca">
<br/><br/>

- [Button - Custom Implementation](https://nextui.org/docs/components/button#custom-implementation)
<img width="904" alt="button" src="https://github.com/nextui-org/nextui/assets/62743644/f3ea9288-e59b-42fd-8e34-c94909f2cdfd">
<br/><br/>

- [Image - With Next.js Image](https://nextui.org/docs/components/image#with-nextjs-image)
<img width="797" alt="image" src="https://github.com/nextui-org/nextui/assets/62743644/47603ef3-78a3-4911-9ecd-e61b4e6f801c">
<br/><br/>

- [Link - Custom Implementation](https://nextui.org/docs/components/link#custom-implementation)\
<img width="906" alt="link" src="https://github.com/nextui-org/nextui/assets/62743644/14171482-4b8f-48c5-bded-810af84ecfbe">


## ⛳️ Current behavior (updates)

- Only JS code example.
- When showOpenInCodeSandbox is false, still shows the “Open In Sandbox” button, unless we set showPreview to false.

## 🚀 New behavior

- Added TS example, following [Async Filter](https://nextui.org/docs/components/autocomplete#asynchronous-filtering) example.
- Differentiate the responsibility between showOpenInCodeSandbox and showPreview to be able to show users the preview, while not showing the “Open In Sandbox” button.

## 💣 Is this a breaking change (Yes/No):

No.


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented infinite pagination in the `Table` component, enhancing data display with dynamic loading as the user scrolls.
- **Enhancements**
	- The `CodeDemo` component now defaults to showing the "Open in CodeSandbox" option, improving accessibility for live code experimentation.
- **Documentation**
	- Updated documentation for `Button`, `Link`, `Avatar`, and `Image` components to include or exclude the "Open in CodeSandbox" option in code demos, reflecting customization capabilities.
	- Enhanced `Table` component documentation with details on implementing infinite pagination using new imports and functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->