### PR TITLE
fix: revise shouldCloseOnInteractOutside for FreeSoloPopover

### DIFF
--- a/.changeset/long-mayflies-film.md
+++ b/.changeset/long-mayflies-film.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/autocomplete": patch
+"@nextui-org/popover": patch
+"@nextui-org/select": patch
+---
+
+revise shouldCloseOnInteractOutside for FreeSoloPopover

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
-import {render} from "@testing-library/react";
+import {act, render} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {Autocomplete, AutocompleteItem, AutocompleteSection} from "../src";
+import {Modal, ModalContent, ModalBody, ModalHeader, ModalFooter} from "../../modal/src";
 
 type Item = {
   label: string;
@@ -132,5 +134,89 @@ describe("Autocomplete", () => {
     );
 
     expect(() => wrapper.unmount()).not.toThrow();
+  });
+
+  it("should close dropdown when clicking outside autocomplete", async () => {
+    const wrapper = render(
+      <Autocomplete
+        aria-label="Favorite Animal"
+        data-testid="close-when-clicking-outside-test"
+        label="Favorite Animal"
+      >
+        <AutocompleteItem key="penguin" value="penguin">
+          Penguin
+        </AutocompleteItem>
+        <AutocompleteItem key="zebra" value="zebra">
+          Zebra
+        </AutocompleteItem>
+        <AutocompleteItem key="shark" value="shark">
+          Shark
+        </AutocompleteItem>
+      </Autocomplete>,
+    );
+
+    const autocomplete = wrapper.getByTestId("close-when-clicking-outside-test");
+
+    // open the select dropdown
+    await act(async () => {
+      await userEvent.click(autocomplete);
+    });
+
+    // assert that the autocomplete dropdown is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
+
+    // click outside the autocomplete component
+    await act(async () => {
+      await userEvent.click(document.body);
+    });
+
+    // assert that the autocomplete is closed
+    expect(autocomplete).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should close dropdown when clicking outside autocomplete with modal open", async () => {
+    const wrapper = render(
+      <Modal isOpen>
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>
+            <Autocomplete
+              aria-label="Favorite Animal"
+              data-testid="close-when-clicking-outside-test"
+              label="Favorite Animal"
+            >
+              <AutocompleteItem key="penguin" value="penguin">
+                Penguin
+              </AutocompleteItem>
+              <AutocompleteItem key="zebra" value="zebra">
+                Zebra
+              </AutocompleteItem>
+              <AutocompleteItem key="shark" value="shark">
+                Shark
+              </AutocompleteItem>
+            </Autocomplete>
+          </ModalBody>
+          <ModalFooter>Modal footer</ModalFooter>
+        </ModalContent>
+      </Modal>,
+    );
+
+    const autocomplete = wrapper.getByTestId("close-when-clicking-outside-test");
+
+    // open the autocomplete dropdown
+    await act(async () => {
+      await userEvent.click(autocomplete);
+    });
+
+    // assert that the autocomplete dropdown is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
+
+    // click outside the autocomplete component
+    await act(async () => {
+      await userEvent.click(document.body);
+    });
+
+    // assert that the autocomplete dropdown is closed
+    expect(autocomplete).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -32,7 +32,12 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
   } = useAutocomplete<T>({...props, ref});
 
   const popoverContent = isOpen ? (
-    <FreeSoloPopover {...getPopoverProps()} state={state}>
+    <FreeSoloPopover
+      {...getPopoverProps()}
+      // avoid popover closing issue in autocomplete with open modal
+      shouldCloseOnInteractOutside={() => false}
+      state={state}
+    >
       <ScrollShadow {...getListBoxWrapperProps()}>
         <Listbox {...getListBoxProps()} />
       </ScrollShadow>

--- a/packages/components/popover/src/free-solo-popover.tsx
+++ b/packages/components/popover/src/free-solo-popover.tsx
@@ -74,8 +74,6 @@ const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>((props, ref) => 
     getContentProps,
   } = usePopover({
     ...props,
-    // avoid closing the popover when navigating with the keyboard
-    shouldCloseOnInteractOutside: () => false,
     ref,
   });
 

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -3,6 +3,7 @@ import {act, render} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {Select, SelectItem, SelectSection, type SelectProps} from "../src";
+import {Modal, ModalContent, ModalHeader, ModalBody, ModalFooter} from "../../modal/src";
 
 type Item = {
   label: string;
@@ -275,5 +276,83 @@ describe("Select", () => {
 
     expect(wrapper.getByText("next Penguin")).toBeInTheDocument();
     expect(wrapper.queryByText("Select an favorite animal")).toBe(null);
+  });
+
+  it("should close dropdown when clicking outside select", async () => {
+    const wrapper = render(
+      <Select
+        aria-label="Favorite Animal"
+        data-testid="close-when-clicking-outside-test"
+        label="Favorite Animal"
+      >
+        <SelectItem key="penguin" value="penguin">
+          Penguin
+        </SelectItem>
+        <SelectItem key="zebra" value="zebra">
+          Zebra
+        </SelectItem>
+        <SelectItem key="shark" value="shark">
+          Shark
+        </SelectItem>
+      </Select>,
+    );
+
+    const select = wrapper.getByTestId("close-when-clicking-outside-test");
+
+    // open the select dropdown
+    await act(async () => {
+      await userEvent.click(select);
+    });
+
+    // click outside the select component
+    await act(async () => {
+      await userEvent.click(document.body);
+    });
+
+    // assert that the select is closed
+    expect(select).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should close dropdown when clicking outside select with modal open", async () => {
+    const wrapper = render(
+      <Modal isOpen>
+        <ModalContent>
+          <ModalHeader>Modal header</ModalHeader>
+          <ModalBody>
+            <Select
+              aria-label="Favorite Animal"
+              data-testid="close-when-clicking-outside-test"
+              label="Favorite Animal"
+            >
+              <SelectItem key="penguin" value="penguin">
+                Penguin
+              </SelectItem>
+              <SelectItem key="zebra" value="zebra">
+                Zebra
+              </SelectItem>
+              <SelectItem key="shark" value="shark">
+                Shark
+              </SelectItem>
+            </Select>
+          </ModalBody>
+          <ModalFooter>Modal footer</ModalFooter>
+        </ModalContent>
+      </Modal>,
+    );
+
+    const select = wrapper.getByTestId("close-when-clicking-outside-test");
+
+    // open the select dropdown
+    await act(async () => {
+      await userEvent.click(select);
+    });
+
+    // click outside the select component
+    await act(async () => {
+      await userEvent.click(document.body);
+    });
+
+    // assert that the select is closed
+    expect(select).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -304,6 +304,9 @@ describe("Select", () => {
       await userEvent.click(select);
     });
 
+    // assert that the select is open
+    expect(select).toHaveAttribute("aria-expanded", "true");
+
     // click outside the select component
     await act(async () => {
       await userEvent.click(document.body);

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -347,6 +347,9 @@ describe("Select", () => {
       await userEvent.click(select);
     });
 
+    // assert that the select is open
+    expect(select).toHaveAttribute("aria-expanded", "true");
+
     // click outside the select component
     await act(async () => {
       await userEvent.click(document.body);

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -103,7 +103,13 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   const popoverContent = useMemo(
     () =>
       state.isOpen ? (
-        <FreeSoloPopover {...getPopoverProps()} state={state} triggerRef={triggerRef}>
+        <FreeSoloPopover
+          {...getPopoverProps()}
+          // avoid closing the popover when navigating with the keyboard
+          shouldCloseOnInteractOutside={undefined}
+          state={state}
+          triggerRef={triggerRef}
+        >
           <ScrollShadow {...getListboxWrapperProps()}>
             <Listbox {...getListboxProps()} />
           </ScrollShadow>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2531

## 📝 Description
 
- set `shouldCloseOnInteractOutside` to `false` for autocomplete (to address closing issue with open modal)
- set `shouldCloseOnInteractOutside` to `undefined` for select (previous behaviour)

## ⛳️ Current behavior (updates)

- the fix done in #2494 should only apply to autocomplete
- currently it prevents select from closing on interact outside

## 🚀 New behavior

- both should be able to close on interact outside

[pr2536-select.webm](https://github.com/nextui-org/nextui/assets/35857179/4f4a6751-9bf5-47cf-bef0-9f2b1804cca4)

[pr2536-autocomplete.webm](https://github.com/nextui-org/nextui/assets/35857179/b8c11dce-3c0a-4c74-bf7e-f230dd1d1d5d)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhancements to the Autocomplete, Popover, and Select components to improve user interaction and accessibility.
- **Bug Fixes**
	- Fixed an issue where the popover would close unexpectedly when interacting outside of it in specific scenarios.
- **Tests**
	- Added new test cases for Autocomplete and Select components to verify the improved behavior of dropdown closure when clicking outside, with modal interactions considered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->