### PR TITLE
fix(docs): className in image blurred example

### DIFF
--- a/apps/docs/content/components/image/blurred.ts
+++ b/apps/docs/content/components/image/blurred.ts
@@ -7,7 +7,7 @@ export default function App() {
       width={240}
       src="https://nextui-docs-v2.vercel.app/images/album-cover.png"
       alt="NextUI Album Cover"
-      classNames="m-5"
+      className="m-5"
     />
   );
 }`;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2539

## 📝 Description

`classNames` -> `className` since the type is `Record<"img"｜ "wrapper"｜ "zoomedWrapper"｜ "blurredImg", string>`, not `string`.

## ⛳️ Current behavior (updates)

`classNames="m-5"`

## 🚀 New behavior

`className="m-5"`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
