### PR TITLE
chore(badge): Remove unnecessary type

### DIFF
--- a/.changeset/three-tools-whisper.md
+++ b/.changeset/three-tools-whisper.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/badge": patch
+---
+
+removing the `children` type from BadgeProps, as the already extended UseBadgeProps has a `children` prop.

--- a/.changeset/three-tools-whisper.md
+++ b/.changeset/three-tools-whisper.md
@@ -2,4 +2,4 @@
 "@nextui-org/badge": patch
 ---
 
-removing the `children` type from BadgeProps, as the already extended UseBadgeProps has a `children` prop.
+Removing the `children` type from BadgeProps, as the already extended UseBadgeProps has a `children` prop.

--- a/packages/components/badge/src/badge.tsx
+++ b/packages/components/badge/src/badge.tsx
@@ -4,9 +4,7 @@ import {forwardRef} from "@nextui-org/system-rsc";
 
 import {UseBadgeProps, useBadge} from "./use-badge";
 
-export interface BadgeProps extends UseBadgeProps {
-  children: ReactNode;
-}
+export interface BadgeProps extends UseBadgeProps {}
 
 const Badge = forwardRef<"span", BadgeProps>((props, ref) => {
   const {Component, children, content, slots, classNames, getBadgeProps} = useBadge({


### PR DESCRIPTION
I suggest removing the `children` type from BadgeProps, as the already extended UseBadgeProps has a `children` prop.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Streamlined the `BadgeProps` interface in the Badge component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->