### PR TITLE
feat direct control navbar-menu

### DIFF
--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -21,32 +21,51 @@ export interface NavbarMenuProps extends HTMLNextUIProps<"ul"> {
    * The props to modify the framer motion animation. Use the `variants` API to create your own animation.
    */
   motionProps?: HTMLMotionProps<"ul">;
+  /**
+   * The prop to control the open state of the menu.
+   */
+  isOpen?: boolean;
 }
 
 const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
-  const {className, children, portalContainer, motionProps, style, ...otherProps} = props;
+  const {
+    className,
+    children,
+    portalContainer,
+    motionProps,
+    style,
+    isOpen,
+    ...otherProps
+  } = props;
   const domRef = useDOMRef(ref);
 
-  const {slots, isMenuOpen, height, disableAnimation, classNames} = useNavbarContext();
+  const navBarContext = useNavbarContext();
+  const { slots, height, disableAnimation, classNames } = navBarContext;
+  let isMenuOpen: boolean | undefined;
+  if (isOpen == undefined) {
+    isMenuOpen = navBarContext.isMenuOpen;
+  } else {
+    isMenuOpen = isOpen;
+  }
 
   const styles = clsx(classNames?.menu, className);
 
   const MenuWrapper = useCallback(
-    ({children}: {children: ReactElement}) => {
+    ({ children }: { children: ReactElement }) => {
       return (
         <RemoveScroll forwardProps enabled={isMenuOpen} removeScrollBar={false}>
           {children}
         </RemoveScroll>
       );
     },
-    [isMenuOpen],
+    [isMenuOpen]
   );
 
   const contents = disableAnimation ? (
     <MenuWrapper>
       <ul
         ref={domRef}
-        className={slots.menu?.({class: styles})}
+        className={slots.menu?.({ class: styles })}
         data-open={dataAttr(isMenuOpen)}
         style={{
           // @ts-expect-error
@@ -66,7 +85,7 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
               ref={domRef}
               layoutScroll
               animate="enter"
-              className={slots.menu?.({class: styles})}
+              className={slots.menu?.({ class: styles })}
               data-open={dataAttr(isMenuOpen)}
               exit="exit"
               initial="exit"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

add direct control state navbar-menu open/close for 2 or more navbarmenu in navbar

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added control over the navbar menu's open state with the new `isOpen` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->