### PR TITLE
fix(select): positioning the label if a description is used

### DIFF
--- a/.changeset/giant-carrots-reply.md
+++ b/.changeset/giant-carrots-reply.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Fixed the bug of positioning the label in the `Select` component if the description field was used

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -28,7 +28,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
     endContent,
     placeholder,
     renderValue,
-    shouldLabelBeOutside,
+    isOutsideLeft,
     disableAnimation,
     getBaseProps,
     getLabelProps,
@@ -115,10 +115,10 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   return (
     <div {...getBaseProps()}>
       <HiddenSelect {...getHiddenSelectProps()} />
-      {shouldLabelBeOutside ? labelContent : null}
+      {isOutsideLeft ? labelContent : null}
       <div {...getMainWrapperProps()}>
         <Component {...getTriggerProps()}>
-          {!shouldLabelBeOutside ? labelContent : null}
+          {!isOutsideLeft ? labelContent : null}
           <div {...getInnerWrapperProps()}>
             {startContent}
             <span {...getValueProps()}>

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -262,6 +262,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     labelPlacement === "outside-left" ||
     (labelPlacement === "outside" && (hasPlaceholder || !!originalProps.isMultiline));
   const shouldLabelBeInside = labelPlacement === "inside";
+  const isOutsideLeft = labelPlacement === "outside-left";
 
   const isFilled =
     state.isOpen ||
@@ -585,6 +586,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     renderValue,
     selectionMode,
     disableAnimation,
+    isOutsideLeft,
     shouldLabelBeOutside,
     shouldLabelBeInside,
     getBaseProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2543

## 📝 Description

Fixed the bug of positioning the `label` in the `Select` component if the `description` prop was used

## ⛳️ Current behavior (updates)

Currently, when using the `description` prop, the `label` is displayed incorrectly

![Screenshot 2024-03-20 at 15 19 25](https://github.com/nextui-org/nextui/assets/57824881/8a2af378-104d-499e-9cb6-0bd0934777d5)

## 🚀 New behavior

This PR solves the bug of incorrect `label` positioning

![Screenshot 2024-03-20 at 15 19 04](https://github.com/nextui-org/nextui/assets/57824881/2b1326c4-6511-4750-91ff-6723dee83f62)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- **Bug Fixes**
    -  Fixed the `label` placement issue in `Select` component if a `description` prop is used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a bug affecting the positioning of the label in the `Select` component when a description is provided.
- **New Features**
	- Enhanced the `Select` component to allow labels to be positioned outside on the left side, improving flexibility in UI design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->