### PR TITLE
fix(select): isFilled & hasValue logic for state.selectedItems

### DIFF
--- a/.changeset/four-walls-rescue.md
+++ b/.changeset/four-walls-rescue.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Fixed isFilled logic for state.selectedItems in select

--- a/.changeset/four-walls-rescue.md
+++ b/.changeset/four-walls-rescue.md
@@ -2,4 +2,4 @@
 "@nextui-org/select": patch
 ---
 
-Fixed isFilled logic for state.selectedItems in select
+Fixed isFilled & hasValue logic for state.selectedItems in select

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -266,11 +266,11 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
   const isFilled =
     state.isOpen ||
     hasPlaceholder ||
-    state.selectedItems?.length ||
+    !!state.selectedItems?.length ||
     !!startContent ||
     !!endContent ||
     !!originalProps.isMultiline;
-  const hasValue = !!state.selectedItems;
+  const hasValue = !!state.selectedItems?.length;
   const hasLabel = !!label;
 
   const baseStyles = clsx(classNames?.base, className);

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -266,7 +266,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
   const isFilled =
     state.isOpen ||
     hasPlaceholder ||
-    !!state.selectedItems ||
+    state.selectedItems?.length ||
     !!startContent ||
     !!endContent ||
     !!originalProps.isMultiline;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2555

## 📝 Description

`!!state.selectedItems` would make `isFilled` & `hasValue` become `true` even there is no selection. This PR is to handle the zero length case.

## ⛳️ Current behavior (updates)

<img width="332" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/90d24d5c-2d15-4555-892a-11ff47b738b3">

## 🚀 New behavior

[pr2556-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/605d7fb2-8a50-43c8-95f9-1bc47f50c315)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for determining if the select component is filled, now accurately reflects the presence of selected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->