### PR TITLE
docs(snippet): fix grammatical error

### DIFF
--- a/apps/docs/content/docs/components/snippet.mdx
+++ b/apps/docs/content/docs/components/snippet.mdx
@@ -56,7 +56,7 @@ You can customize the tooltip by using the `tooltipProps` property.
 
 <CodeDemo title="Custom Tooltip" highlightedLines="7-10" files={snippetContent.customTooltip} />
 
-> **Note**: For more information about the `Tootlip` props, please visit the [Tooltip](/docs/components/tooltip) page.
+> **Note**: For more information about the `Tooltip` props, please visit the [Tooltip](/docs/components/tooltip) page.
 
 ### Multiline
 


### PR DESCRIPTION
Closes #N/A
## 📝 Description

Fixes grammatical error in Snippet docs

## ⛳️ Current behavior (updates)

Snippet docs contains a grammatical error

## 🚀 New behavior

Snippet docs doesn't contain a grammatical error

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the documentation link text from "Tootlip" to "Tooltip" for improved accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->