### PR TITLE
fix(docs): some user links in support us section led to 404 pages

### DIFF
--- a/apps/docs/.sponsorsrc
+++ b/apps/docs/.sponsorsrc
@@ -202,7 +202,7 @@
     "email": null,
     "twitter": null,
     "github": "https://github.com/HighError",
-    "website": "https://higherror.github.io/"
+    "website": null
   },
   {
     "MemberId": 409558,


### PR DESCRIPTION
Closes #2575

## 📝 Description

Whenever you click on the links to some users presented on the **NextUI** Website, under the **Sponsor us** section. It will sometimes lead to a 404 page. Maybe some of the links have changed, since the site's creation.

## ⛳️ Current behavior (updates)

[HigherError user](https://opencollective.com/higherror) leads to 404 pages.

## 🚀 New behavior

Instead of 404 page, it navigates to [its OpenCollective page](https://opencollective.com/higherror).

https://github.com/nextui-org/nextui/assets/62743644/d448bf1c-6004-4788-ad5f-eace3974703e



## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated sponsor information in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->