### PR TITLE
fix(docs): typo mistake in override-styles.mdx

### DIFF
--- a/apps/docs/content/docs/customization/override-styles.mdx
+++ b/apps/docs/content/docs/customization/override-styles.mdx
@@ -10,7 +10,7 @@ or to the `classNames` prop for components with slots.
 
 <CarbonAd />
 
-### What's is a Slot?
+### What is a Slot?
 
 A slot is a part of a component that can be styled separately. For example, the [CircularProgress](/docs/components/circular-progress) component
 has multiple slots/parts that can be styled separately, such as the `track`, `indicator`, `value`, etc.


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This commit corrects a typo in the override-styles.mdx file. The typo was in the phrase 'What's is slot?', which has been corrected to 'What is slot?' for grammatical accuracy.

## ⛳️ Current behavior (updates)

Typo mistake

## 🚀 New behavior

Typo Correction

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the customization documentation, changing "What's is a Slot?" to "What is a Slot?".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->