### PR TITLE
fix(hooks): handle numeric selectedKeys in Select 

### DIFF
--- a/.changeset/hot-rivers-move.md
+++ b/.changeset/hot-rivers-move.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-aria-multiselect": patch
+---
+
+Handle numeric selectedKeys in Select

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
@@ -29,7 +29,7 @@ export function useMultiSelectListState<T extends object>(
     if (selectedKeys.size !== 0) {
       return Array.from(selectedKeys)
         .filter(Boolean)
-        .filter((key) => !collection.getItem(key));
+        .filter((key) => !collection.getItem(key + ""));
     }
 
     return [];
@@ -39,7 +39,7 @@ export function useMultiSelectListState<T extends object>(
     selectedKeys.size !== 0
       ? Array.from(selectedKeys)
           .map((key) => {
-            return collection.getItem(key);
+            return collection.getItem(key + "");
           })
           // Remove undefined values when some keys are not present in the collection
           .filter(Boolean)

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
@@ -29,7 +29,7 @@ export function useMultiSelectListState<T extends object>(
     if (selectedKeys.size !== 0) {
       return Array.from(selectedKeys)
         .filter(Boolean)
-        .filter((key) => !collection.getItem(key + ""));
+        .filter((key) => !collection.getItem(`${key}`));
     }
 
     return [];
@@ -39,7 +39,7 @@ export function useMultiSelectListState<T extends object>(
     selectedKeys.size !== 0
       ? Array.from(selectedKeys)
           .map((key) => {
-            return collection.getItem(key + "");
+            return collection.getItem(`${key}`);
           })
           // Remove undefined values when some keys are not present in the collection
           .filter(Boolean)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2587

## 📝 Description

In collection, the key of the map is always string no matter the inputted key is numeric or string. Therefore, handle such case when we get the item from the collection.

## ⛳️ Current behavior (updates)

<img width="437" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/5cb91078-7ed5-47cf-8dbe-4a087e5c7266">

## 🚀 New behavior

<img width="428" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/c9c18155-5854-406a-b3ae-d5a972015298">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Improved handling of numeric keys in the multi-select component to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->