### PR TITLE
fix: lazy motion forward ref issue

### DIFF
--- a/.changeset/spicy-coats-exist.md
+++ b/.changeset/spicy-coats-exist.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/modal": patch
+"@nextui-org/popover": patch
+---
+
+Fixed lazy motion forwardRef issue

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -1,7 +1,7 @@
 import type {AriaDialogProps} from "@react-aria/dialog";
 import type {HTMLMotionProps} from "framer-motion";
 
-import {cloneElement, isValidElement, ReactNode, useMemo} from "react";
+import {cloneElement, isValidElement, ReactNode, useMemo, useCallback, ReactElement} from "react";
 import {forwardRef} from "@nextui-org/system";
 import {DismissButton} from "@react-aria/overlays";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-transitions";
@@ -90,27 +90,42 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     );
   }, [backdrop, disableAnimation, getBackdropProps]);
 
+  const RemoveScrollWrapper = useCallback(
+    ({children}: {children: ReactElement}) => {
+      return (
+        <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
+          {children}
+        </RemoveScroll>
+      );
+    },
+    [shouldBlockScroll, isOpen],
+  );
+
+  const contents = disableAnimation ? (
+    <RemoveScrollWrapper>
+      <div className={slots.wrapper({class: classNames?.wrapper})}>{content}</div>
+    </RemoveScrollWrapper>
+  ) : (
+    <LazyMotion features={domAnimation}>
+      <RemoveScrollWrapper>
+        <m.div
+          animate="enter"
+          className={slots.wrapper({class: classNames?.wrapper})}
+          exit="exit"
+          initial="exit"
+          variants={scaleInOut}
+          {...motionProps}
+        >
+          {content}
+        </m.div>
+      </RemoveScrollWrapper>
+    </LazyMotion>
+  );
+
   return (
     <div tabIndex={-1}>
       {backdropContent}
-      <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
-        {disableAnimation ? (
-          <div className={slots.wrapper({class: classNames?.wrapper})}>{content}</div>
-        ) : (
-          <LazyMotion features={domAnimation}>
-            <m.div
-              animate="enter"
-              className={slots.wrapper({class: classNames?.wrapper})}
-              exit="exit"
-              initial="exit"
-              variants={scaleInOut}
-              {...motionProps}
-            >
-              {content}
-            </m.div>
-          </LazyMotion>
-        )}
-      </RemoveScroll>
+      {contents}
     </div>
   );
 });

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -1,7 +1,7 @@
 import type {AriaDialogProps} from "@react-aria/dialog";
 import type {HTMLMotionProps} from "framer-motion";
 
-import {DOMAttributes, ReactNode, useMemo, useRef} from "react";
+import {DOMAttributes, ReactNode, useMemo, useRef, useCallback, ReactElement} from "react";
 import {forwardRef} from "@nextui-org/system";
 import {DismissButton} from "@react-aria/overlays";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-transitions";
@@ -81,29 +81,42 @@ const PopoverContent = forwardRef<"div", PopoverContentProps>((props, _) => {
     );
   }, [backdrop, disableAnimation, getBackdropProps]);
 
+  const RemoveScrollWrapper = useCallback(
+    ({children}: {children: ReactElement}) => {
+      return (
+        <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
+          {children}
+        </RemoveScroll>
+      );
+    },
+    [shouldBlockScroll, isOpen],
+  );
+
+  const contents = disableAnimation ? (
+    <RemoveScrollWrapper>{content}</RemoveScrollWrapper>
+  ) : (
+    <LazyMotion features={domAnimation}>
+      <RemoveScrollWrapper>
+        <m.div
+          animate="enter"
+          exit="exit"
+          initial="initial"
+          style={{
+            ...getTransformOrigins(placement === "center" ? "top" : placement),
+          }}
+          variants={TRANSITION_VARIANTS.scaleSpringOpacity}
+          {...motionProps}
+        >
+          {content}
+        </m.div>
+      </RemoveScrollWrapper>
+    </LazyMotion>
+  );
+
   return (
     <div {...getPopoverProps()}>
       {backdropContent}
-      <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
-        {disableAnimation ? (
-          content
-        ) : (
-          <LazyMotion features={domAnimation}>
-            <m.div
-              animate="enter"
-              exit="exit"
-              initial="initial"
-              style={{
-                ...getTransformOrigins(placement === "center" ? "top" : placement),
-              }}
-              variants={TRANSITION_VARIANTS.scaleSpringOpacity}
-              {...motionProps}
-            >
-              {content}
-            </m.div>
-          </LazyMotion>
-        )}
-      </RemoveScroll>
+      {contents}
     </div>
   );
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- Applied the same fix as https://github.com/nextui-org/nextui/pull/2527

## ⛳️ Current behavior (updates)

if you run `pnpm test popover` or `pnpm test modal`, you can see the following error

```
  console.error
    Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

    Check the render method of `ForwardRef`.
        at LazyMotion (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/framer-motion@10.16.4_react-dom@18.2.0_react@18.2.0/node_modules/framer-motion/dist/cjs/index.js:4977:23)
        at /Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/react-remove-scroll@2.5.7_@types+react@18.2.8_react@18.2.0/node_modules/react-remove-scroll/dist/es5/UI.js:16:21
        at div
        at as (/Users/wingkwong/Documents/GitHub/nextui/packages/components/modal/src/modal-content.tsx:25:10)
        at $a7a032acae3ddda9$export$20e40289641fbbb6 (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/@react-aria+focus@3.14.3_react@18.2.0/node_modules/@react-aria/focus/dist/packages/@react-aria/focus/src/FocusScope.tsx:83:8)
        at $3596bae48579386f$export$cf75428e0b9ed1ea (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/@react-aria+interactions@3.19.1_react@18.2.0/node_modules/@react-aria/interactions/dist/packages/@react-aria/interactions/src/PressResponder.tsx:56:38)
        at $745edbb83ab4296f$export$c6fdb837b070b4ff (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/@react-aria+overlays@3.18.1_react-dom@18.2.0_react@18.2.0/node_modules/@react-aria/overlays/dist/packages/@react-aria/overlays/src/Overlay.tsx:48:22)
        at PresenceChild (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/framer-motion@10.16.4_react-dom@18.2.0_react@18.2.0/node_modules/framer-motion/dist/cjs/index.js:4706:26)
        at AnimatePresence (/Users/wingkwong/Documents/GitHub/nextui/node_modules/.pnpm/framer-motion@10.16.4_react-dom@18.2.0_react@18.2.0/node_modules/framer-motion/dist/cjs/index.js:4808:28)
        at children (/Users/wingkwong/Documents/GitHub/nextui/packages/components/modal/src/modal.tsx:17:10)
```

## 🚀 New behavior

the error is gone

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced modal and popover components with improved animation and scroll behavior control.
- **Bug Fixes**
	- Fixed an issue related to lazy motion with forward references.
- **Refactor**
	- Updated versions of modal and popover dependencies for better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->