### PR TITLE
fix: incorrect level of m.div

### DIFF
--- a/.changeset/thin-rice-smile.md
+++ b/.changeset/thin-rice-smile.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/modal": patch
+"@nextui-org/popover": patch
+---
+
+Fixed incorrect level of m.div

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -93,7 +93,7 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
   const RemoveScrollWrapper = useCallback(
     ({children}: {children: ReactElement}) => {
       return (
-        <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
+        <RemoveScroll enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
           {children}
         </RemoveScroll>
       );

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -107,18 +107,16 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     </RemoveScrollWrapper>
   ) : (
     <LazyMotion features={domAnimation}>
-      <RemoveScrollWrapper>
-        <m.div
-          animate="enter"
-          className={slots.wrapper({class: classNames?.wrapper})}
-          exit="exit"
-          initial="exit"
-          variants={scaleInOut}
-          {...motionProps}
-        >
-          {content}
-        </m.div>
-      </RemoveScrollWrapper>
+      <m.div
+        animate="enter"
+        className={slots.wrapper({class: classNames?.wrapper})}
+        exit="exit"
+        initial="exit"
+        variants={scaleInOut}
+        {...motionProps}
+      >
+        <RemoveScrollWrapper>{content}</RemoveScrollWrapper>
+      </m.div>
     </LazyMotion>
   );
 

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -84,7 +84,7 @@ const PopoverContent = forwardRef<"div", PopoverContentProps>((props, _) => {
   const RemoveScrollWrapper = useCallback(
     ({children}: {children: ReactElement}) => {
       return (
-        <RemoveScroll forwardProps enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
+        <RemoveScroll enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
           {children}
         </RemoveScroll>
       );

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -96,20 +96,18 @@ const PopoverContent = forwardRef<"div", PopoverContentProps>((props, _) => {
     <RemoveScrollWrapper>{content}</RemoveScrollWrapper>
   ) : (
     <LazyMotion features={domAnimation}>
-      <RemoveScrollWrapper>
-        <m.div
-          animate="enter"
-          exit="exit"
-          initial="initial"
-          style={{
-            ...getTransformOrigins(placement === "center" ? "top" : placement),
-          }}
-          variants={TRANSITION_VARIANTS.scaleSpringOpacity}
-          {...motionProps}
-        >
-          {content}
-        </m.div>
-      </RemoveScrollWrapper>
+      <m.div
+        animate="enter"
+        exit="exit"
+        initial="initial"
+        style={{
+          ...getTransformOrigins(placement === "center" ? "top" : placement),
+        }}
+        variants={TRANSITION_VARIANTS.scaleSpringOpacity}
+        {...motionProps}
+      >
+        <RemoveScrollWrapper>{content}</RemoveScrollWrapper>
+      </m.div>
     </LazyMotion>
   );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2615

## 📝 Description

- revise the level of m.div
- remove forwardProps due to the change of order

## ⛳️ Current behavior (updates)

pressing `esc` won't close

## 🚀 New behavior

[modal-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/ec5cfef7-be44-452a-abc2-27d21e3fd69d)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with incorrect layering in modal and popover components.
	- Improved the structure within modal and popover components for better animation and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->