### PR TITLE
fix(docs): changed breakpoint to md

### DIFF
--- a/packages/components/navbar/stories/navbar.stories.tsx
+++ b/packages/components/navbar/stories/navbar.stories.tsx
@@ -176,7 +176,7 @@ const WithMenuTemplate = (args: NavbarProps) => {
             <p className="font-bold hidden sm:block text-inherit">ACME</p>
           </NavbarBrand>
         </NavbarContent>
-        <NavbarContent className="hidden sm:flex">
+        <NavbarContent className="hidden md:flex">
           <NavbarItem>
             <Link color="foreground" href="#">
               Features


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2629 

## 📝 Description

- The signup button in Navbar with menu is getting clipped in stories.
- The breakpoint of Navbar with Menu is `md` while the breakpoint for other Navbars (Sticky, Static, Hide on Scroll) is `sm`


## ⛳️ Current behavior (updates)

- The Sign up button is getting clipped when you resize the window at a specific point.

- The breakpoints are different when compared to other Navbars.

## 🚀 New behavior
Now the Sign Up button is not getting clipped and consistent behaviour is maintained across Navbars(Sticky, Static, Hide on Scroll, With Menu)

![NavbarBugFix](https://github.com/nextui-org/nextui/assets/8769408/da51ea79-5d20-4013-8d37-8123eb7a27f9)


## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved responsiveness of the Navbar for better visibility across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->