### PR TITLE
refactor: assigned type(DateValue) to focusedDate(ControlledFocusedVaue)

### DIFF
--- a/packages/components/calendar/stories/calendar.stories.tsx
+++ b/packages/components/calendar/stories/calendar.stories.tsx
@@ -104,7 +104,7 @@ const UnavailableDatesTemplate = (args: CalendarProps) => {
 
 const ControlledFocusedValueTemplate = (args: CalendarProps) => {
   let defaultDate = today(getLocalTimeZone());
-  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+  let [focusedDate, setFocusedDate] = React.useState<DateValue>(defaultDate);
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
Closes #

## 📝 Description

Added type to focusedDate in Calendar of ControlledFocusedValueTemplate

## ⛳️ Current behavior (updates)

`let [focusedDate, setFocusedDate] = React.useState(defaultDate);`

## 🚀 New behavior

`let [focusedDate, setFocusedDate] = React.useState<DateValue>(defaultDate);`

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
