### PR TITLE
Update remix.mdx

### DIFF
--- a/apps/docs/content/docs/frameworks/remix.mdx
+++ b/apps/docs/content/docs/frameworks/remix.mdx
@@ -43,7 +43,7 @@ the following code to your `tailwind.config.js` file:
 // tailwind.config.ts
 const { nextui } = require("@nextui-org/react");
 
-import type { Config} from 'tailwindcss'
+import type { Config } from 'tailwindcss'
 
 export default {
   content: [


### PR DESCRIPTION
Fix spacing in import statement for Config type in Remix documentation.

- Corrected the spacing in the import statement of the Config type from 'tailwindcss' to follow standard formatting conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a formatting issue in the Remix framework documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->