### PR TITLE
refactor: removed CalendarDate, assigned type(DateValue) to focusedDate(ControlledFocusedValue)

### DIFF
--- a/packages/components/calendar/stories/calendar.stories.tsx
+++ b/packages/components/calendar/stories/calendar.stories.tsx
@@ -104,7 +104,7 @@ const UnavailableDatesTemplate = (args: CalendarProps) => {
 
 const ControlledFocusedValueTemplate = (args: CalendarProps) => {
   let defaultDate = today(getLocalTimeZone());
-  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+  let [focusedDate, setFocusedDate] = React.useState<DateValue>(defaultDate);
 
   return (
     <div className="flex flex-col gap-4">

--- a/packages/components/calendar/stories/range-calendar.stories.tsx
+++ b/packages/components/calendar/stories/range-calendar.stories.tsx
@@ -7,7 +7,6 @@ import {
   today,
   getLocalTimeZone,
   isWeekend,
-  CalendarDate,
   startOfMonth,
   startOfWeek,
   endOfMonth,
@@ -124,8 +123,8 @@ const NonContiguousRangesTemplate = (args: RangeCalendarProps) => {
 };
 
 const ControlledFocusedValueTemplate = (args: RangeCalendarProps) => {
-  let defaultDate = new CalendarDate(2024, 3, 1);
-  let [focusedDate, setFocusedDate] = React.useState(defaultDate);
+  let defaultDate = today(getLocalTimeZone());
+  let [focusedDate, setFocusedDate] = React.useState<DateValue>(defaultDate);
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
Closes #

## 📝 Description

- Removed `CalendarDate` and replaced it with `today`
- Added type to `focusedDate` in `ControlledFocusedValueTemplate` of Range-Calendar


## ⛳️ Current behavior (updates)
 
```
let defaultDate = new CalendarDate(2024, 3, 1);
let [focusedDate, setFocusedDate] = React.useState(defaultDate);
```

## 🚀 New behavior 

```
let defaultDate = today(getLocalTimeZone());
let [focusedDate, setFocusedDate] = React.useState<DateValue>(defaultDate);
```
## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
