### PR TITLE
fix: modal - searching with one char shows no results & cmdk esc does not work without recent search results

### DIFF
--- a/apps/docs/components/cmdk.tsx
+++ b/apps/docs/components/cmdk.tsx
@@ -266,7 +266,7 @@ export const Cmdk: FC<{}> = () => {
         }
       }
     },
-    [activeItem, items, router],
+    [activeItem, items, router, query],
   );
 
   useUpdateEffect(() => {
@@ -410,8 +410,8 @@ export const Cmdk: FC<{}> = () => {
             </Kbd>
           </div>
           <Command.List ref={listRef} className={slots.list()} role="listbox">
-            {query.length > 0 && (
-              <Command.Empty>
+            <Command.Empty>
+              {query.length > 0 && (
                 <div className={slots.emptyWrapper()}>
                   <div>
                     <p>No results for &quot;{query}&quot;</p>
@@ -424,8 +424,8 @@ export const Cmdk: FC<{}> = () => {
                     )}
                   </div>
                 </div>
-              </Command.Empty>
-            )}
+              )}
+            </Command.Empty>
 
             {isEmpty(query) &&
               (isEmpty(recentSearches) ? (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2643

## 📝 Description

*make sure that you remove the recent search results.
 - When users search from the search-modal with one single char like the pic, it will fail with no result.
 -  Cmdk ESC does not work when there is no recent search results cache.

## ⛳️ Current behavior (updates)

one char searching will show no result in the search modal.

## 🚀 New behavior


https://github.com/nextui-org/nextui/assets/62743644/e7907c29-ec8a-4863-939a-ffaa4de8ee0c



## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the responsiveness of the command list to user input in the documentation viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->