### PR TITLE
fix: selectedKeys are not present in the collection warning in async case

### DIFF
--- a/.changeset/rare-plums-speak.md
+++ b/.changeset/rare-plums-speak.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/use-aria-multiselect": patch
+"@nextui-org/stories-utils": patch
+---
+
+Fixed SELECT defaultSelectedKeys Warning selectedKeys are not present in the collection (#2605)

--- a/.changeset/rare-plums-speak.md
+++ b/.changeset/rare-plums-speak.md
@@ -3,4 +3,4 @@
 "@nextui-org/stories-utils": patch
 ---
 
-Fixed SELECT defaultSelectedKeys Warning selectedKeys are not present in the collection (#2605)
+Fixed an issue where a warning was triggered in the Select component when `defaultSelectedKeys` were used and items were still loading (#2605).

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
@@ -1,8 +1,11 @@
 import {ListState, useListState} from "@react-stately/list";
-import {CollectionBase, MultipleSelection, Node} from "@react-types/shared";
+import {CollectionBase, MultipleSelection, AsyncLoadable, Node} from "@react-types/shared";
 import {Key, useMemo} from "react";
 
-export interface MultiSelectListProps<T> extends CollectionBase<T>, MultipleSelection {}
+export interface MultiSelectListProps<T>
+  extends CollectionBase<T>,
+    AsyncLoadable,
+    MultipleSelection {}
 
 export interface MultiSelectListState<T> extends ListState<T> {
   /** The keys for the currently selected items. */
@@ -46,7 +49,7 @@ export function useMultiSelectListState<T extends object>(
       : null
   ) as Node<T>[] | null;
 
-  if (missingKeys.length) {
+  if (!!!props?.isLoading && missingKeys.length) {
     // eslint-disable-next-line no-console
     console.warn(
       `Select: Keys "${missingKeys.join(

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-list-state.ts
@@ -29,7 +29,7 @@ export function useMultiSelectListState<T extends object>(
   } = useListState<T>(props);
 
   const missingKeys: Key[] = useMemo(() => {
-    if (selectedKeys.size !== 0) {
+    if (!props.isLoading && selectedKeys.size !== 0) {
       return Array.from(selectedKeys)
         .filter(Boolean)
         .filter((key) => !collection.getItem(`${key}`));
@@ -49,7 +49,7 @@ export function useMultiSelectListState<T extends object>(
       : null
   ) as Node<T>[] | null;
 
-  if (!!!props?.isLoading && missingKeys.length) {
+  if (missingKeys.length) {
     // eslint-disable-next-line no-console
     console.warn(
       `Select: Keys "${missingKeys.join(

--- a/packages/utilities/stories-utils/src/hooks/use-pokemon-list.ts
+++ b/packages/utilities/stories-utils/src/hooks/use-pokemon-list.ts
@@ -14,7 +14,7 @@ export type UsePokemonListProps = {
 export function usePokemonList({fetchDelay = 0}: UsePokemonListProps = {}) {
   const [items, setItems] = useState<Pokemon[]>([]);
   const [hasMore, setHasMore] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [offset, setOffset] = useState(0);
   const limit = 20; // Number of items per page, adjust as necessary
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2605

## 📝 Description

- When `isLoading` is `true`, skip checking missing keys since the collection hasn't built yet.
- Changed `isLoading` to `true` in use-pokemon-list.ts  by default to avoid cases like `false` -> `true` -> `false`.

## ⛳️ Current behavior (updates)

Currently when the data is being fetched (isLoading = true), the warning is shown saying `defaultSelectedKeys` is not in the collection. 

## 🚀 New behavior

- as mentioned in description

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Patched issues in "@nextui-org/use-aria-multiselect" and "@nextui-org/stories-utils" packages to fix a warning about `SELECT defaultSelectedKeys`.
- **Refactor**
	- Enhanced `useMultiSelectListState` to better handle loading states.
- **Chores**
	- Adjusted initial loading state in `usePokemonList` for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->