### PR TITLE
refactor(autocomplete): remove unnecessary map after getting all collection key

### DIFF
--- a/.changeset/silly-pants-type.md
+++ b/.changeset/silly-pants-type.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Removed unnecessary map after getting all collection keys

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -181,7 +181,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
   state = {
     ...state,
     ...(isReadOnly && {
-      disabledKeys: new Set([...state.collection.getKeys()].map((k) => k)),
+      disabledKeys: new Set([...state.collection.getKeys()]),
     }),
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

as titled

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- Improved performance of the autocomplete feature by eliminating redundant operations.
	- Enhanced the behavior of the autocomplete when in read-only mode to handle disabled keys more efficiently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->