### PR TITLE
fix(slider): fix slider component vertical mark y position focus …

### DIFF
--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -144,7 +144,7 @@ const slider = tv({
         track: "h-full border-y-transparent",
         labelWrapper: "flex-col justify-center items-center",
         step: ["left-1/2", "-translate-x-1/2", "translate-y-1/2"],
-        mark: ["left-1/2", "ml-1", "translate-x-1/2", "-translate-y-1/2"],
+        mark: ["left-1/2", "ml-1", "translate-x-1/2", "translate-y-1/2"],
       },
       false: {
         thumb: "top-1/2",


### PR DESCRIPTION
…issue

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2658

## 📝 Description

When applying the vertical direction property in a slide component and rendering a mark, we have solved an issue where the y-axis position where the mark is rendered is not in focus with the corresponding % position.

## ⛳️ Current behavior (updates)

![스크린샷 2024-04-07 오후 1 59 08](https://github.com/nextui-org/nextui/assets/110542210/bb36197c-e5a8-4907-9814-5ea15d4ade1e)


## 🚀 New behavior

![스크린샷 2024-04-07 오후 1 59 21](https://github.com/nextui-org/nextui/assets/110542210/1cc86b2d-5f6c-4118-beae-880a9c74e98a)

> Please describe the behavior or changes this PR adds

The position of the y-axis where the mark is rendered when using the vertical attribute has been modified to match the focus.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the positioning of the mark element within the slider component for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->