### PR TITLE
fix(autocomplete): empty items with allowCustomValue

### DIFF
--- a/.changeset/chatty-singers-remember.md
+++ b/.changeset/chatty-singers-remember.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Fixed empty items with allowCustomValue by avoiding null node in `ariaHideOutside` from `@react-aria/overlays`

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -26,6 +26,7 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
     getInputProps,
     getListBoxProps,
     getPopoverProps,
+    getEmptyPopoverProps,
     getClearButtonProps,
     getListBoxWrapperProps,
     getEndContentWrapperProps,
@@ -42,7 +43,9 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
         <Listbox {...getListBoxProps()} />
       </ScrollShadow>
     </FreeSoloPopover>
-  ) : null;
+  ) : (
+    <div {...getEmptyPopoverProps()} />
+  );
 
   return (
     <Component {...getBaseProps()}>

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -400,6 +400,14 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     } as unknown as PopoverProps;
   };
 
+  const getEmptyPopoverProps = () => {
+    // avoid null node in `ariaHideOutside` from `@react-aria/overlays`
+    return {
+      ref: popoverRef,
+      classNames: "hidden",
+    };
+  };
+
   const getListBoxWrapperProps: PropGetter = (props: any = {}) => ({
     ...mergeProps(slotsProps.scrollShadowProps, props),
     className: slots.listboxWrapper({
@@ -443,6 +451,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     getInputProps,
     getListBoxProps,
     getPopoverProps,
+    getEmptyPopoverProps,
     getClearButtonProps,
     getSelectorButtonProps,
     getListBoxWrapperProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2554

## 📝 Description

In `useComboBox.ts`, when `state.isOpen`, it will pass input ref and popover ref to `ariaHideOutside`, where the error was thrown. If we have autocomplete with empty items + allowCustomValue, when we open the popover, the ref will be null causing the issue.

ref: [useComboBox.ts#L321](https://github.com/adobe/react-spectrum/blob/b2d25ef23b827ec2427bf47b343e6dbd66326ed3/packages/%40react-aria/combobox/src/useComboBox.ts#L321) and [ariaHideOutside.ts#L112](https://github.com/adobe/react-spectrum/blob/b2d25ef23b827ec2427bf47b343e6dbd66326ed3/packages/%40react-aria/overlays/src/ariaHideOutside.ts#L112)

## ⛳️ Current behavior (updates)

Autocomplete with empty items + allowCustomValue -> open popover -> see the error

```
import.mjs:1290 Uncaught TypeError: Cannot read properties of null (reading 'contains')
    at eval (import.mjs:1290:33)
    at Array.some (<anonymous>)
    at MutationObserver.eval (import.mjs:1290:15)
```

## 🚀 New behavior

No error is shown

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Patched the "@nextui-org/autocomplete" package to fix an issue where empty items with `allowCustomValue` would not render properly due to a null node problem.

- **New Features**
	- Enhanced the `Autocomplete` component to render an empty `div` when there are no suggestions, improving the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->