### PR TITLE
fix: remove conflicting transition utilities

### DIFF
--- a/.changeset/rare-ants-ring.md
+++ b/.changeset/rare-ants-ring.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/theme": patch
+---
+
+fix: remove conflicting transition utilities (close #1502)
+
+see: https://tailwindcss.com/docs/transition-property

--- a/.changeset/rare-ants-ring.md
+++ b/.changeset/rare-ants-ring.md
@@ -2,6 +2,6 @@
 "@nextui-org/theme": patch
 ---
 
-fix: remove conflicting transition utilities (close #1502)
+Fix: remove conflicting transition utilities (close #1502)
 
-see: https://tailwindcss.com/docs/transition-property
+See: https://tailwindcss.com/docs/transition-property

--- a/packages/core/theme/src/plugin.ts
+++ b/packages/core/theme/src/plugin.ts
@@ -20,6 +20,7 @@ import {createSpacingUnits, generateSpacingScale, isBaseTheme} from "./utils/the
 import {ConfigTheme, ConfigThemes, DefaultThemeType, NextUIPluginConfig} from "./types";
 import {lightLayout, darkLayout, defaultLayout} from "./default-layout";
 import {baseStyles} from "./utils/classes";
+import {DEFAULT_TRANSITION_DURATION} from "./utilities/transition";
 
 const DEFAULT_PREFIX = "nextui";
 
@@ -264,6 +265,7 @@ const corePlugin = (
             0: "0ms",
             250: "250ms",
             400: "400ms",
+            DEFAULT: DEFAULT_TRANSITION_DURATION,
           },
           transitionTimingFunction: {
             "soft-spring": "cubic-bezier(0.155, 1.105, 0.295, 1.12)",

--- a/packages/core/theme/src/utilities/transition.ts
+++ b/packages/core/theme/src/utilities/transition.ts
@@ -1,36 +1,36 @@
-const DEFAULT_TRANSITION_DURATION = "250ms";
+export const DEFAULT_TRANSITION_DURATION = "250ms";
 
 export default {
   /**
    * Transition utilities
    */
-  ".transition-all": {
-    "transition-property": "all",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
+  // ".transition-all": {
+  //   "transition-property": "all",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
   ".transition-background": {
     "transition-property": "background",
     "transition-timing-function": "ease",
     "transition-duration": DEFAULT_TRANSITION_DURATION,
   },
-  ".transition": {
-    "transition-property":
-      "color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
-  ".transition-colors": {
-    "transition-property":
-      "color, background-color, border-color, text-decoration-color, fill, stroke",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
-  ".transition-opacity": {
-    "transition-property": "opacity",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
+  // ".transition": {
+  //   "transition-property":
+  //     "color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
+  // ".transition-colors": {
+  //   "transition-property":
+  //     "color, background-color, border-color, text-decoration-color, fill, stroke",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
+  // ".transition-opacity": {
+  //   "transition-property": "opacity",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
   ".transition-colors-opacity": {
     "transition-property":
       "color, background-color, border-color, text-decoration-color, fill, stroke, opacity",
@@ -57,16 +57,16 @@ export default {
     "transition-timing-function": "ease",
     "transition-duration": DEFAULT_TRANSITION_DURATION,
   },
-  ".transition-shadow": {
-    "transition-property": "box-shadow",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
-  ".transition-transform": {
-    "transition-property": "transform",
-    "transition-timing-function": "ease",
-    "transition-duration": DEFAULT_TRANSITION_DURATION,
-  },
+  // ".transition-shadow": {
+  //   "transition-property": "box-shadow",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
+  // ".transition-transform": {
+  //   "transition-property": "transform",
+  //   "transition-timing-function": "ease",
+  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
+  // },
   ".transition-transform-opacity": {
     "transition-property": "transform, opacity",
     "transition-timing-function": "ease",

--- a/packages/core/theme/src/utilities/transition.ts
+++ b/packages/core/theme/src/utilities/transition.ts
@@ -4,33 +4,11 @@ export default {
   /**
    * Transition utilities
    */
-  // ".transition-all": {
-  //   "transition-property": "all",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
   ".transition-background": {
     "transition-property": "background",
     "transition-timing-function": "ease",
     "transition-duration": DEFAULT_TRANSITION_DURATION,
   },
-  // ".transition": {
-  //   "transition-property":
-  //     "color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
-  // ".transition-colors": {
-  //   "transition-property":
-  //     "color, background-color, border-color, text-decoration-color, fill, stroke",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
-  // ".transition-opacity": {
-  //   "transition-property": "opacity",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
   ".transition-colors-opacity": {
     "transition-property":
       "color, background-color, border-color, text-decoration-color, fill, stroke, opacity",
@@ -57,16 +35,6 @@ export default {
     "transition-timing-function": "ease",
     "transition-duration": DEFAULT_TRANSITION_DURATION,
   },
-  // ".transition-shadow": {
-  //   "transition-property": "box-shadow",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
-  // ".transition-transform": {
-  //   "transition-property": "transform",
-  //   "transition-timing-function": "ease",
-  //   "transition-duration": DEFAULT_TRANSITION_DURATION,
-  // },
   ".transition-transform-opacity": {
     "transition-property": "transform, opacity",
     "transition-timing-function": "ease",


### PR DESCRIPTION
Remove the default duplicate Transition utilities in TailwindCSS (they do not need to be redefined) to prevent users from customizing transition effects, such as `duration-300` being overridden by the higher priority of the NextUI Plugin and not working.

Removing these redundant transition effects will not cause existing component effects to fail because TailwindCSS already includes them. Please feel free to check the preview documentation page. We only need to set `DEFAULT_TRANSITION_DURATION` to the `DEFAULT` key in order to modify the default transition time.

See: https://tailwindcss.com/docs/transition-property

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1502 <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Patched the theme package to resolve conflicts with transition utilities, enhancing CSS compatibility and addressing issue #1502.
	- Removed conflicting transition definitions affecting CSS classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->