### PR TITLE
fix(core): hsl rounding issue

### DIFF
--- a/.changeset/real-parrots-act.md
+++ b/.changeset/real-parrots-act.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-Fixed hsl rounding issue (#2697)
+Changed the HSL rounding to 2 decimal places (#2697)

--- a/.changeset/real-parrots-act.md
+++ b/.changeset/real-parrots-act.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Fixed hsl rounding issue (#2697)

--- a/packages/core/theme/src/plugin.ts
+++ b/packages/core/theme/src/plugin.ts
@@ -78,7 +78,7 @@ const resolveConfig = (
 
       try {
         const parsedColor =
-          parsedColorsCache[colorValue] || Color(colorValue).hsl().round().array();
+          parsedColorsCache[colorValue] || Color(colorValue).hsl().round(2).array();
 
         parsedColorsCache[colorValue] = parsedColor;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2697

## 📝 Description

Currently the HSL values got rounded. 

`#787865`:

```
Color(colorValue).hsl() {
  model: 'hsl',
  color: [ 60, 8.597285067873305, 43.333333333333336 ],
  valpha: 1
}
```

It will become `color: [ 60, 9, 43 ]`. In this case, the color will be slightly changed.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed an HSL color rounding issue in the theme settings to ensure accurate color representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->