### PR TITLE
fix: Calendar visibleMonth UI glitch (to v2.3.0)

### DIFF
--- a/packages/core/theme/src/components/date-picker.ts
+++ b/packages/core/theme/src/components/date-picker.ts
@@ -23,6 +23,7 @@ const datePicker = tv({
     hasMultipleMonths: {
       true: {
         calendar: "w-[calc(var(--visible-months)_*_var(--calendar-width))]",
+        calendarContent: "w-[calc(var(--visible-months)_*_var(--calendar-width))]",
       },
       false: {},
     },


### PR DESCRIPTION
Closes #

## 📝 Description

**branch: v2.3.0**
In the DatePicker storybook, for the visibleMonth section, calendarContent(slot) does not widen enough its width.(demo video attached)

## ⛳️ Current behavior (updates)

https://github.com/nextui-org/nextui/assets/62743644/803ef02f-79be-4076-8742-0a35a43c8f19

## 🚀 New behavior

https://github.com/nextui-org/nextui/assets/62743644/db2a301d-e012-418c-a9da-397295ad0ccd


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
