### PR TITLE
fix(modal): input carry over with IMEs in modal forms

### DIFF
--- a/.changeset/old-cameras-sip.md
+++ b/.changeset/old-cameras-sip.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/modal": patch
+---
+
+prevent IME input carryover in form fields when tabbing

--- a/.changeset/old-cameras-sip.md
+++ b/.changeset/old-cameras-sip.md
@@ -2,4 +2,4 @@
 "@nextui-org/modal": patch
 ---
 
-prevent IME input carryover in form fields when tabbing
+Prevent IME input carryover in form fields when tabbing

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -9,7 +9,7 @@ import {CloseIcon} from "@nextui-org/shared-icons";
 import {RemoveScroll} from "react-remove-scroll";
 import {domAnimation, LazyMotion, m} from "framer-motion";
 import {useDialog} from "@react-aria/dialog";
-import {mergeProps} from "@react-aria/utils";
+import {chain, mergeProps} from "@react-aria/utils";
 import {HTMLNextUIProps} from "@nextui-org/system";
 import {KeyboardEvent} from "react";
 
@@ -60,6 +60,7 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     </button>
   );
 
+  // Handle Tab key during IME composition to prevent input carryover
   const onKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === "Tab" && e.nativeEvent.isComposing) {
       e.stopPropagation();
@@ -67,8 +68,9 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     }
   }, []);
 
+  const contentProps = getDialogProps(mergeProps(dialogProps, otherProps));
   const content = (
-    <Component {...getDialogProps(mergeProps(dialogProps, otherProps))} onKeyDown={onKeyDown}>
+    <Component {...contentProps} onKeyDown={chain(contentProps.onKeyDown, onKeyDown)}>
       <DismissButton onDismiss={onClose} />
       {!hideCloseButton && closeButtonContent}
       {typeof children === "function" ? children(onClose) : children}

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -11,6 +11,7 @@ import {domAnimation, LazyMotion, m} from "framer-motion";
 import {useDialog} from "@react-aria/dialog";
 import {mergeProps} from "@react-aria/utils";
 import {HTMLNextUIProps} from "@nextui-org/system";
+import {KeyboardEvent} from "react";
 
 import {useModalContext} from "./modal-context";
 import {scaleInOut} from "./modal-transition";
@@ -59,8 +60,15 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     </button>
   );
 
+  const onKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "Tab" && e.nativeEvent.isComposing) {
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }, []);
+
   const content = (
-    <Component {...getDialogProps(mergeProps(dialogProps, otherProps))}>
+    <Component {...getDialogProps(mergeProps(dialogProps, otherProps))} onKeyDown={onKeyDown}>
       <DismissButton onDismiss={onClose} />
       {!hideCloseButton && closeButtonContent}
       {typeof children === "function" ? children(onClose) : children}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/2445

## 📝 Description

Fixed an issue where typing with an IME (like Korean or Japanese) and pressing tab would carry the input to the next field. This was resolved using the [isComposing property](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing).

https://github.com/nextui-org/nextui/assets/76232929/0c7a228f-677a-4f0d-a930-7adc8b3419dd


## ⛳️ Current behavior (updates)

When entering text in a modal form using Korean, pressing the tab key causes the last character to be entered into the next input field.

## 🚀 New behavior

Pressing the tab key after entering text in Korean no longer transfers the last character to the next input field. 

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This bug does not occur in Storybook, so the behavior was verified using the [docs](https://nextui.org/docs/components/modal#with-form).
This was tested using both Japanese and 2-set Korean IMEs on browsers including Chrome, Safari, and Firefox.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Implemented a fix in modal components to prevent carryover of IME (Input Method Editor) input when switching fields using the Tab key.
	- Enhanced accessibility by handling Tab key press event in the `ModalContent` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->