### PR TITLE
refactor(theme): units removed, tailwind-variants upgraded

### DIFF
--- a/apps/docs/app/examples/perf/page.tsx
+++ b/apps/docs/app/examples/perf/page.tsx
@@ -124,15 +124,15 @@ const MyInput = extendVariants(Input, {
     },
     size: {
       xs: {
-        inputWrapper: "h-unit-6 min-h-unit-6 px-1",
+        inputWrapper: "h-6 min-h-6 px-1",
         input: "text-tiny",
       },
       md: {
-        inputWrapper: "h-unit-10 min-h-unit-10",
+        inputWrapper: "h-10 min-h-10",
         input: "text-small",
       },
       xl: {
-        inputWrapper: "h-unit-14 min-h-unit-14",
+        inputWrapper: "h-14 min-h-14",
         input: "text-medium",
       },
     },

--- a/apps/docs/config/routes.json
+++ b/apps/docs/config/routes.json
@@ -84,7 +84,8 @@
         {
           "key": "layout",
           "title": "Layout",
-          "path": "/docs/customization/layout.mdx"
+          "path": "/docs/customization/layout.mdx",
+          "updated": true
         },
         {
           "key": "colors",

--- a/apps/docs/content/components/breadcrumbs/customizing-ellipsis.ts
+++ b/apps/docs/content/components/breadcrumbs/customizing-ellipsis.ts
@@ -12,7 +12,7 @@ export default function App() {
             <DropdownTrigger>
               <Button
                 isIconOnly
-                className="min-w-unit-6 w-unit-6 h-unit-6"
+                className="min-w-6 w-6 h-6"
                 size="sm"
                 variant="flat"
               >

--- a/apps/docs/content/components/select/custom-styles.ts
+++ b/apps/docs/content/components/select/custom-styles.ts
@@ -213,7 +213,7 @@ export default function App() {
       variant="bordered"
       classNames={{
         label: "group-data-[filled=true]:-translate-y-5",
-        trigger: "min-h-unit-16",
+        trigger: "min-h-16",
         listboxWrapper: "max-h-[400px]",
       }}
       listboxProps={{

--- a/apps/docs/content/components/select/multiple-chips.ts
+++ b/apps/docs/content/components/select/multiple-chips.ts
@@ -216,7 +216,7 @@ export default function App() {
       labelPlacement="outside"
       classNames={{
         base: "max-w-xs",
-        trigger: "min-h-unit-12 py-2",
+        trigger: "min-h-12 py-2",
       }}
       renderValue={(items) => {
         return (
@@ -269,7 +269,7 @@ export default function App() {
       labelPlacement="outside"
       classNames={{
         base: "max-w-xs",
-        trigger: "min-h-unit-12 py-2",
+        trigger: "min-h-12 py-2",
       }}
       renderValue={(items: SelectedItems<User>) => {
         return (

--- a/apps/docs/content/customization/colors/semantic-colors.ts
+++ b/apps/docs/content/customization/colors/semantic-colors.ts
@@ -1,6 +1,6 @@
 const App = `export default function App() {
   return (
-    <div class="bg-primary-500 text-primary-50 rounded-small px-unit-2 py-unit-1">
+    <div class="bg-primary-500 text-primary-50 rounded-small px-2 py-1">
       This is a primary color box
     </div>
   );

--- a/apps/docs/content/customization/custom-variants/no-slots-component.ts
+++ b/apps/docs/content/customization/custom-variants/no-slots-component.ts
@@ -11,9 +11,9 @@ const MyButton = extendVariants(Button, {
       true: "bg-[#eaeaea] text-[#000] opacity-50 cursor-not-allowed",
     },
     size: { 
-      xs: "px-unit-2 min-w-unit-12 h-unit-6 text-tiny gap-unit-1 rounded-small",
-      md: "px-unit-4 min-w-unit-20 h-unit-10 text-small gap-unit-2 rounded-small",
-      xl: "px-unit-8 min-w-unit-28 h-unit-14 text-large gap-unit-4 rounded-medium",
+      xs: "px-2 min-w-12 h-6 text-tiny gap-1 rounded-small",
+      md: "px-4 min-w-20 h-10 text-small gap-2 rounded-small",
+      xl: "px-8 min-w-28 h-14 text-large gap-4 rounded-medium",
     },
   },
   defaultVariants: {

--- a/apps/docs/content/customization/custom-variants/slots-component.ts
+++ b/apps/docs/content/customization/custom-variants/slots-component.ts
@@ -63,15 +63,15 @@ const MyInput = extendVariants(Input, {
     },
     size: {
       xs: {
-        inputWrapper: "h-unit-6 min-h-unit-6 px-1",
+        inputWrapper: "h-6 min-h-6 px-1",
         input: "text-tiny",
       },
       md: {
-        inputWrapper: "h-unit-10 min-h-unit-10",
+        inputWrapper: "h-10 min-h-10",
         input: "text-small",
       },
       xl: {
-        inputWrapper: "h-unit-14 min-h-unit-14",
+        inputWrapper: "h-14 min-h-14",
         input: "text-medium",
       },
     },

--- a/apps/docs/content/docs/customization/colors.mdx
+++ b/apps/docs/content/docs/customization/colors.mdx
@@ -158,7 +158,7 @@ Semantic colors can be applied anywhere in your project where colors are used, s
 text color, border color, background color utilities, and more.
 
 ```html
-<div class="bg-primary-500 text-primary-50 rounded-small px-unit-2 py-unit-1">
+<div class="bg-primary-500 text-primary-50 rounded-small px-2 py-1">
   This is a primary color box
 </div>
 ```
@@ -205,10 +205,10 @@ Then you can use the CSS variables in your CSS files.
 ```css
 /* With default prefix */
 .my-component {
-  background-color: var(--nextui-primary-500);
+  background-color: hsl(var(--nextui-primary-500));
 }
 /*  With custom prefix */
 .my-component {
-  background-color: var(--myapp-primary-500);
+  background-color: hsl(var(--myapp-primary-500));
 }
 ```

--- a/apps/docs/content/docs/customization/custom-variants.mdx
+++ b/apps/docs/content/docs/customization/custom-variants.mdx
@@ -47,9 +47,9 @@ export const MyButton = extendVariants(Button, {
       true: "bg-[#eaeaea] text-[#000] opacity-50 cursor-not-allowed",
     },
     size: {
-      xs: "px-unit-2 min-w-unit-12 h-unit-6 text-tiny gap-unit-1 rounded-small",
-      md: "px-unit-4 min-w-unit-20 h-unit-10 text-small gap-unit-2 rounded-small",
-      xl: "px-unit-8 min-w-unit-28 h-unit-14 text-large gap-unit-4 rounded-medium",
+      xs: "px-2 min-w-12 h-6 text-tiny gap-1 rounded-small",
+      md: "px-4 min-w-20 h-10 text-small gap-2 rounded-small",
+      xl: "px-8 min-w-28 h-14 text-large gap-4 rounded-medium",
     },
   },
   defaultVariants: { // <- modify/add default variants
@@ -151,15 +151,15 @@ const MyInput = extendVariants(Input, {
     },
     size: {
       xs: {
-        inputWrapper: "h-unit-6 min-h-unit-6 px-1",
+        inputWrapper: "h-6 min-h-6 px-1",
         input: "text-tiny",
       },
       md: {
-        inputWrapper: "h-unit-10 min-h-unit-10",
+        inputWrapper: "h-10 min-h-10",
         input: "text-small",
       },
       xl: {
-        inputWrapper: "h-unit-14 min-h-unit-14",
+        inputWrapper: "h-14 min-h-14",
         input: "text-medium",
       },
     },

--- a/apps/docs/content/docs/customization/layout.mdx
+++ b/apps/docs/content/docs/customization/layout.mdx
@@ -46,9 +46,8 @@ module.exports = {
   plugins: [
     nextui({
       layout: {
-        spacingUnit: 4, // in px
-        disabledOpacity: 0.5, // this value is applied as opacity-[value] when the component is disabled
         dividerWeight: "1px", // h-divider the default height applied to the divider component
+        disabledOpacity: 0.5, // this value is applied as opacity-[value] when the component is disabled
         fontSize: {
           tiny: "0.75rem", // text-tiny
           small: "0.875rem", // text-small
@@ -111,84 +110,6 @@ module.exports = {
 };
 ```
 
-## Units
-
-Units tokens define consistent spacing, padding, margin, gap and sizes across the components. Based on the 
-`spacingUnit` token (default 4px), NextUI auto-generates the following units:
-
-```ts
-// spacingUnit = 4px
-{
-  'unit-xs': '8px', // 2 * spacingUnit
-  'unit-sm': '12px', // 3 * spacingUnit
-  'unit-md': '16px', // 4 * spacingUnit
-  'unit-lg': '22px', // 5.5 * spacingUnit
-  'unit-xl': '36px', // 9 * spacingUnit
-  'unit-2xl': '48px', // 12 * spacingUnit
-  'unit-3xl': '80px', // 20 * spacingUnit
-  'unit-4xl': '120px', // 30 * spacingUnit
-  'unit-5xl': '224px', // 56 * spacingUnit
-  'unit-6xl': '288px', // 72 * spacingUnit
-  'unit-7xl': '384px', // 96 * spacingUnit
-  'unit-8xl': '512px', // 128 * spacingUnit
-  'unit-9xl': '640px', // 160 * spacingUnit
-  'unit-0': '0px', // 0 * spacingUnit
-  'unit-1': '4px', // 1 * spacingUnit
-  'unit-2': '8px', // 2 * spacingUnit
-  'unit-3': '12px', // 3 * spacingUnit
-  'unit-3_5': '14px' // 3.5 * spacingUnit
-  'unit-4': '16px', // 4 * spacingUnit
-  'unit-5': '20px', // 5 * spacingUnit
-  'unit-6': '24px', // 6 * spacingUnit
-  'unit-7': '28px', // 7 * spacingUnit
-  'unit-8': '32px', // 8 * spacingUnit
-  'unit-9': '36px', // 9 * spacingUnit
-  'unit-10': '40px', // 10 * spacingUnit
-  'unit-11': '44px', // 11 * spacingUnit
-  'unit-12': '48px', // 12 * spacingUnit
-  'unit-13': '52px', // 13 * spacingUnit
-  'unit-14': '56px', // 14 * spacingUnit
-  'unit-15': '60px', // 15 * spacingUnit
-  'unit-16': '64px', // 16 * spacingUnit
-  'unit-17': '68px', // 17 * spacingUnit
-  'unit-18': '72px', // 18 * spacingUnit
-  'unit-20': '80px', // 20 * spacingUnit
-  'unit-24': '96px', // 24 * spacingUnit
-  'unit-28': '112px', // 28 * spacingUnit
-  'unit-32': '128px', // 32 * spacingUnit
-  'unit-36': '144px', // 36 * spacingUnit
-  'unit-40': '160px', // 40 * spacingUnit
-  'unit-44': '176px', // 44 * spacingUnit
-  'unit-48': '192px', // 48 * spacingUnit
-  'unit-52': '208px', // 52 * spacingUnit
-  'unit-56': '224px', // 56 * spacingUnit
-  'unit-60': '240px', // 60 * spacingUnit
-  'unit-64': '256px', // 64 * spacingUnit
-  'unit-72': '288px', // 72 * spacingUnit
-  'unit-80': '320px', // 80 * spacingUnit
-  'unit-96': '384px', // 96 * spacingUnit
-}
-```
-
-### Using Units
-
-NextUI units behave like [Tailwind CSS spacing](https://tailwindcss.com/docs/customizing-spacing#default-spacing-scale) units. You can use them in the `margin`, `padding`,
-`width`, `height`, `min-width`, `min-height`, `gap`, `top`, `right`, `bottom`, and `left` properties.
-
-```jsx {5}
-import {Button} from "@nextui-org/react";
-
-export const MyButton = () => {
-  return (
-    <Button className="px-unit-2 py-unit-1 min-w-unit-3xl">
-      My Button
-    </Button>
-  );
-};
-```
-
-> **Remember**: Any changes to the `spacingUnit` token will automatically update the units.
-
 ### CSS Variables
 
 NextUI creates CSS variables using the format `--prefix-prop-name-scale` for each layout token. By
@@ -209,14 +130,13 @@ Then you can use the CSS variables in your CSS files.
 ```css
 /* With default prefix */
 .my-button {
-  padding: var(--nextui-spacing-unit-4);
   font-size: var(--nextui-font-size-small);
   line-height: var(--nextui-line-height-small);
   border-radius: var(--nextui-radius-medium);
 }
+
 /*  With custom prefix */
 .my-component {
-  padding: var(--myapp-spacing-unit-4);
   font-size: var(--myapp-font-size-small);
   line-height: var(--myapp-line-height-small);
   border-radius: var(--myapp-radius-medium);
@@ -227,9 +147,8 @@ Then you can use the CSS variables in your CSS files.
 
 | Attribute       | Type                            | Description                                                                                 |
 | --------------- | ------------------------------- | ------------------------------------------------------------------------------------------- |
-| spacingUnit     | number                          | Base unit token that defines a consistent spacing scale across the components.              |
-| disabledOpacity | string, number                  | A number between 0 and 1 that is applied as opacity-[value] when the component is disabled. |
 | hoverOpacity    | string, number                  | A number between 0 and 1 that is applied as opacity-[value] when the component is hovered.  |
+| disabledOpacity | string, number                  | A number between 0 and 1 that is applied as opacity-[value] when the component is disabled. |
 | dividerWeight   | string                          | The default height applied to the divider component. We recommend to use `px` units.        |
 | fontSize        | [FontThemeUnit](#fontthemeunit) | The default font size applied across the components.                                        |
 | lineHeight      | [FontThemeUnit](#fontthemeunit) | The default line height applied across the components.                                      |

--- a/apps/docs/content/docs/customization/theme.mdx
+++ b/apps/docs/content/docs/customization/theme.mdx
@@ -211,11 +211,6 @@ type FontThemeUnit = {
 
 interface LayoutTheme {
   /**
-   * Base unit token that defines a consistent spacing scale across
-   * the components.
-   */
-  spacingUnit?: number;
-  /**
    * The default font size applied across the components.
    */
   fontSize?: FontThemeUnit;

--- a/apps/docs/content/docs/frameworks/astro.mdx
+++ b/apps/docs/content/docs/frameworks/astro.mdx
@@ -8,7 +8,7 @@ description: How to use NextUI with Astro
 Requirements:
 
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/docs/guides/astro) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/docs/guides/astro) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ------

--- a/apps/docs/content/docs/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs.mdx
@@ -10,7 +10,7 @@ Requirements:
 
 - [Next.js 12](https://nextjs.org/) or later
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/docs/guides/nextjs) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/docs/guides/nextjs) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ------

--- a/apps/docs/content/docs/frameworks/remix.mdx
+++ b/apps/docs/content/docs/frameworks/remix.mdx
@@ -8,7 +8,7 @@ description: How to use NextUI with Remix
 Requirements:
 
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/docs/guides/remix) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/docs/guides/remix) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ------

--- a/apps/docs/content/docs/frameworks/vite.mdx
+++ b/apps/docs/content/docs/frameworks/vite.mdx
@@ -9,7 +9,7 @@ Requirements:
 
 - [Vite 2](https://vitejs.dev/) or later
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/docs/guides/vite#react) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/docs/guides/vite#react) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ------

--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -8,7 +8,7 @@ description: Get started with NextUI in the official documentation, and learn mo
 Requirements:
 
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ---

--- a/apps/docs/content/docs/guide/upgrade-to-v2.mdx
+++ b/apps/docs/content/docs/guide/upgrade-to-v2.mdx
@@ -9,7 +9,7 @@ description: Upgrade from NextUI v1 to v2
 Requirements:
 
 - [React 18](https://reactjs.org/) or later
-- [Tailwind CSS 3](https://tailwindcss.com/) or later
+- [Tailwind CSS 3.4](https://tailwindcss.com/) or later
 - [Framer Motion 4](https://www.framer.com/motion/) or later
 
 ----- 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -91,7 +91,7 @@
     "sharp": "^0.32.1",
     "shelljs": "^0.8.4",
     "swr": "^2.2.1",
-    "tailwind-variants": "^0.1.18",
+    "tailwind-variants": "^0.1.20",
     "unified": "^9.2.2",
     "unist-util-visit": "^4.1.2",
     "usehooks-ts": "^2.9.1",

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -528,7 +528,7 @@ const CustomStylesTemplate = ({color, variant, ...args}: AutocompleteProps<User>
     <Autocomplete
       className="max-w-xs"
       classNames={{
-        base: "min-h-unit-16",
+        base: "min-h-16",
         listboxWrapper: "max-h-[400px]",
       }}
       color={color}

--- a/packages/components/breadcrumbs/stories/breadcrumbs.stories.tsx
+++ b/packages/components/breadcrumbs/stories/breadcrumbs.stories.tsx
@@ -237,7 +237,7 @@ const WithDropdownEllipsisTemplate = (args: BreadcrumbsProps & {page: number}) =
       <div className="flex items-center">
         <Dropdown>
           <DropdownTrigger>
-            <Button isIconOnly className="min-w-unit-6 w-unit-6 h-unit-6" size="sm" variant="flat">
+            <Button isIconOnly className="min-w-6 w-6 h-6" size="sm" variant="flat">
               {ellipsisIcon}
             </Button>
           </DropdownTrigger>

--- a/packages/components/select/stories/select.stories.tsx
+++ b/packages/components/select/stories/select.stories.tsx
@@ -504,7 +504,7 @@ const CustomStylesTemplate = ({color, variant, ...args}: SelectProps<User>) => {
       className="max-w-xs"
       classNames={{
         label: "group-data-[filled=true]:-translate-y-5",
-        trigger: "min-h-unit-16",
+        trigger: "min-h-16",
         listboxWrapper: "max-h-[400px]",
       }}
       color={color}
@@ -802,7 +802,7 @@ export const WithChips = {
     labelPlacement: "outside",
     classNames: {
       base: "max-w-xs",
-      trigger: "min-h-unit-12 py-2",
+      trigger: "min-h-12 py-2",
     },
     renderValue: (items: SelectedItems<User>) => {
       return (

--- a/packages/core/system-rsc/__tests__/extend-variants.test.tsx
+++ b/packages/core/system-rsc/__tests__/extend-variants.test.tsx
@@ -128,9 +128,7 @@ describe("extendVariants function - no slots", () => {
 
     const button = container.querySelector("button");
 
-    expect(button).toHaveClass(
-      "px-unit-3 min-w-unit-16 h-unit-8 text-tiny gap-unit-2 rounded-small",
-    );
+    expect(button).toHaveClass("px-3 min-w-16 h-8 text-tiny gap-2 rounded-small");
   });
 
   test("should include the compound variant styles - extended", () => {

--- a/packages/core/system-rsc/package.json
+++ b/packages/core/system-rsc/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "react": "^18.0.0",
-    "tailwind-variants": "^0.1.18",
+   "tailwind-variants": "^0.1.20",
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/react-utils": "workspace:*",
     "@nextui-org/shared-utils": "workspace:*",

--- a/packages/core/system-rsc/test-utils/no-slots-component.tsx
+++ b/packages/core/system-rsc/test-utils/no-slots-component.tsx
@@ -27,9 +27,9 @@ const button = tv({
       foreground: "bg-foreground text-background",
     },
     size: {
-      sm: "px-unit-3 min-w-unit-16 h-unit-8 text-tiny gap-unit-2 rounded-small",
-      md: "px-unit-4 min-w-unit-20 h-unit-10 text-small gap-unit-2 rounded-medium",
-      lg: "px-unit-6 min-w-unit-24 h-unit-12 text-medium gap-unit-3 rounded-large",
+      sm: "px-3 min-w-16 h-8 text-tiny gap-2 rounded-small",
+      md: "px-4 min-w-20 h-10 text-small gap-2 rounded-medium",
+      lg: "px-6 min-w-24 h-12 text-medium gap-3 rounded-large",
     },
     isDisabled: {
       true: "opacity-disabled pointer-events-none",

--- a/packages/core/theme/package.json
+++ b/packages/core/theme/package.json
@@ -55,7 +55,7 @@
     "lodash.kebabcase": "^4.1.1",
     "lodash.mapkeys": "^4.6.0",
     "lodash.omit": "^4.5.0",
-    "tailwind-variants": "^0.1.18"
+    "tailwind-variants": "^0.1.20"
   },
   "peerDependencies": {
     "tailwindcss": ">=3.4.0"

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -51,9 +51,9 @@ const button = tv({
       ghost: "border-medium bg-transparent",
     },
     size: {
-      sm: "px-unit-3 min-w-unit-16 h-unit-8 text-tiny gap-unit-2 rounded-small",
-      md: "px-unit-4 min-w-unit-20 h-unit-10 text-small gap-unit-2 rounded-medium",
-      lg: "px-unit-6 min-w-unit-24 h-unit-12 text-medium gap-unit-3 rounded-large",
+      sm: "px-3 min-w-16 h-8 text-tiny gap-2 rounded-small",
+      md: "px-4 min-w-20 h-10 text-small gap-2 rounded-medium",
+      lg: "px-6 min-w-24 h-12 text-medium gap-3 rounded-large",
     },
     color: {
       default: "",
@@ -80,7 +80,7 @@ const button = tv({
       true: "[&:not(:first-child):not(:last-child)]:rounded-none",
     },
     isIconOnly: {
-      true: "px-unit-0 !gap-unit-0",
+      true: "px-0 !gap-0",
       false: "[&>svg]:max-w-[theme(spacing.unit-8)]",
     },
     disableAnimation: {
@@ -407,17 +407,17 @@ const button = tv({
     {
       isIconOnly: true,
       size: "sm",
-      class: "min-w-unit-8 w-unit-8 h-unit-8",
+      class: "min-w-8 w-8 h-8",
     },
     {
       isIconOnly: true,
       size: "md",
-      class: "min-w-unit-10 w-unit-10 h-unit-10",
+      class: "min-w-10 w-10 h-10",
     },
     {
       isIconOnly: true,
       size: "lg",
-      class: "min-w-unit-12 w-unit-12 h-unit-12",
+      class: "min-w-12 w-12 h-12",
     },
     // variant / hover
     {

--- a/packages/core/theme/src/components/chip.ts
+++ b/packages/core/theme/src/components/chip.ts
@@ -419,7 +419,7 @@ const chip = tv({
       hasEndContent: false,
       size: "sm",
       class: {
-        base: "w-5 h-5 min-w-unit-5 min-h-5",
+        base: "w-5 h-5 min-w-5 min-h-5",
       },
     },
     {
@@ -428,7 +428,7 @@ const chip = tv({
       hasEndContent: false,
       size: "md",
       class: {
-        base: "w-6 h-6 min-w-unit-6 min-h-6",
+        base: "w-6 h-6 min-w-6 min-h-6",
       },
     },
     {
@@ -437,7 +437,7 @@ const chip = tv({
       hasEndContent: false,
       size: "lg",
       class: {
-        base: "w-7 h-7 min-w-unit-7 min-h-7",
+        base: "w-7 h-7 min-w-7 min-h-7",
       },
     },
     // isOneChar / isCloseable

--- a/packages/core/theme/src/components/date-input.ts
+++ b/packages/core/theme/src/components/date-input.ts
@@ -133,16 +133,16 @@ const dateInput = tv({
       sm: {
         label: "text-tiny",
         input: "text-small",
-        inputWrapper: "h-unit-8 min-h-unit-8 px-2 rounded-small",
+        inputWrapper: "h-8 min-h-8 px-2 rounded-small",
       },
       md: {
         input: "text-small",
-        inputWrapper: "h-unit-10 min-h-unit-10 rounded-medium",
+        inputWrapper: "h-10 min-h-10 rounded-medium",
         clearButton: "text-large",
       },
       lg: {
         input: "text-medium",
-        inputWrapper: "h-unit-12 min-h-unit-12 rounded-large",
+        inputWrapper: "h-12 min-h-12 rounded-large",
       },
     },
     radius: {

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -132,17 +132,17 @@ const input = tv({
     size: {
       sm: {
         label: "text-tiny",
-        inputWrapper: "h-unit-8 min-h-unit-8 px-2 rounded-small",
+        inputWrapper: "h-8 min-h-8 px-2 rounded-small",
         input: "text-small",
         clearButton: "text-medium",
       },
       md: {
-        inputWrapper: "h-unit-10 min-h-unit-10 rounded-medium",
+        inputWrapper: "h-10 min-h-10 rounded-medium",
         input: "text-small",
         clearButton: "text-large",
       },
       lg: {
-        inputWrapper: "h-unit-12 min-h-unit-12 rounded-large",
+        inputWrapper: "h-12 min-h-12 rounded-large",
         input: "text-medium",
         clearButton: "text-large",
       },

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -20,8 +20,8 @@ const select = tv({
     trigger:
       "relative px-3 gap-3 w-full inline-flex flex-row items-center shadow-sm outline-none tap-highlight-transparent",
     innerWrapper:
-      "inline-flex h-full w-[calc(100%_-_theme(spacing.unit-6))] min-h-unit-4 items-center gap-1.5 box-border",
-    selectorIcon: "absolute right-3 w-unit-4 h-unit-4",
+      "inline-flex h-full w-[calc(100%_-_theme(spacing.unit-6))] min-h-4 items-center gap-1.5 box-border",
+    selectorIcon: "absolute right-3 w-4 h-4",
     spinner: "absolute right-3",
     value: ["text-foreground-500", "font-normal", "w-full", "text-left"],
     listboxWrapper: "scroll-py-6 max-h-64 w-full",
@@ -97,15 +97,15 @@ const select = tv({
     size: {
       sm: {
         label: "text-tiny",
-        trigger: "h-unit-8 min-h-unit-8 px-2 rounded-small",
+        trigger: "h-8 min-h-8 px-2 rounded-small",
         value: "text-small",
       },
       md: {
-        trigger: "h-unit-10 min-h-unit-10 rounded-medium",
+        trigger: "h-10 min-h-10 rounded-medium",
         value: "text-small",
       },
       lg: {
-        trigger: "h-unit-12 min-h-unit-12 rounded-large",
+        trigger: "h-12 min-h-12 rounded-large",
         value: "text-medium",
       },
     },
@@ -516,14 +516,14 @@ const select = tv({
       labelPlacement: "inside",
       size: "sm",
       class: {
-        trigger: "h-12 min-h-unit-12 py-1.5 px-3",
+        trigger: "h-12 min-h-12 py-1.5 px-3",
       },
     },
     {
       labelPlacement: "inside",
       size: "md",
       class: {
-        trigger: "h-14 min-h-unit-14 py-2",
+        trigger: "h-14 min-h-14 py-2",
       },
     },
     {
@@ -531,7 +531,7 @@ const select = tv({
       size: "lg",
       class: {
         label: "text-small",
-        trigger: "h-16 min-h-unit-16 py-2.5 gap-0",
+        trigger: "h-16 min-h-16 py-2.5 gap-0",
       },
     },
     //  labelPlacement=[inside, outside]

--- a/packages/core/theme/src/default-layout.ts
+++ b/packages/core/theme/src/default-layout.ts
@@ -1,9 +1,8 @@
 import {LayoutTheme} from "./types";
 
 export const defaultLayout: LayoutTheme = {
-  spacingUnit: 4,
-  disabledOpacity: ".5",
   dividerWeight: "1px",
+  disabledOpacity: ".5",
   fontSize: {
     tiny: "0.75rem",
     small: "0.875rem",

--- a/packages/core/theme/src/plugin.ts
+++ b/packages/core/theme/src/plugin.ts
@@ -16,7 +16,7 @@ import {semanticColors, commonColors} from "./colors";
 import {animations} from "./animations";
 import {utilities} from "./utilities";
 import {flattenThemeObject} from "./utils/object";
-import {createSpacingUnits, generateSpacingScale, isBaseTheme} from "./utils/theme";
+import {isBaseTheme} from "./utils/theme";
 import {ConfigTheme, ConfigThemes, DefaultThemeType, NextUIPluginConfig} from "./types";
 import {lightLayout, darkLayout, defaultLayout} from "./default-layout";
 import {baseStyles} from "./utils/classes";
@@ -129,26 +129,13 @@ const resolveConfig = (
           resolved.utilities[cssSelector]![nestedLayoutVariable] = nestedValue;
         }
       } else {
-        // Process base units and spacing scale
-        if (key === "spacing-unit") {
-          resolved.utilities[cssSelector]![layoutVariablePrefix] = value; // Add the base unit
+        // Handle opacity values and other singular layout values
+        const formattedValue =
+          layoutVariablePrefix.includes("opacity") && typeof value === "number"
+            ? value.toString().replace(/^0\./, ".")
+            : value;
 
-          const spacingScale = generateSpacingScale(Number(value));
-
-          for (const [scaleKey, scaleValue] of Object.entries(spacingScale)) {
-            const spacingVariable = `${layoutVariablePrefix}-${scaleKey}`;
-
-            resolved.utilities[cssSelector]![spacingVariable] = scaleValue;
-          }
-        } else {
-          // Handle opacity values and other singular layout values
-          const formattedValue =
-            layoutVariablePrefix.includes("opacity") && typeof value === "number"
-              ? value.toString().replace(/^0\./, ".")
-              : value;
-
-          resolved.utilities[cssSelector]![layoutVariablePrefix] = formattedValue;
-        }
+        resolved.utilities[cssSelector]![layoutVariablePrefix] = formattedValue;
       }
     }
   }
@@ -163,24 +150,6 @@ const corePlugin = (
   addCommonColors: boolean,
 ) => {
   const resolved = resolveConfig(themes, defaultTheme, prefix);
-  const minSizes = {
-    "unit-1": `var(--${prefix}-spacing-unit)`,
-    "unit-2": `var(--${prefix}-spacing-unit-2`,
-    "unit-3": `var(--${prefix}-spacing-unit-3)`,
-    "unit-3.5": `var(--${prefix}-spacing-unit-3_5)`,
-    "unit-4": `var(--${prefix}-spacing-unit-4)`,
-    "unit-5": `var(--${prefix}-spacing-unit-5)`,
-    "unit-6": `var(--${prefix}-spacing-unit-6)`,
-    "unit-7": `var(--${prefix}-spacing-unit-7)`,
-    "unit-8": `var(--${prefix}-spacing-unit-8)`,
-    "unit-9": `var(--${prefix}-spacing-unit-9)`,
-    "unit-10": `var(--${prefix}-spacing-unit-10)`,
-    "unit-11": `var(--${prefix}-spacing-unit-11)`,
-    "unit-12": `var(--${prefix}-spacing-unit-12)`,
-    "unit-16": `var(--${prefix}-spacing-unit-16)`,
-    "unit-20": `var(--${prefix}-spacing-unit-20)`,
-    "unit-24": `var(--${prefix}-spacing-unit-24)`,
-  };
 
   return plugin(
     ({addBase, addUtilities, addVariant}) => {
@@ -216,16 +185,6 @@ const corePlugin = (
           },
           width: {
             divider: `var(--${prefix}-divider-weight)`,
-          },
-          spacing: {
-            unit: `var(--${prefix}-spacing-unit)`,
-            ...createSpacingUnits(prefix),
-          },
-          minWidth: {
-            ...minSizes,
-          },
-          minHeight: {
-            ...minSizes,
           },
           fontSize: {
             tiny: [`var(--${prefix}-font-size-tiny)`, `var(--${prefix}-line-height-tiny)`],

--- a/packages/core/theme/src/types.ts
+++ b/packages/core/theme/src/types.ts
@@ -12,70 +12,7 @@ export type FontThemeUnit = BaseThemeUnit & {
   tiny?: string;
 };
 
-export const spacingScaleKeys = [
-  "0",
-  "xs",
-  "sm",
-  "md",
-  "lg",
-  "xl",
-  "2xl",
-  "3xl",
-  "4xl",
-  "5xl",
-  "6xl",
-  "7xl",
-  "8xl",
-  "9xl",
-  "1",
-  "2",
-  "3",
-  "3.5",
-  "4",
-  "5",
-  "6",
-  "7",
-  "8",
-  "9",
-  "10",
-  "11",
-  "12",
-  "13",
-  "14",
-  "15",
-  "16",
-  "17",
-  "18",
-  "20",
-  "24",
-  "28",
-  "32",
-  "36",
-  "40",
-  "44",
-  "48",
-  "52",
-  "56",
-  "60",
-  "64",
-  "72",
-  "80",
-  "96",
-];
-
-export const mappedSpacingScaleKeys = spacingScaleKeys.map((key) => `unit-${key}`);
-
-export type SpacingScaleKeys = (typeof spacingScaleKeys)[number];
-
-export type SpacingScale = Partial<Record<SpacingScaleKeys, string>>;
-
 export interface LayoutTheme {
-  /**
-   * Base unit token that defines a consistent spacing scale across the components.
-   *
-   * @default 4 (px)
-   */
-  spacingUnit?: number;
   /**
    * The default font size applied across the components.
    *

--- a/packages/core/theme/src/utils/theme.ts
+++ b/packages/core/theme/src/utils/theme.ts
@@ -1,5 +1,3 @@
-import {spacingScaleKeys, SpacingScaleKeys, SpacingScale} from "../types";
-
 /**
  * Determines if the theme is a base theme
  *
@@ -7,73 +5,3 @@ import {spacingScaleKeys, SpacingScaleKeys, SpacingScale} from "../types";
  * @returns "light" | "dark
  */
 export const isBaseTheme = (theme: string) => theme === "light" || theme === "dark";
-
-const ROOT_FONT_SIZE = 16;
-const baseScale = [1, 2, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
-const extendedScale = [20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96];
-
-export const generateSpacingScale = (spacingUnit: number) => {
-  const scaleLabels: Partial<Record<SpacingScaleKeys, number>> = {
-    xs: 2,
-    sm: 3,
-    md: 4,
-    lg: 5.5,
-    xl: 9,
-    "2xl": 12,
-    "3xl": 20,
-    "4xl": 30,
-    "5xl": 56,
-    "6xl": 72,
-    "7xl": 96,
-    "8xl": 128,
-    "9xl": 160,
-  };
-
-  const scale = {0: "0px"} as SpacingScale;
-
-  Object.entries(scaleLabels).forEach(([label, multiplier]) => {
-    scale[label as SpacingScaleKeys] = multiplier
-      ? `${(spacingUnit * multiplier) / ROOT_FONT_SIZE}rem`
-      : `${spacingUnit / ROOT_FONT_SIZE}rem`;
-  });
-
-  baseScale.forEach((i) => {
-    let key = `${i}` as SpacingScaleKeys;
-
-    // if the key has decimal e.g 3.5 change it to "3-5" format
-    if (key.includes(".")) {
-      const [first, second] = key.split(".");
-
-      key = `${first}_${second}`;
-    }
-
-    scale[key] = `${(spacingUnit * i) / ROOT_FONT_SIZE}rem`;
-  });
-
-  extendedScale.forEach((i) => {
-    const key = `${i}` as SpacingScaleKeys;
-
-    scale[key] = `${(spacingUnit * i) / ROOT_FONT_SIZE}rem`;
-  });
-
-  return scale;
-};
-
-export function createSpacingUnits(prefix: string) {
-  let result = spacingScaleKeys.reduce((acc, key) => {
-    let value = `var(--${prefix}-spacing-unit-${key})`;
-
-    if (key.includes(".")) {
-      const [first, second] = key.split(".");
-
-      value = `var(--${prefix}-spacing-unit-${first}_${second})`;
-    }
-
-    return {
-      ...acc,
-      [`unit-${key}`]: value,
-    };
-  }, {});
-
-  return result as Record<SpacingScaleKeys, string>;
-}

--- a/packages/core/theme/src/utils/tv.ts
+++ b/packages/core/theme/src/utils/tv.ts
@@ -1,6 +1,5 @@
 import {tv as tvBase, TV} from "tailwind-variants";
 
-import {mappedSpacingScaleKeys} from "../types";
 const COMMON_UNITS = ["small", "medium", "large"];
 
 export const tv: TV = (options, config) =>
@@ -12,7 +11,7 @@ export const tv: TV = (options, config) =>
       theme: {
         ...config?.twMergeConfig?.theme,
         opacity: ["disabled"],
-        spacing: ["divider", "unit", ...mappedSpacingScaleKeys],
+        spacing: ["divider"],
         borderWidth: COMMON_UNITS,
         borderRadius: COMMON_UNITS,
       },
@@ -21,16 +20,6 @@ export const tv: TV = (options, config) =>
         shadow: [{shadow: COMMON_UNITS}],
         "font-size": [{text: ["tiny", ...COMMON_UNITS]}],
         "bg-image": ["bg-stripe-gradient"],
-        "min-w": [
-          {
-            "min-w": ["unit", ...mappedSpacingScaleKeys],
-          },
-        ],
-        "min-h": [
-          {
-            "min-h": ["unit", ...mappedSpacingScaleKeys],
-          },
-        ],
       },
     },
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,8 +499,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.4(react@18.2.0)
       tailwind-variants:
-        specifier: ^0.1.18
-        version: 0.1.18(tailwindcss@3.4.3)
+        specifier: ^0.1.20
+        version: 0.1.20(tailwindcss@3.4.3)
       unified:
         specifier: ^9.2.2
         version: 9.2.2
@@ -3012,8 +3012,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       tailwind-variants:
-        specifier: ^0.1.18
-        version: 0.1.18(tailwindcss@3.4.3)
+        specifier: ^0.1.20
+        version: 0.1.20(tailwindcss@3.4.3)
 
   packages/core/theme:
     dependencies:
@@ -3045,8 +3045,8 @@ importers:
         specifier: ^4.5.0
         version: 4.5.0
       tailwind-variants:
-        specifier: ^0.1.18
-        version: 0.1.18(tailwindcss@3.4.3)
+        specifier: ^0.1.20
+        version: 0.1.20(tailwindcss@3.4.3)
     devDependencies:
       '@types/color':
         specifier: ^3.0.3
@@ -5902,6 +5902,10 @@ packages:
     peerDependencies:
       '@effect-ts/otel-node': '*'
     peerDependenciesMeta:
+      '@effect-ts/core':
+        optional: true
+      '@effect-ts/otel':
+        optional: true
       '@effect-ts/otel-node':
         optional: true
     dependencies:
@@ -22486,6 +22490,9 @@ packages:
     resolution: {integrity: sha512-wRvsK9v12Nt2/EIjLp/uvxd3UeRSN9DRoSofDn21Ot+rEw4e98ODvbdSHi6dYr82s4oo6mF823ACmOp1hXd4wg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.10.2(@parcel/core@2.10.2)(typescript@4.9.5)
       '@parcel/core': 2.10.2
@@ -25446,8 +25453,8 @@ packages:
   /tailwind-merge@1.14.0:
     resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
 
-  /tailwind-variants@0.1.18(tailwindcss@3.4.3):
-    resolution: {integrity: sha512-yoydMYm3FbZRw7wak+E2sqwYv2Uo3YWRqVZR03DGqDGm0ytzDrEnWO/Q/GMHdhaz8adOvycKw/bwCgQFCfmfhg==}
+  /tailwind-variants@0.1.20(tailwindcss@3.4.3):
+    resolution: {integrity: sha512-AMh7x313t/V+eTySKB0Dal08RHY7ggYK0MSn/ad8wKWOrDUIzyiWNayRUm2PIJ4VRkvRnfNuyRuKbLV3EN+ewQ==}
     engines: {node: '>=16.x', pnpm: '>=7.x'}
     peerDependencies:
       tailwindcss: '*'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Units variables were removed in favour of TailwindCSS' `min-h` `max-h` new units

https://tailwindcss.com/blog/tailwindcss-v3-4
https://tailwindcss.com/docs/min-width
https://tailwindcss.com/docs/min-height

## ⛳️ Current behavior (updates)

```jsx
import {Button} from "@nextui-org/react";

export const MyButton = () => {
  return (
    <Button className="px-unit-2 py-unit-1 min-w-unit-3xl">
      My Button
    </Button>
  );
}
```

## 🚀 New behavior

```jsx
import {Button} from "@nextui-org/react";

export const MyButton = () => {
  return (
    <Button className="px-2 py-1 min-w-3xl">
      My Button
    </Button>
  );
}
```

## 💣 Is this a breaking change (Yes/No): Yes

Replace `-unit-` by `-`

```diff
- <Button className="px-unit-2 py-unit-1 min-w-unit-3xl">
+ <Button className="px-2 py-1 min-w-3xl"> 
```


## 📝 Additional Information
