### PR TITLE
fix(autocomplete): incorrect prop name in getEmptyPopoverProps

### DIFF
--- a/.changeset/six-seas-shout.md
+++ b/.changeset/six-seas-shout.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Fixed incorrect prop name in getEmptyPopoverProps (#2715)

--- a/.changeset/six-seas-shout.md
+++ b/.changeset/six-seas-shout.md
@@ -2,4 +2,4 @@
 "@nextui-org/autocomplete": patch
 ---
 
-Fixed incorrect prop name in getEmptyPopoverProps (#2715)
+Fixes incorrect prop name in getEmptyPopoverProps (#2715)

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -404,7 +404,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     // avoid null node in `ariaHideOutside` from `@react-aria/overlays`
     return {
       ref: popoverRef,
-      classNames: "hidden",
+      className: "hidden",
     };
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2715

## 📝 Description

classNames -> className

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed an incorrect property name in the autocomplete functionality to enhance consistency and performance.
	- Patched the "@nextui-org/autocomplete" package to address an issue with a prop name in the getEmptyPopoverProps function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->