### PR TITLE
fix(cmdk): Add min width to cmdk menu eng 588

### DIFF
--- a/apps/docs/components/cmdk.tsx
+++ b/apps/docs/components/cmdk.tsx
@@ -15,6 +15,7 @@ import {isAppleDevice, isWebKit} from "@react-aria/utils";
 import {create} from "zustand";
 import {intersectionBy, isEmpty} from "lodash";
 import {writeStorage, useLocalStorage} from "@rehooks/local-storage";
+import {useMediaQuery} from "usehooks-ts";
 
 import {
   DocumentCodeBoldIcon,
@@ -136,6 +137,8 @@ export const Cmdk: FC<{}> = () => {
   const eventRef = useRef<"mouse" | "keyboard">();
   const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+
+  const isMobile = useMediaQuery("(max-width: 650px)");
 
   const {isOpen, onClose, onOpen} = useCmdkStore();
 
@@ -369,7 +372,7 @@ export const Cmdk: FC<{}> = () => {
       backdrop="opaque"
       classNames={{
         base: [
-          "w-[580px]",
+          isMobile ? "w-[320px]" : "w-[580px]",
           "mt-[20vh]",
           "border-small",
           "dark:border-default-100",

--- a/apps/docs/components/cmdk.tsx
+++ b/apps/docs/components/cmdk.tsx
@@ -86,7 +86,7 @@ const cmdk = tv({
       "data-[active=true]:bg-primary",
       "data-[active=true]:text-primary-foreground",
     ],
-    leftWrapper: ["flex", "gap-3", "items-center", "w-full", "max-w-full", "min-w-[500px]"],
+    leftWrapper: ["flex", "gap-3", "items-center", "w-full", "max-w-full"],
     leftIcon: [
       "text-default-500 dark:text-default-300",
       "group-data-[active=true]:text-primary-foreground",
@@ -369,6 +369,7 @@ export const Cmdk: FC<{}> = () => {
       backdrop="opaque"
       classNames={{
         base: [
+          "w-[580px]",
           "mt-[20vh]",
           "border-small",
           "dark:border-default-100",

--- a/apps/docs/components/cmdk.tsx
+++ b/apps/docs/components/cmdk.tsx
@@ -86,7 +86,7 @@ const cmdk = tv({
       "data-[active=true]:bg-primary",
       "data-[active=true]:text-primary-foreground",
     ],
-    leftWrapper: ["flex", "gap-3", "items-center", "w-full", "max-w-full"],
+    leftWrapper: ["flex", "gap-3", "items-center", "w-full", "max-w-full", "min-w-[500px]"],
     leftIcon: [
       "text-default-500 dark:text-default-300",
       "group-data-[active=true]:text-primary-foreground",


### PR DESCRIPTION
Closes #

## 📝 Description

Add min-width to cmdk menu.

## ⛳️ Current behavior (updates)

The cmdk menu looks smaller than it should when searching some items

## 🚀 New behavior

Added min-width to cmdk menu so that it won't be shrunk.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


https://github.com/nextui-org/nextui/assets/62743644/99dfdff8-dadc-421a-8783-55851a70feba




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of components by adjusting widths for screens narrower than 650px.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->