### PR TITLE
fix(components): Fix 'Tap to click' behavior on macOS for Accordion, Tab, and Dropdown

### DIFF
--- a/packages/components/accordion/src/use-accordion-item.ts
+++ b/packages/components/accordion/src/use-accordion-item.ts
@@ -170,8 +170,9 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
         otherProps.onBlur,
         item.props?.onBlur,
       ),
-      ...mergeProps(buttonProps, hoverProps, pressProps, props),
-      onClick: chain(pressProps.onClick, onClick),
+      ...mergeProps(buttonProps, hoverProps, pressProps, props, {
+        onClick: chain(pressProps.onClick, onClick),
+      }),
     };
   };
 

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -125,6 +125,7 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
         enabled: shouldFilterDOMProps,
       }),
       props,
+      {onClick: chain(pressProps.onClick, onClick)},
     ),
     "data-focus": dataAttr(isFocused),
     "data-selectable": dataAttr(isSelectable),
@@ -134,7 +135,6 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
     "data-pressed": dataAttr(isPressed),
     "data-focus-visible": dataAttr(isFocusVisible),
     className: slots.base({class: clsx(baseStyles, props.className)}),
-    onClick: chain(pressProps.onClick, onClick),
   });
 
   const getLabelProps: PropGetter = (props = {}) => ({

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -111,11 +111,11 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
           enabled: shouldFilterDOMProps,
           omitPropNames: new Set(["title"]),
         }),
+        {onClick: handleClick},
       )}
       className={slots.tab?.({class: tabStyles})}
       title={otherProps?.titleValue}
       type={Component === "button" ? "button" : undefined}
-      onClick={handleClick}
     >
       {isSelected && !disableAnimation && !disableCursorAnimation && isMounted ? (
         <LazyMotion features={domMax}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1538

## 📝 Description

A few components (accordion, tabs, and dropdown menu) don't seem to register a click when the user taps on them with the trackpad on macOS with the "Tap to click" option enabled. However, a full click on the trackpad will still trigger the correct event without any issues.

Solution: moving the `onClick` definition to the `mergeProps` section instead of leaving it outside fixes this issue while preserving all existing functionality.

## ⛳️ Current behavior (updates)

Here's a quick video showing what happens when tapping on the tabs on the [NextUI documentation page](https://nextui.org/docs/components/tabs). The tabs only update when I start fully clicking on the trackpad instead of tapping to click.

https://github.com/nextui-org/nextui/assets/13712381/97b8ba73-038b-43d9-a625-bd44c752e089

## 🚀 New behavior

Tapping on accordions, dropdown menu items, and tabs with the trackpad on macOS now works as expected. Here's a link to a Codesandbox with these changes: [codesandbox.io](https://codesandbox.io/p/github/ericfabreu/nextui/fix/macos_tap?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clv19wvyk00073p6ibvlmdgrj%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clv19wvyk00023p6inabc7qiv%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clv19wvyk00043p6iwi26wgem%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clv19wvyk00063p6id9anitd3%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clv19wvyk00023p6inabc7qiv%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clv19wvyk00013p6ir189kv8a%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252F.changeset%252Fdirty-beans-repair.md%2522%257D%255D%252C%2522id%2522%253A%2522clv19wvyk00023p6inabc7qiv%2522%252C%2522activeTabId%2522%253A%2522clv19wvyk00013p6ir189kv8a%2522%257D%252C%2522clv19wvyk00063p6id9anitd3%2522%253A%257B%2522id%2522%253A%2522clv19wvyk00063p6id9anitd3%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clv19wvyk00053p6ixkj86iqi%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A6006%252C%2522path%2522%253A%2522%252F%253Fpath%253D%252Fstory%252Fcomponents-accordion--default%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clv19wvyk00053p6ixkj86iqi%2522%257D%252C%2522clv19wvyk00043p6iwi26wgem%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clv19wvyk00033p6igcc6obj3%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%255D%252C%2522id%2522%253A%2522clv19wvyk00043p6iwi26wgem%2522%252C%2522activeTabId%2522%253A%2522clv19wvyk00033p6igcc6obj3%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
