### PR TITLE
refactor: updated labelPlacement value in comment

### DIFF
--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -333,7 +333,6 @@ const select = tv({
       },
     },
     // underlined & color
-    // underlined & color
     {
       variant: "underlined",
       color: "default",
@@ -422,7 +421,7 @@ const select = tv({
         label: "text-danger",
       },
     },
-    // labelPlacement=outside & default
+    // labelPlacement=inside & default
     {
       labelPlacement: "inside",
       color: "default",


### PR DESCRIPTION
Closes #

## 📝 Description
Fixed the incorrect `labelPlacement` value in comment while trying to fix 2710. Also removed a duplicate comment.

## ⛳️ Current behavior (updates)
`// labelPlacement=outside & default`

## 🚀 New behavior
`// labelPlacement=inside & default`

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
