### PR TITLE
refactor: renamed variable `isOutsideLeft` in Select component

### DIFF
--- a/.changeset/famous-islands-drive.md
+++ b/.changeset/famous-islands-drive.md
@@ -2,4 +2,4 @@
 "@nextui-org/select": patch
 ---
 
-Renamed variable `isOutsideLeft` to `shouldLabelBeOutsideLeft` for consistentency
+Renamed variable `isOutsideLeft` to `shouldLabelBeOutsideLeft` for consistency

--- a/.changeset/famous-islands-drive.md
+++ b/.changeset/famous-islands-drive.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Renamed variable `isOutsideLeft` to `shouldLabelBeOutsideLeft` for consistentency

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -29,7 +29,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
     endContent,
     placeholder,
     renderValue,
-    isOutsideLeft,
+    shouldLabelBeOutsideLeft,
     disableAnimation,
     getBaseProps,
     getLabelProps,
@@ -123,10 +123,10 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   return (
     <div {...getBaseProps()}>
       <HiddenSelect {...getHiddenSelectProps()} />
-      {isOutsideLeft ? labelContent : null}
+      {shouldLabelBeOutsideLeft ? labelContent : null}
       <div {...getMainWrapperProps()}>
         <Component {...getTriggerProps()}>
-          {!isOutsideLeft ? labelContent : null}
+          {!shouldLabelBeOutsideLeft ? labelContent : null}
           <div {...getInnerWrapperProps()}>
             {startContent}
             <span {...getValueProps()}>

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -297,7 +297,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     labelPlacement === "outside-left" ||
     (labelPlacement === "outside" && (hasPlaceholder || !!originalProps.isMultiline));
   const shouldLabelBeInside = labelPlacement === "inside";
-  const isOutsideLeft = labelPlacement === "outside-left";
+  const shouldLabelBeOutsideLeft = labelPlacement === "outside-left";
 
   const isFilled =
     state.isOpen ||
@@ -635,8 +635,8 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     renderValue,
     selectionMode,
     disableAnimation,
-    isOutsideLeft,
     shouldLabelBeOutside,
+    shouldLabelBeOutsideLeft,
     shouldLabelBeInside,
     isInvalid,
     errorMessage,


### PR DESCRIPTION
Closes #

## 📝 Description
Currently the variable name is `isOutsideLeft`, it is a bit inconsistent when compared with `shouldLabelBeOutside` and `shouldLabelBeInside` and it does not indicate what(**_Label_**) is outside left.

## ⛳️ Current behavior (updates)
`isOutsideLeft`

## 🚀 New behavior
`shouldLabelBeOutsideLeft`

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
