### PR TITLE
refactor: renamed variable `isOutsideLeft` in Input component

### DIFF
--- a/.changeset/lazy-kangaroos-arrive.md
+++ b/.changeset/lazy-kangaroos-arrive.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Renamed variable `isOutsideLeft` to `shouldLabelBeOutsideLeft` for consistency

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -16,8 +16,8 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
     endContent,
     labelPlacement,
     hasHelper,
-    isOutsideLeft,
     shouldLabelBeOutside,
+    shouldLabelBeOutsideLeft,
     errorMessage,
     isInvalid,
     getBaseProps,
@@ -87,7 +87,7 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
       return (
         <div {...getMainWrapperProps()}>
           <div {...getInputWrapperProps()}>
-            {!isOutsideLeft ? labelContent : null}
+            {!shouldLabelBeOutsideLeft ? labelContent : null}
             {innerWrapper}
           </div>
           {helperWrapper}
@@ -120,7 +120,7 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      {isOutsideLeft ? labelContent : null}
+      {shouldLabelBeOutsideLeft ? labelContent : null}
       {mainWrapper}
     </Component>
   );

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -211,7 +211,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     ? (!domRef.current.value || domRef.current.value === "" || !inputValue || inputValue === "") &&
       hasPlaceholder
     : false;
-  const isOutsideLeft = labelPlacement === "outside-left";
+  const shouldLabelBeOutsideLeft = labelPlacement === "outside-left";
 
   const hasStartContent = !!startContent;
   const isLabelOutside = shouldLabelBeOutside
@@ -464,9 +464,9 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     hasHelper,
     hasStartContent,
     isLabelOutside,
-    isOutsideLeft,
     isLabelOutsideAsPlaceholder,
     shouldLabelBeOutside,
+    shouldLabelBeOutsideLeft,
     shouldLabelBeInside,
     hasPlaceholder,
     isInvalid,


### PR DESCRIPTION
Closes #

## 📝 Description
Currently the variable name is `isOutsideLeft`, it is a bit inconsistent when compared with `shouldLabelBeOutside `and `shouldLabelBeInside `and it does not indicate what(_**Label**_) is outside left.

## ⛳️ Current behavior (updates)
`isOutsideLeft`

## 🚀 New behavior
`shouldLabelBeOutsideLeft`

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information
