### PR TITLE
fix(date-picker): invalid and disabled props removed

### DIFF
--- a/.changeset/red-jobs-rest.md
+++ b/.changeset/red-jobs-rest.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-picker": patch
+---
+
+Static props removed from date range input picker field

--- a/packages/components/date-picker/src/date-range-picker-field.tsx
+++ b/packages/components/date-picker/src/date-range-picker-field.tsx
@@ -44,8 +44,6 @@ function DateRangePickerField<T extends DateValue>(
   let state = useDateFieldState({
     ...otherProps,
     locale,
-    isInvalid: true,
-    isDisabled: true,
     validationBehavior: "native",
     createCalendar:
       !createCalendarProp || typeof createCalendarProp !== "function"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

The DateRangePicker input is currenly always disabled/readonly 

## ⛳️ Current behavior (updates)

The DateRangePicker input is currenly always disabled/readonly 

## 🚀 New behavior

Static props removed from DateRange Field

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
