### PR TITLE
fix(popover): isDisabled prop on a DOM element

### DIFF
--- a/.changeset/hot-paws-smell.md
+++ b/.changeset/hot-paws-smell.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/popover": patch
+---
+
+Fixes isDisabled prop on a DOM element

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -109,6 +109,7 @@ describe("Dropdown", () => {
               items={section.children}
               title={section.title}
             >
+              {/* @ts-ignore */}
               {(item: any) => <DropdownItem key={item.key}>{item.name}</DropdownItem>}
             </DropdownSection>
           )}

--- a/packages/components/dropdown/stories/dropdown.stories.tsx
+++ b/packages/components/dropdown/stories/dropdown.stories.tsx
@@ -137,7 +137,7 @@ const Template = ({color, variant, ...args}: DropdownProps & DropdownMenuProps) 
     <DropdownTrigger>
       <Button>Trigger</Button>
     </DropdownTrigger>
-    <DropdownMenu aria-label="Actions" color={color} variant={variant} onAction={alert}>
+    <DropdownMenu aria-label="Actions" color={color} variant={variant}>
       <DropdownItem key="new">New file</DropdownItem>
       <DropdownItem key="copy">Copy link</DropdownItem>
       <DropdownItem key="edit">Edit file</DropdownItem>

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -1,6 +1,6 @@
 import React, {Children, cloneElement, useMemo} from "react";
 import {forwardRef, isNextUIEl} from "@nextui-org/system";
-import {pickChildren} from "@nextui-org/react-utils";
+import {filterDOMProps, pickChildren} from "@nextui-org/react-utils";
 import {useAriaButton} from "@nextui-org/use-aria-button";
 import {Button} from "@nextui-org/button";
 import {mergeProps} from "@react-aria/utils";
@@ -42,14 +42,16 @@ const PopoverTrigger = forwardRef<"button", PopoverTriggerProps>((props, _) => {
     return triggerChildren?.[0] !== undefined;
   }, [triggerChildren]);
 
-  const isNextUIElement = isNextUIEl(child);
-
-  // `isDisabled` is added in `getMenuTriggerProps()` in `use-dropdown.ts`.
-  // if we include `isDisabled` prop in a DOM element, react will fail to recognize it on a DOM element.
-  // hence, apply filterDOMProps for such case
-  if (!isNextUIElement) delete restProps["isDisabled"];
-
-  return cloneElement(child, mergeProps(restProps, hasNextUIButton ? {onPress} : buttonProps));
+  return cloneElement(
+    child,
+    mergeProps(
+      restProps,
+      filterDOMProps(restProps, {
+        enabled: !isNextUIEl(child),
+      }),
+      hasNextUIButton ? {onPress} : buttonProps,
+    ),
+  );
 });
 
 PopoverTrigger.displayName = "NextUI.PopoverTrigger";

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -45,7 +45,6 @@ const PopoverTrigger = forwardRef<"button", PopoverTriggerProps>((props, _) => {
   return cloneElement(
     child,
     mergeProps(
-      restProps,
       filterDOMProps(restProps, {
         enabled: !isNextUIEl(child),
       }),

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -1,6 +1,6 @@
 import React, {Children, cloneElement, useMemo} from "react";
 import {forwardRef, isNextUIEl} from "@nextui-org/system";
-import {pickChildren, filterDOMProps} from "@nextui-org/react-utils";
+import {pickChildren} from "@nextui-org/react-utils";
 import {useAriaButton} from "@nextui-org/use-aria-button";
 import {Button} from "@nextui-org/button";
 import {mergeProps} from "@react-aria/utils";
@@ -42,22 +42,14 @@ const PopoverTrigger = forwardRef<"button", PopoverTriggerProps>((props, _) => {
     return triggerChildren?.[0] !== undefined;
   }, [triggerChildren]);
 
-  const isDisabled = !!restProps?.isDisabled;
-
   const isNextUIElement = isNextUIEl(child);
 
-  return cloneElement(
-    child,
-    mergeProps(
-      // if we add `isDisabled` prop to DOM elements,
-      // react will fail to recognize it on a DOM element,
-      // hence, apply filterDOMProps for such case
-      filterDOMProps(restProps, {
-        enabled: isDisabled && !isNextUIElement,
-      }),
-      hasNextUIButton ? {onPress} : buttonProps,
-    ),
-  );
+  // `isDisabled` is added in `getMenuTriggerProps()` in `use-dropdown.ts`.
+  // if we include `isDisabled` prop in a DOM element, react will fail to recognize it on a DOM element.
+  // hence, apply filterDOMProps for such case
+  if (!isNextUIElement) delete restProps["isDisabled"];
+
+  return cloneElement(child, mergeProps(restProps, hasNextUIButton ? {onPress} : buttonProps));
 });
 
 PopoverTrigger.displayName = "NextUI.PopoverTrigger";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2474

## 📝 Description

Reported from [here](https://github.com/nextui-org/nextui/issues/2626#issuecomment-2059431947).

`isDisabled` prop is introduced in `getMenuTriggerProps()` in `use-dropdown.ts`. If `DropdownTrigger` is a DOM element and `isDisabled` is `false`, it will cause that error. 

- P.S. `isDisabled` prop is always here
- P.S.S if `isDisabled` is not specified, then the value will be `false`.

Example

```tsx
const Template = ({color, variant, ...args}: DropdownProps & DropdownMenuProps) => (
  <Dropdown {...args}>
    <DropdownTrigger data-test="Test">foo</DropdownTrigger>
    <DropdownMenu aria-label="Actions" color={color} variant={variant} onAction={alert}>
      <DropdownItem key="new">New file</DropdownItem>
      <DropdownItem key="copy">Copy link</DropdownItem>
      <DropdownItem key="edit">Edit file</DropdownItem>
      <DropdownItem key="delete" className="text-danger" color="danger">
        Delete file
      </DropdownItem>
    </DropdownMenu>
  </Dropdown>
);

```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Improved handling of the `isDisabled` property for elements in the popover component to ensure proper functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->