### PR TITLE
fix(table): add empty content only when table size is 0 #2742

### DIFF
--- a/.changeset/lazy-pears-turn.md
+++ b/.changeset/lazy-pears-turn.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": patch
+---
+
+Fixes adding of empty content at the bottom of the table when rows present in Table (#2742)

--- a/packages/components/table/src/table-body.tsx
+++ b/packages/components/table/src/table-body.tsx
@@ -121,7 +121,9 @@ const TableBody = forwardRef<"tbody", TableBodyProps>((props, ref) => {
         >
           {bodyProps.loadingContent}
         </td>
-        {!emptyContent && <td className={slots?.emptyWrapper({class: classNames?.emptyWrapper})} />}
+        {!emptyContent && collection.size === 0 ? (
+          <td className={slots?.emptyWrapper({class: classNames?.emptyWrapper})} />
+        ) : null}
       </tr>
     );
   }


### PR DESCRIPTION
Closes #2742 

## 📝 Description
When using the Table component and `isLoading` is set to `true` on the `TableBody` and there are already rows present, empty content is being added to the end of the table

## ⛳️ Current behavior (updates)
![image](https://github.com/nextui-org/nextui/assets/8769408/70a8fc2c-f898-4abd-9bd0-9c5b355b202c)

## 🚀 New behavior
![image](https://github.com/nextui-org/nextui/assets/8769408/2c1be96e-b9c2-43be-a309-8dfe3b08bde2)


## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced the table display to conditionally show a specific element when there are no items in the collection.
    - Fixed the issue of adding empty content at the bottom of the table when rows are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->