### PR TITLE
fix(radio): omit non-react props on radio-group

### DIFF
--- a/.changeset/twelve-gorillas-stare.md
+++ b/.changeset/twelve-gorillas-stare.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/radio": patch
+---
+
+Fix #2759 non-react props omitted from radio group component

--- a/packages/components/radio/src/use-radio-group.ts
+++ b/packages/components/radio/src/use-radio-group.ts
@@ -8,7 +8,7 @@ import {useCallback, useMemo} from "react";
 import {RadioGroupState, useRadioGroupState} from "@react-stately/radio";
 import {useRadioGroup as useReactAriaRadioGroup} from "@react-aria/radio";
 import {HTMLNextUIProps, PropGetter} from "@nextui-org/system";
-import {useDOMRef} from "@nextui-org/react-utils";
+import {filterDOMProps, useDOMRef} from "@nextui-org/react-utils";
 import {clsx, safeAriaLabel} from "@nextui-org/shared-utils";
 import {mergeProps} from "@react-aria/utils";
 
@@ -70,6 +70,8 @@ export function useRadioGroup(props: UseRadioGroupProps) {
     label,
     value,
     name,
+    isInvalid: isInvalidProp,
+    validationState,
     size = "md",
     color = "primary",
     isDisabled = false,
@@ -86,6 +88,7 @@ export function useRadioGroup(props: UseRadioGroupProps) {
   } = props;
 
   const Component = as || "div";
+  const shouldFilterDOMProps = typeof Component === "string";
 
   const domRef = useDOMRef(ref);
 
@@ -97,7 +100,7 @@ export function useRadioGroup(props: UseRadioGroupProps) {
       "aria-label": safeAriaLabel(otherProps["aria-label"], label),
       isRequired,
       isReadOnly,
-      isInvalid: props.validationState === "invalid" || props.isInvalid,
+      isInvalid: validationState === "invalid" || isInvalidProp,
       orientation,
       validationBehavior: "native",
       onChange: onValueChange,
@@ -109,8 +112,8 @@ export function useRadioGroup(props: UseRadioGroupProps) {
     label,
     isRequired,
     isReadOnly,
-    props.isInvalid,
-    props.validationState,
+    isInvalidProp,
+    validationState,
     orientation,
     onValueChange,
   ]);
@@ -127,7 +130,7 @@ export function useRadioGroup(props: UseRadioGroupProps) {
     validationDetails,
   } = useReactAriaRadioGroup(otherPropsWithOrientation, groupState);
 
-  const isInvalid = props.validationState === "invalid" || props.isInvalid || isAriaInvalid;
+  const isInvalid = otherPropsWithOrientation.isInvalid || isAriaInvalid;
 
   const context: ContextType = useMemo(
     () => ({
@@ -168,7 +171,12 @@ export function useRadioGroup(props: UseRadioGroupProps) {
     return {
       ref: domRef,
       className: slots.base({class: baseStyles}),
-      ...mergeProps(groupProps, otherProps),
+      ...mergeProps(
+        groupProps,
+        filterDOMProps(otherProps, {
+          enabled: shouldFilterDOMProps,
+        }),
+      ),
     };
   }, [domRef, slots, baseStyles, groupProps, otherProps]);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2759

## 📝 Description

Non-react props omitted from being passed to the RadioGroup component

## ⛳️ Current behavior (updates)

`isInvalid` warning since it is not a HTML prop

## 🚀 New behavior

`isInvalid` prop extracted from the original props, `otherProps` filtered to a void passing more non-react props to the component

## 💣 Is this a breaking change (Yes/No): Bo

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the radio group component to include all relevant properties, improving consistency and validation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->