### PR TITLE
Fix: onPress Event Handling for DropdownItem

### DIFF
--- a/packages/components/dropdown/stories/dropdown.stories.tsx
+++ b/packages/components/dropdown/stories/dropdown.stories.tsx
@@ -137,8 +137,26 @@ const Template = ({color, variant, ...args}: DropdownProps & DropdownMenuProps) 
     <DropdownTrigger>
       <Button>Trigger</Button>
     </DropdownTrigger>
-    <DropdownMenu aria-label="Actions" color={color} variant={variant} onAction={alert}>
-      <DropdownItem key="new">New file</DropdownItem>
+    <DropdownMenu
+      aria-label="Actions"
+      color={color}
+      variant={variant}
+      // eslint-disable-next-line no-console
+      onAction={() => console.log("onAction")}
+    >
+      <DropdownItem
+        key="new"
+        // eslint-disable-next-line no-console
+        onPress={() => console.log("onPress new file")}
+        // eslint-disable-next-line no-console
+        onPressEnd={() => console.log("onPressEnd new file")}
+        // eslint-disable-next-line no-console
+        onPressStart={() => console.log("onPressStart new file")}
+        // eslint-disable-next-line no-console
+        onPressUp={() => console.log("onPressUp new file")}
+      >
+        New file
+      </DropdownItem>
       <DropdownItem key="copy">Copy link</DropdownItem>
       <DropdownItem key="edit">Edit file</DropdownItem>
       <DropdownItem key="delete" className="text-danger" color="danger">

--- a/packages/components/dropdown/stories/dropdown.stories.tsx
+++ b/packages/components/dropdown/stories/dropdown.stories.tsx
@@ -149,6 +149,8 @@ const Template = ({color, variant, ...args}: DropdownProps & DropdownMenuProps) 
         // eslint-disable-next-line no-console
         onPress={() => console.log("onPress new file")}
         // eslint-disable-next-line no-console
+        onPressChange={() => console.log("onPressChange new file")}
+        // eslint-disable-next-line no-console
         onPressEnd={() => console.log("onPressEnd new file")}
         // eslint-disable-next-line no-console
         onPressStart={() => console.log("onPressStart new file")}

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -9,7 +9,7 @@ import {filterDOMProps} from "@nextui-org/react-utils";
 import {TreeState} from "@react-stately/tree";
 import {clsx, dataAttr, objectToDeps, removeEvents} from "@nextui-org/shared-utils";
 import {useMenuItem as useAriaMenuItem} from "@react-aria/menu";
-import {chain, mergeProps} from "@react-aria/utils";
+import {mergeProps} from "@react-aria/utils";
 import {useHover, usePress} from "@react-aria/interactions";
 import {useIsMobile} from "@nextui-org/use-is-mobile";
 
@@ -39,7 +39,10 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
     onAction,
     autoFocus,
     onPress,
-    onClick,
+    onPressStart,
+    onPressUp,
+    onPressEnd,
+    onPressChange,
     hideSelectedIcon = false,
     isReadOnly = false,
     closeOnSelect,
@@ -63,8 +66,12 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
 
   const {pressProps, isPressed} = usePress({
     ref: domRef,
-    isDisabled: isDisabled,
+    isDisabled,
+    onPressStart,
     onPress,
+    onPressUp,
+    onPressEnd,
+    onPressChange,
   });
 
   const {isHovered, hoverProps} = useHover({
@@ -133,7 +140,6 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
     "data-pressed": dataAttr(isPressed),
     "data-focus-visible": dataAttr(isFocusVisible),
     className: slots.base({class: clsx(baseStyles, props.className)}),
-    onClick: chain(pressProps.onClick, onClick),
   });
 
   const getLabelProps: PropGetter = (props = {}) => ({

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -123,7 +123,6 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
     onPressUp,
     onPressEnd,
     onPressChange,
-
     isDisabled,
     ref: domRef,
   });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #2743
- Closes #2751

## 📝 Description

Fixed a bug that onPress was not called.
You can check it at the following link.
https://nextui-storybook-v2-79k1jdwm7-nextui-org.vercel.app/?path=/story/components-dropdown--default

https://github.com/nextui-org/nextui/assets/76232929/692dbf24-33d3-4532-89f9-8ce37d698f86

## ⛳️ Current behavior (updates)

`onPress` is not working.

## 🚀 New behavior

`onPress` is work.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced Dropdown Menu with multiple event handlers for better interaction feedback.
- **Refactor**
    - Updated Dropdown Menu components to handle press events more explicitly and efficiently.
- **Chores**
    - Cleaned up unnecessary code and imports in menu handling functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->