### PR TITLE
fix(popover): Dropdown/Popover open issue in production

### DIFF
--- a/.changeset/ninety-ways-look.md
+++ b/.changeset/ninety-ways-look.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/popover": patch
+---
+
+Adding a `ref` into popover trigger element, when using custom trigger for that

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -42,15 +42,15 @@ const PopoverTrigger = forwardRef<"button", PopoverTriggerProps>((props, _) => {
     return triggerChildren?.[0] !== undefined;
   }, [triggerChildren]);
 
-  return cloneElement(
-    child,
-    mergeProps(
+  return cloneElement(child, {
+    ref: triggerRef,
+    ...mergeProps(
       filterDOMProps(restProps, {
         enabled: !isNextUIEl(child),
       }),
-      hasNextUIButton ? {onPress, ref: triggerRef} : buttonProps,
+      hasNextUIButton ? {onPress} : buttonProps,
     ),
-  );
+  });
 });
 
 PopoverTrigger.displayName = "NextUI.PopoverTrigger";

--- a/packages/components/popover/src/popover-trigger.tsx
+++ b/packages/components/popover/src/popover-trigger.tsx
@@ -48,7 +48,7 @@ const PopoverTrigger = forwardRef<"button", PopoverTriggerProps>((props, _) => {
       filterDOMProps(restProps, {
         enabled: !isNextUIEl(child),
       }),
-      hasNextUIButton ? {onPress} : buttonProps,
+      hasNextUIButton ? {onPress, ref: triggerRef} : buttonProps,
     ),
   );
 });


### PR DESCRIPTION
- Closes #2768
- Closes #2775

## 📝 Description

In this PR, I solved the popover/dropdown open issue in production.

## ⛳️ Current behavior (updates)

>  Popover/Dropdown is not opening. (In fact, it's open but it's at the very bottom so it will not show)

## 🚀 New behavior

> It is working as expected

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Hi, 
Maintainer, Not sure exact flow for popover. But I do some console (in dev & prod). Getting that the ref is not passing to popover trigger, so it does not calculate the exact position of popover content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Enhanced `PopoverTrigger` component to seamlessly integrate with UI button features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->