### PR TITLE
fix(input): correct label margin for RTL required inputs

### DIFF
--- a/.changeset/shaggy-cooks-pay.md
+++ b/.changeset/shaggy-cooks-pay.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/autocomplete": patch
+"@nextui-org/input": patch
+---
+
+Fixed incorrect margin on labels for RTL required inputs.

--- a/.changeset/shaggy-cooks-pay.md
+++ b/.changeset/shaggy-cooks-pay.md
@@ -1,6 +1,0 @@
----
-"@nextui-org/autocomplete": patch
-"@nextui-org/input": patch
----
-
-Fixed incorrect margin on labels for RTL required inputs.

--- a/.changeset/witty-birds-watch.md
+++ b/.changeset/witty-birds-watch.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Fixed incorrect margin on labels for RTL required inputs. (#2780)

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -206,7 +206,8 @@ const input = tv({
     },
     isRequired: {
       true: {
-        label: "after:content-['*'] after:text-danger after:ml-0.5",
+        label:
+          "after:content-['*'] after:text-danger after:ml-0.5 rtl:after:ml-[unset] rtl:after:mr-0.5",
       },
     },
     isMultiline: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2780 

## 📝 Description

> This pull request fixes an issue where the Autocomplete, Textarea, and Input components do not display correctly under RTL configurations when the "required" property is used. The labels are not positioned correctly, which affects the layout.

## ⛳️ Current behavior (updates)

> Currently, in RTL layouts, when the "required" property is set for Autocomplete, Textarea, and Input components, the labels are misaligned. This results in an inconsistent appearance and can lead to a poor user experience.

## 🚀 New behavior

> With this update, the labels in the Autocomplete, Textarea, and Input components are correctly positioned in RTL configurations. This ensures the visual consistency across different text directions and improves the overall interface aesthetics.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

This fix enhances the usability and visual alignment of form elements in RTL layouts, ensuring that NextUI continues to provide a seamless experience for global users with diverse text direction needs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Enhanced visual alignment and consistency by fixing incorrect margin on labels for right-to-left (RTL) required inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->