### PR TITLE
fix(core): export * from not supported on client components

### DIFF
--- a/.changeset/sharp-planes-reply.md
+++ b/.changeset/sharp-planes-reply.md
@@ -6,4 +6,4 @@
 "@nextui-org/react-utils": patch
 ---
 
-Named exports implemented
+Fix #2749 Introduced named exports for several UI-related packages to enhance modularity and usability in Next.js projects.

--- a/.changeset/sharp-planes-reply.md
+++ b/.changeset/sharp-planes-reply.md
@@ -1,0 +1,9 @@
+---
+"@nextui-org/react": patch
+"@nextui-org/system": patch
+"@nextui-org/aria-utils": patch
+"@nextui-org/framer-utils": patch
+"@nextui-org/react-utils": patch
+---
+
+Named exports implemented

--- a/packages/core/react/tsup.config.ts
+++ b/packages/core/react/tsup.config.ts
@@ -5,5 +5,4 @@ export default defineConfig({
   target: "es2019",
   entry: ["src/index.ts", "!src/scripts"],
   format: ["cjs", "esm"],
-  banner: {js: '"use client";'},
 });

--- a/packages/core/system/src/index.ts
+++ b/packages/core/system/src/index.ts
@@ -1,6 +1,35 @@
-export * from "./provider";
-export * from "./provider-context";
+export type {
+  As,
+  DOMElement,
+  DOMElements,
+  CapitalizedDOMElements,
+  DOMAttributes,
+  OmitCommonProps,
+  RightJoinProps,
+  MergeWithAs,
+  InternalForwardRefRenderFunction,
+  PropsOf,
+  Merge,
+  HTMLNextUIProps,
+  PropGetter,
+  ExtendVariantProps,
+  ExtendVariantWithSlotsProps,
+  ExtendVariants,
+} from "@nextui-org/system-rsc";
 
-export * from "@nextui-org/system-rsc";
+export {
+  cn,
+  forwardRef,
+  toIterator,
+  mapPropsVariants,
+  mapPropsVariantsWithCommon,
+  isNextUIEl,
+  extendVariants,
+} from "@nextui-org/system-rsc";
 
 export type {SupportedCalendars} from "./types";
+export type {NextUIProviderProps} from "./provider";
+export type {ProviderContextProps} from "./provider-context";
+
+export {NextUIProvider} from "./provider";
+export {ProviderContext, useProviderContext} from "./provider-context";

--- a/packages/utilities/aria-utils/src/collections/index.ts
+++ b/packages/utilities/aria-utils/src/collections/index.ts
@@ -1,3 +1,7 @@
-export * from "./item";
-export * from "./section";
-export * from "./types";
+export type {ItemProps} from "./item";
+export {BaseItem} from "./item";
+
+export type {SectionProps} from "./section";
+export {BaseSection} from "./section";
+
+export type {CollectionProps, PartialNode} from "./types";

--- a/packages/utilities/aria-utils/src/index.ts
+++ b/packages/utilities/aria-utils/src/index.ts
@@ -1,4 +1,15 @@
-export * from "./collections";
-export * from "./utils";
-export * from "./type-utils";
-export * from "./overlays";
+export type {NodeWithProps} from "./type-utils";
+export type {ItemProps, SectionProps, CollectionProps, PartialNode} from "./collections";
+export type {OverlayPlacement, OverlayOptions} from "./overlays";
+
+export {BaseItem, BaseSection} from "./collections";
+export {isNonContiguousSelectionModifier, isCtrlKeyPressed} from "./utils";
+
+export {
+  ariaHideOutside,
+  getTransformOrigins,
+  toReactAriaPlacement,
+  toOverlayPlacement,
+  getShouldUseAxisPlacement,
+  getArrowPlacement,
+} from "./overlays";

--- a/packages/utilities/aria-utils/src/overlays/index.ts
+++ b/packages/utilities/aria-utils/src/overlays/index.ts
@@ -1,3 +1,11 @@
-export * from "./types";
-export * from "./utils";
-export * from "./ariaHideOutside";
+export type {OverlayPlacement, OverlayOptions} from "./types";
+
+export {
+  getTransformOrigins,
+  toReactAriaPlacement,
+  toOverlayPlacement,
+  getShouldUseAxisPlacement,
+  getArrowPlacement,
+} from "./utils";
+
+export {ariaHideOutside} from "./ariaHideOutside";

--- a/packages/utilities/framer-utils/src/index.ts
+++ b/packages/utilities/framer-utils/src/index.ts
@@ -1,2 +1,11 @@
-export * from "./transition-utils";
-export * from "./resizable-panel";
+export type {
+  TransitionConfig,
+  TransitionEndConfig,
+  TransitionProperties,
+  Variants,
+} from "./transition-utils";
+
+export {TRANSITION_EASINGS, TRANSITION_DEFAULTS, TRANSITION_VARIANTS} from "./transition-utils";
+
+export type {ResizablePanelProps} from "./resizable-panel";
+export {ResizablePanel} from "./resizable-panel";

--- a/packages/utilities/react-utils/src/index.ts
+++ b/packages/utilities/react-utils/src/index.ts
@@ -1,6 +1,28 @@
-export * from "./context";
-export * from "./refs";
-export * from "./dom";
-export * from "./dimensions";
+export type {CreateContextOptions, CreateContextReturn} from "./context";
+export {createContext} from "./context";
+
+export type {ReactRef} from "./refs";
+export {assignRef, mergeRefs} from "./refs";
+
+export type {UserAgentBrowser, UserAgentOS, ContextValue, UserAgentDeviceType} from "./dom";
+export {
+  isBrowser,
+  canUseDOM,
+  getUserAgentBrowser,
+  getUserAgentOS,
+  detectOS,
+  detectDeviceType,
+  detectBrowser,
+  detectTouch,
+  createDOMRef,
+  createFocusableRef,
+  useDOMRef,
+  useFocusableRef,
+  useSyncRef,
+  areRectsIntersecting,
+} from "./dom";
+
+export type {ShapeType} from "./dimensions";
+export {getCSSStyleVal, getRealShape} from "./dimensions";
 
 export * from "@nextui-org/react-rsc-utils";

--- a/packages/utilities/react-utils/src/index.ts
+++ b/packages/utilities/react-utils/src/index.ts
@@ -1,10 +1,10 @@
 export type {CreateContextOptions, CreateContextReturn} from "./context";
-export {createContext} from "./context";
-
 export type {ReactRef} from "./refs";
-export {assignRef, mergeRefs} from "./refs";
-
+export type {ShapeType} from "./dimensions";
 export type {UserAgentBrowser, UserAgentOS, ContextValue, UserAgentDeviceType} from "./dom";
+
+export {createContext} from "./context";
+export {assignRef, mergeRefs} from "./refs";
 export {
   isBrowser,
   canUseDOM,
@@ -22,7 +22,13 @@ export {
   areRectsIntersecting,
 } from "./dom";
 
-export type {ShapeType} from "./dimensions";
 export {getCSSStyleVal, getRealShape} from "./dimensions";
 
-export * from "@nextui-org/react-rsc-utils";
+export {
+  DOMPropNames,
+  DOMEventNames,
+  getValidChildren,
+  pickChildren,
+  renderFn,
+  filterDOMProps,
+} from "@nextui-org/react-rsc-utils";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2749

## 📝 Description

- **New Features**
	- Introduced named exports for several UI-related packages to enhance modularity and usability in Next.js projects.
- **Refactor**
	- Optimized and reorganized exports across various utility packages for clearer structure and improved accessibility of specific types and functions.
- **Chores**
	- Removed unnecessary configuration options in the build process to streamline development.
## ⛳️ Current behavior (updates)

 #2749

## 🚀 New behavior

`export * from` error should be fixed.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- end of auto-generated comment: release notes by coderabbit.ai -->