### PR TITLE
chore(docs): fix minor typo in `date-input` docs

### DIFF
--- a/apps/docs/content/components/date-input/description.ts
+++ b/apps/docs/content/components/date-input/description.ts
@@ -7,7 +7,7 @@ export default function App() {
       <DateInput 
         label={"Birth date"} 
         placeholderValue={new CalendarDate(1995, 11, 6)} 
-        description={"Thiis is my birth date."}
+        description={"This is my birth date."}
       />
     </div>
   );


### PR DESCRIPTION
## 📝 Description

This PR fixes a tiny typo in the `date-input` demo component (`Thiis` instead of `this`). 

That's it. That's the PR :)

## 💣 Is this a breaking change (Yes/No): nope 🤞🏻 

## 📝 Additional Information

Thank you for the library! Keep up the good work! 🚀 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the description of the `DateInput` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->