### PR TITLE
fix(input): clear feature fix #2791

### DIFF
--- a/.changeset/long-boxes-grin.md
+++ b/.changeset/long-boxes-grin.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fix #2791 input clear feature fix

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -156,7 +156,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       ...originalProps,
       validationBehavior: "native",
       autoCapitalize: originalProps.autoCapitalize as AutoCapitalize,
-      value: domRef?.current?.value ?? inputValue,
+      value: inputValue,
       "aria-label": safeAriaLabel(
         originalProps?.["aria-label"],
         originalProps?.label,


### PR DESCRIPTION
Closes #2791 

## 📝 Description
After entering the value in the input field, the `inputValue` was never set, as `domRef?.current?.value ??` always contains the typed value.

## ⛳️ Current behavior (updates)
`value: domRef?.current?.value ?? inputValue` 

![image](https://github.com/nextui-org/nextui/assets/8769408/67bfe407-2670-4aed-97df-4e408fbd05ea)

## 🚀 New behavior
`value: inputValue,`

![image](https://github.com/nextui-org/nextui/assets/8769408/14cbde1f-851c-4375-8c28-ba37140cd445)

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the input clear feature in the input component for enhanced user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->