### PR TITLE
fix(input): isClearable & add test cases to input

### DIFF
--- a/.changeset/gold-dolphins-fail.md
+++ b/.changeset/gold-dolphins-fail.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fixes isClearable function in input (#2791)

--- a/.changeset/gold-dolphins-fail.md
+++ b/.changeset/gold-dolphins-fail.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-Fixes isClearable function in input (#2791)
+Fixes the isClearable function in the input component (#2791)

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import {render} from "@testing-library/react";
+import {act, render} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import {Input} from "../src";
 
@@ -115,5 +116,33 @@ describe("Input", () => {
     container.querySelector("input")?.focus();
 
     expect(ref.current?.value)?.toBe(value);
+  });
+
+  it("should clear the value and onClear is triggered", async () => {
+    const onClear = jest.fn();
+
+    const ref = React.createRef<HTMLInputElement>();
+
+    const {container} = render(
+      <Input
+        ref={ref}
+        isClearable
+        defaultValue="junior@nextui.org"
+        label="test input"
+        onClear={onClear}
+      />,
+    );
+
+    const clearButton = container.querySelector("[data-slot='clear-button']") as HTMLElement;
+
+    expect(clearButton).not.toBeNull();
+
+    await act(async () => {
+      await userEvent.click(clearButton);
+    });
+
+    expect(ref.current?.value)?.toBe("");
+
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {act, render} from "@testing-library/react";
+import {render} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {Input} from "../src";
@@ -123,7 +123,7 @@ describe("Input", () => {
 
     const ref = React.createRef<HTMLInputElement>();
 
-    const {container} = render(
+    const {getByRole} = render(
       <Input
         ref={ref}
         isClearable
@@ -133,13 +133,13 @@ describe("Input", () => {
       />,
     );
 
-    const clearButton = container.querySelector("[data-slot='clear-button']") as HTMLElement;
+    const clearButton = getByRole("button");
 
     expect(clearButton).not.toBeNull();
 
-    await act(async () => {
-      await userEvent.click(clearButton);
-    });
+    const user = userEvent.setup();
+
+    await user.click(clearButton);
 
     expect(ref.current?.value)?.toBe("");
 

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -58,7 +58,8 @@
     "@nextui-org/system": "workspace:*",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-hook-form": "^7.51.3"
   },
   "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -43,6 +43,7 @@
     "@nextui-org/react-utils": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
     "@nextui-org/shared-utils": "workspace:*",
+    "@nextui-org/use-safe-layout-effect": "workspace:*",
     "@react-aria/focus": "^3.16.2",
     "@react-aria/interactions": "^3.21.1",
     "@react-aria/textfield": "^3.14.3",

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -2,6 +2,7 @@ import type {InputVariantProps, SlotsToClasses, InputSlots} from "@nextui-org/th
 import type {AriaTextFieldOptions} from "@react-aria/textfield";
 
 import {HTMLNextUIProps, mapPropsVariants, PropGetter} from "@nextui-org/system";
+import {useSafeLayoutEffect} from "@nextui-org/use-safe-layout-effect";
 import {AriaTextFieldProps} from "@react-types/textfield";
 import {useFocusRing} from "@react-aria/focus";
 import {input} from "@nextui-org/theme";
@@ -143,6 +144,15 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     domRef.current?.focus();
   }, [setInputValue, onClear]);
 
+  // if we use `react-hook-form`, it will set the input value using the ref in register
+  // i.e. setting ref.current.value to something which is uncontrolled
+  // hence, sync the state with `ref.current.value`
+  useSafeLayoutEffect(() => {
+    if (!domRef.current) return;
+
+    setInputValue(domRef.current.value);
+  }, [domRef.current]);
+
   const {
     labelProps,
     inputProps,
@@ -156,7 +166,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       ...originalProps,
       validationBehavior: "native",
       autoCapitalize: originalProps.autoCapitalize as AutoCapitalize,
-      value: domRef?.current?.value ?? inputValue,
+      value: inputValue,
       "aria-label": safeAriaLabel(
         originalProps?.["aria-label"],
         originalProps?.label,

--- a/packages/components/input/stories/input.stories.tsx
+++ b/packages/components/input/stories/input.stories.tsx
@@ -13,6 +13,7 @@ import {
   CloseFilledIcon,
 } from "@nextui-org/shared-icons";
 import {button} from "@nextui-org/theme";
+import {useForm} from "react-hook-form";
 
 import {Input, InputProps, useInput} from "../src";
 
@@ -474,6 +475,38 @@ const CustomWithHooksTemplate = (args: InputProps) => {
   );
 };
 
+const WithReactHookFormTemplate = (args: InputProps) => {
+  const {
+    register,
+    formState: {errors},
+    handleSubmit,
+  } = useForm({
+    defaultValues: {
+      withDefaultValue: "wkw",
+      withoutDefaultValue: "",
+      requiredField: "",
+    },
+  });
+
+  const onSubmit = (data: any) => {
+    // eslint-disable-next-line no-console
+    console.log(data);
+    alert("Submitted value: " + JSON.stringify(data));
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+      <Input isClearable label="With default value" {...register("withDefaultValue")} />
+      <Input {...args} label="Without default value" {...register("withoutDefaultValue")} />
+      <Input {...args} label="Required" {...register("requiredField", {required: true})} />
+      {errors.requiredField && <span className="text-danger">This field is required</span>}
+      <button className={button({class: "w-fit"})} type="submit">
+        Submit
+      </button>
+    </form>
+  );
+};
+
 export const Default = {
   render: MirrorTemplate,
 
@@ -704,5 +737,13 @@ export const CustomWithHooks = {
     startContent: (
       <SearchIcon className="text-black/50 mb-0.5 dark:text-white/90 text-slate-400 pointer-events-none flex-shrink-0" />
     ),
+  },
+};
+
+export const WithReactHookForm = {
+  render: WithReactHookFormTemplate,
+
+  args: {
+    ...defaultProps,
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1566,6 +1566,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.51.3
+        version: 7.51.3(react@18.2.0)
 
   packages/components/kbd:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1523,6 +1523,9 @@ importers:
       '@nextui-org/shared-utils':
         specifier: workspace:*
         version: link:../../utilities/shared-utils
+      '@nextui-org/use-safe-layout-effect':
+        specifier: workspace:*
+        version: link:../../hooks/use-safe-layout-effect
       '@react-aria/focus':
         specifier: ^3.16.2
         version: 3.16.2(react@18.2.0)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2791

## 📝 Description

- use `useSafeLayoutEffect` to handle react-hook-form case. consistent with others
- add test case for isClearable
- add react hook form to input storybook (for test case, will be handled in another PR)

## ⛳️ Current behavior (updates)

with `isClearable`, users fail to clear the value due to the previous change

## 🚀 New behavior

with `isClearable`, users are able to clear the value.

[pr2796-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/39ee8d35-502f-41cb-b51b-d6f28c153f0b)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced the input component to support clear functionality with the `isClearable` option.
    - Introduced `WithReactHookForm` component for better form handling and validation using `react-hook-form`.

- **Bug Fixes**
    - Fixed an issue where the input value was not properly cleared when using the clear button.

- **Tests**
    - Added tests to ensure the clear functionality triggers the `onClear` callback correctly.

- **Dependencies**
    - Added `react-hook-form` to improve form state management and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->