### PR TITLE
fix(docs): Date input start & end content calendar import issue (codesandbox)

### DIFF
--- a/apps/docs/content/components/date-input/start-end-content.ts
+++ b/apps/docs/content/components/date-input/start-end-content.ts
@@ -55,7 +55,7 @@ export default function App() {
 
 const react = {
   "/App.jsx": App,
-  "/MailIcon.jsx": CalendarIcon,
+  "/CalendarIcon.jsx": CalendarIcon,
 };
 
 export default {


### PR DESCRIPTION
## 📝 Description

This PR request fixes the import issue in codesandbox for CalendarIcon instead of MailIcon

## 💣 Is this a breaking change (Yes/No):

No
