### PR TITLE
fix(docs): Date input - Time zone example code is not showing js (code mode)

### DIFF
--- a/apps/docs/content/components/date-input/time-zones.ts
+++ b/apps/docs/content/components/date-input/time-zones.ts
@@ -1,5 +1,5 @@
 const App = `import {DateInput} from "@nextui-org/react";
-import {parseZonedDateTime} from "@internationalized/date";
+import {parseZonedDateTime, parseAbsoluteToLocal} from "@internationalized/date";
 
 export default function App() {
   return (

--- a/apps/docs/content/components/date-input/time-zones.ts
+++ b/apps/docs/content/components/date-input/time-zones.ts
@@ -1,4 +1,4 @@
-const AppTs = `import {DateInput} from "@nextui-org/react";
+const App = `import {DateInput} from "@nextui-org/react";
 import {parseZonedDateTime} from "@internationalized/date";
 
 export default function App() {
@@ -19,7 +19,7 @@ export default function App() {
 }`;
 
 const react = {
-  "/App.tsx": AppTs,
+  "/App.jsx": App,
 };
 
 export default {


### PR DESCRIPTION
## 📝 Description
In Date time (Time zones example), there is no need for ts and js separately for code.

This PR request 

## ⛳️ Current behavior (updates)

Currently, Date time (Time zones example - docs), in `js` code there Is nothing (Sample app code)

## 🚀 New behavior

It will be the same for ts and js code

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date input components to support converting absolute time to local time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->