### PR TITLE
docs(button): add missing type prop and its default

### DIFF
--- a/apps/docs/content/docs/components/button.mdx
+++ b/apps/docs/content/docs/components/button.mdx
@@ -164,6 +164,7 @@ building buttons that work well across devices and interaction methods.
 | color            | `default` \| `primary` \| `secondary` \| `success` \| `warning` \| `danger`  | The button color theme.                                      | `default` |
 | size             | `sm` \| `md` \| `lg`                                                         | The button size.                                             | `md`      |
 | radius           | `none` \| `sm` \| `md` \| `lg` \| `full`                                     | The button border radius.                                    | -         |
+| type             | `button` \| `submit` \| `reset`                                              | The button type.                                             | `button`  |
 | startContent     | `ReactNode`                                                                  | The button start content.                                    | -         |
 | endContent       | `ReactNode`                                                                  | The button end content.                                      | -         |
 | spinner          | `ReactNode`                                                                  | Spinner to display when loading.                             | -         |


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Filled documentation for type property of Button.

## ⛳️ Current behavior (updates)

Current docs are not stating the default, nor possible values for button's type property.

## 🚀 New behavior

Default type and it's values can be found in docs.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new property `type` for buttons, allowing specification as `button`, `submit`, or `reset`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->