### PR TITLE
fix: add missing react-dom peer dependency to @nextui-org/use-aria-menu

### DIFF
--- a/packages/hooks/use-aria-menu/package.json
+++ b/packages/hooks/use-aria-menu/package.json
@@ -34,7 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
     "@react-aria/utils": "^3.23.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3205,6 +3205,9 @@ importers:
       '@react-types/shared':
         specifier: ^3.22.1
         version: 3.22.1(react@18.2.0)
+      react-dom:
+        specifier: '>=18'
+        version: 18.2.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

```
ERROR in ../.yarn/__virtual__/@react-aria-selection-virtual-892896c25b/5/.yarn/berry/cache/@react-aria-selection-npm-3.17.5-76ba97ff20-10c0.zip/node_modules/@react-aria/selection/dist/import.mjs 1:0-56
Module not found: Error: @react-aria/selection tried to access react-dom (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.

Required package: react-dom
Required by: @react-aria/selection@virtual:4e38beada090ba2a34dd941cf8a49a73221df9b86e1e9e6c2772c0d2905b813939e0cbad041feb9f634f9bbfff3f6c80f7e01d595908ace41bfff92a347644e6#npm:3.17.5 (via /path/.yarn/__virtual__/@react-aria-selection-virtual-892896c25b/5/.yarn/berry/cache/@react-aria-selection-npm-3.17.5-76ba97ff20-10c0.zip/node_modules/@react-aria/selection/dist/)

Ancestor breaking the chain: @nextui-org/use-aria-menu@virtual:b5af278080fdfcea734a3a24082114d47e8020ac0ae500168610c21dca77e391a946be681907fbaa86cf6f4082c39af47cc754dbcfb41f3d6561e8fca0a49af4#npm:2.0.1
```

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

nextui can be build with pnp

## 💣 Is this a breaking change (Yes/No):

no

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated peer dependencies to include `"react-dom": ">=18"` for improved compatibility with React components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->