### PR TITLE
fix: no overflow for the installs commands list

### DIFF
--- a/apps/docs/components/docs/components/package-managers.tsx
+++ b/apps/docs/components/docs/components/package-managers.tsx
@@ -54,7 +54,7 @@ export const PackageManagers = ({commands}: PackageManagersProps) => {
     <Tabs
       aria-label="NextUI installation commands"
       classNames={{
-        base: "group mt-4",
+        base: "group mt-4 min-w-[300px] w-full overflow-x-auto",
         tabList: "h-10",
       }}
       selectedKey={selectedManager}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # 

## 📝 Description

no overflow for the installs commands list

![IMG_53741495AEA7-1](https://github.com/nextui-org/nextui/assets/62743644/1329264b-fdb6-4438-bc21-bc43b22e1521)


## ⛳️ Current behavior (updates)

Above

## 🚀 New behavior


https://github.com/nextui-org/nextui/assets/62743644/5235aef1-d6e8-4666-8122-fc59903a4240



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the styling of the `Tabs` component in the documentation section to ensure better readability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->