### PR TITLE
fix(components): added aria label to chip close button

### DIFF
--- a/packages/components/chip/src/chip.tsx
+++ b/packages/components/chip/src/chip.tsx
@@ -33,7 +33,11 @@ const Chip = forwardRef<"div", ChipProps>((props, ref) => {
 
   const end = useMemo(() => {
     if (isCloseable) {
-      return <span {...getCloseButtonProps()}>{endContent || <CloseFilledIcon />}</span>;
+      return (
+        <span {...getCloseButtonProps()} aria-label="close-button">
+          {endContent || <CloseFilledIcon />}
+        </span>
+      );
     }
 
     return endContent;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2802 

## 📝 Description
- The chip component close button was missing an aria-label attribute. This causes the accessibility tests to fail for a chip with a close button

## ⛳️ Current behavior (updates)
- No aria-label attribute on the button component
![Screenshot 2024-04-24 at 07 04 39 (2)](https://github.com/nextui-org/nextui/assets/166782331/195eab02-8121-4f6f-b5bc-37ed212ec458)
![Screenshot 2024-04-24 at 07 04 44 (2)](https://github.com/nextui-org/nextui/assets/166782331/c43acdbf-2a81-4cfb-8340-cdc06a1eba73)

## 🚀 New behavior
- Added aria-label attribute
![Screenshot 2024-04-24 at 07 03 49 (2)](https://github.com/nextui-org/nextui/assets/166782331/cf3cf213-0f6c-4adc-84bd-6cd0a3542dec)
![Screenshot 2024-04-24 at 07 04 00 (2)](https://github.com/nextui-org/nextui/assets/166782331/10a4a8d5-e0c9-4d57-ac26-093d9b3d7aad)

## 💣 Is this a breaking change (Yes/No):
- No

## 📝 Additional Information
