### PR TITLE
fix(calendar):  maximum update depth exceeded 

### DIFF
--- a/.changeset/tasty-keys-cover.md
+++ b/.changeset/tasty-keys-cover.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+Fix #2820 #2857 Maximum update depth exceeded on Calendar & RangeCalendar when hovering the dates.

--- a/packages/components/calendar/src/calendar-month.tsx
+++ b/packages/components/calendar/src/calendar-month.tsx
@@ -1,5 +1,3 @@
-import type {CalendarState, RangeCalendarState} from "@react-stately/calendar";
-
 import {CalendarDate, endOfMonth, getWeeksInMonth} from "@internationalized/date";
 import {CalendarPropsBase} from "@react-types/calendar";
 import {HTMLNextUIProps} from "@nextui-org/system";
@@ -7,7 +5,6 @@ import {useLocale} from "@react-aria/i18n";
 import {useCalendarGrid} from "@react-aria/calendar";
 import {m} from "framer-motion";
 import {dataAttr} from "@nextui-org/shared-utils";
-import {useEffect, useState} from "react";
 
 import {CalendarCell} from "./calendar-cell";
 import {slideVariants} from "./calendar-transitions";
@@ -25,29 +22,8 @@ export function CalendarMonth(props: CalendarMonthProps) {
   const {locale} = useLocale();
   const weeksInMonth = getWeeksInMonth(startDate, locale);
 
-  const {
-    state: stateProp,
-    slots,
-    weekdayStyle,
-    isHeaderExpanded,
-    disableAnimation,
-    classNames,
-  } = useCalendarContext();
-
-  // Self-controlled state
-  const [state, setState] = useState<CalendarState | RangeCalendarState>(() => stateProp);
-
-  /**
-   * This avoid focusing the date cell when navigating through the picker'
-   * months/years with the keyboard.
-   */
-  useEffect(() => {
-    if (isHeaderExpanded) {
-      return;
-    }
-
-    setState(stateProp);
-  }, [stateProp, isHeaderExpanded]);
+  const {state, slots, weekdayStyle, isHeaderExpanded, disableAnimation, classNames} =
+    useCalendarContext();
 
   const {gridProps, headerProps, weekDays} = useCalendarGrid(
     {


### PR DESCRIPTION
…dar & RangeCalendar

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2820 #2857 

## 📝 Description

This PR fixes the "Maximum update depth exceeded" error when hovering quickly over the dates on Calendar & RangeCalendar.

## ⛳️ Current behaviour (updates)

![image](https://github.com/nextui-org/nextui/assets/30373425/5cf582a3-6b8c-46fe-8d2e-4ccc1a865b52)

## 🚀 New behavior

Needless `self-state` removed so this error is gone.

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue in Calendar & RangeCalendar that caused maximum update depth exceeded errors when hovering over dates.

- **Refactor**
	- Simplified state management in the `CalendarMonth` component for enhanced clarity and reduced complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->