### PR TITLE
fix: change sort priority - cmdk

### DIFF
--- a/apps/docs/components/cmdk.tsx
+++ b/apps/docs/components/cmdk.tsx
@@ -154,6 +154,16 @@ export const Cmdk: FC<{}> = () => {
     }
   };
 
+  const prioritizeFirstLevelItems = (a: SearchResultItem, b: SearchResultItem) => {
+    if (a.type === "lvl1") {
+      return -1;
+    } else if (b.type === "lvl1") {
+      return 1;
+    }
+
+    return 0;
+  };
+
   const results = useMemo<SearchResultItem[]>(
     function getResults() {
       if (query.length < 2) return [];
@@ -165,12 +175,22 @@ export const Cmdk: FC<{}> = () => {
       if (words.length === 1) {
         return matchSorter(data, query, {
           keys: MATCH_KEYS,
+          sorter: (matches) => {
+            matches.sort((a, b) => prioritizeFirstLevelItems(a.item, b.item));
+
+            return matches;
+          },
         }).slice(0, MAX_RESULTS);
       }
 
       const matchesForEachWord = words.map((word) =>
         matchSorter(data, word, {
           keys: MATCH_KEYS,
+          sorter: (matches) => {
+            matches.sort((a, b) => prioritizeFirstLevelItems(a.item, b.item));
+
+            return matches;
+          },
         }),
       );
 


### PR DESCRIPTION
Closes #

## 📝 Description

When searching the components in the result should have more priority than the API/docs ones 

e.g. Listbox should be first

![CleanShot 2024-04-22 at 18 41 27](https://github.com/nextui-org/nextui/assets/62743644/991c5608-0645-4460-9070-3b5e2cefc769)


## ⛳️ Current behavior (updates)

No sorting.

## 🚀 New behavior

https://github.com/nextui-org/nextui/assets/62743644/7a8f0726-fdad-46dc-84fd-8604f0b64520


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the search functionality in the `Cmdk` component to prioritize first-level items, improving result relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->