### PR TITLE
fix(slider): missing marks when hideThumb is true & revise slider styles

### DIFF
--- a/.changeset/eighty-kids-drop.md
+++ b/.changeset/eighty-kids-drop.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Revise slider styles (#2880)

--- a/packages/components/slider/__tests__/slider.test.tsx
+++ b/packages/components/slider/__tests__/slider.test.tsx
@@ -214,3 +214,77 @@ describe("Slider", () => {
     expect(setValues).toStrictEqual([[15, 25]]);
   });
 });
+
+it("should supports hideThumb", async function () {
+  const {container} = render(<Slider hideThumb defaultValue={20} label="The Label" />);
+
+  const track = container.querySelector("[data-slot='track']");
+
+  expect(track).toHaveAttribute("data-thumb-hidden", "true");
+});
+
+it("should supports marks", async function () {
+  const {container} = render(
+    <Slider
+      hideThumb
+      defaultValue={20}
+      label="The Label"
+      marks={[
+        {
+          value: 0.2,
+          label: "20%",
+        },
+        {
+          value: 0.5,
+          label: "50%",
+        },
+        {
+          value: 0.8,
+          label: "80%",
+        },
+      ]}
+      maxValue={1}
+      minValue={0}
+      step={0.1}
+    />,
+  );
+
+  const marks = container.querySelectorAll("[data-slot='mark']");
+
+  expect(marks).toHaveLength(3);
+});
+
+it("should supports marks with hideThumb", async function () {
+  const {container} = render(
+    <Slider
+      hideThumb
+      defaultValue={20}
+      label="The Label"
+      marks={[
+        {
+          value: 0.2,
+          label: "20%",
+        },
+        {
+          value: 0.5,
+          label: "50%",
+        },
+        {
+          value: 0.8,
+          label: "80%",
+        },
+      ]}
+      maxValue={1}
+      minValue={0}
+      step={0.1}
+    />,
+  );
+
+  const track = container.querySelector("[data-slot='track']");
+
+  expect(track).toHaveAttribute("data-thumb-hidden", "true");
+
+  const marks = container.querySelectorAll("[data-slot='mark']");
+
+  expect(marks).toHaveLength(3);
+});

--- a/packages/components/slider/stories/slider.stories.tsx
+++ b/packages/components/slider/stories/slider.stories.tsx
@@ -315,7 +315,24 @@ export const ThumbHidden = {
     "aria-label": "Player progress",
     color: "foreground",
     hideThumb: true,
-    defaultValue: 20,
+    maxValue: 1,
+    minValue: 0,
+    step: 0.1,
+    marks: [
+      {
+        value: 0.2,
+        label: "20%",
+      },
+      {
+        value: 0.5,
+        label: "50%",
+      },
+      {
+        value: 0.8,
+        label: "80%",
+      },
+    ],
+    defaultValue: 0.2,
   },
 };
 

--- a/packages/core/theme/src/components/slider.ts
+++ b/packages/core/theme/src/components/slider.ts
@@ -166,6 +166,7 @@ const slider = tv({
     hasMarks: {
       true: {
         base: "mb-5",
+        mark: "cursor-pointer",
       },
       false: {},
     },
@@ -185,7 +186,7 @@ const slider = tv({
     hideThumb: {
       true: {
         thumb: "sr-only",
-        track: "overflow-hidden cursor-pointer",
+        track: "cursor-pointer",
       },
     },
     hasSingleThumb: {
@@ -266,7 +267,7 @@ const slider = tv({
       isVertical: false,
       class: {
         track:
-          "h-1 my-[calc((theme(spacing.5)-theme(spacing.1))/2)] data-[thumb-hidden=false]:border-x-[calc(theme(spacing.5)/2)]",
+          "h-1 my-[calc((theme(spacing.5)-theme(spacing.1))/2)] border-x-[calc(theme(spacing.5)/2)]",
       },
     },
     {
@@ -274,7 +275,7 @@ const slider = tv({
       isVertical: false,
       class: {
         track:
-          "h-3 my-[calc((theme(spacing.6)-theme(spacing.3))/2)] data-[thumb-hidden=false]:border-x-[calc(theme(spacing.6)/2)]",
+          "h-3 my-[calc((theme(spacing.6)-theme(spacing.3))/2)] border-x-[calc(theme(spacing.6)/2)]",
       },
     },
     {
@@ -282,7 +283,7 @@ const slider = tv({
       isVertical: false,
       class: {
         track:
-          "h-7 my-[calc((theme(spacing.7)-theme(spacing.5))/2)] data-[thumb-hidden=false]:border-x-[calc(theme(spacing.7)/2)]",
+          "h-7 my-[calc((theme(spacing.7)-theme(spacing.5))/2)] border-x-[calc(theme(spacing.7)/2)]",
       },
     },
     // size && isVertical
@@ -291,7 +292,7 @@ const slider = tv({
       isVertical: true,
       class: {
         track:
-          "w-1 mx-[calc((theme(spacing.5)-theme(spacing.1))/2)] data-[thumb-hidden=false]:border-y-[calc(theme(spacing.5)/2)]",
+          "w-1 mx-[calc((theme(spacing.5)-theme(spacing.1))/2)] border-y-[calc(theme(spacing.5)/2)]",
       },
     },
     {
@@ -299,7 +300,7 @@ const slider = tv({
       isVertical: true,
       class: {
         track:
-          "w-3 mx-[calc((theme(spacing.6)-theme(spacing.3))/2)] data-[thumb-hidden=false]:border-y-[calc(theme(spacing.6)/2)]",
+          "w-3 mx-[calc((theme(spacing.6)-theme(spacing.3))/2)] border-y-[calc(theme(spacing.6)/2)]",
       },
     },
     {
@@ -307,7 +308,7 @@ const slider = tv({
       isVertical: true,
       class: {
         track:
-          "w-7 mx-[calc((theme(spacing.7)-theme(spacing.5))/2)] data-[thumb-hidden=false]:border-y-[calc(theme(spacing.7)/2)]",
+          "w-7 mx-[calc((theme(spacing.7)-theme(spacing.5))/2)] border-y-[calc(theme(spacing.7)/2)]",
       },
     },
     // color && !isVertical && hasSingleThumb


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2880

## 📝 Description

- revise slider styles
- add some tests

## ⛳️ Current behavior (updates)

with marks specified, when `hideThumb` is true, all marks will be gone.

![image](https://github.com/nextui-org/nextui/assets/35857179/f31a8530-e53c-4ab7-bd47-c78449ec79cc)

## 🚀 New behavior

![image](https://github.com/nextui-org/nextui/assets/35857179/1d668403-c07f-44c5-961f-3e681986cb4f)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced slider component with new configuration options including `maxValue`, `minValue`, `step`, and `marks`.
  
- **Tests**
  - Added new test cases for the `Slider` component to ensure functionality with features like hidden thumb and display of marks.

- **Style**
  - Updated slider styling to accommodate different sizes, orientations, and configurations.

- **Documentation**
  - Updated component stories to demonstrate new slider configurations and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->