### PR TITLE
fix(range-calendar): hide only dates outside the month

### DIFF
--- a/.changeset/nasty-pillows-travel.md
+++ b/.changeset/nasty-pillows-travel.md
@@ -2,4 +2,4 @@
 "@nextui-org/calendar": patch
 ---
 
-Fixed hiding of Unavailable dates in RangeCalendar (#2890)
+Fixed hiding of unavailable dates in RangeCalendar (#2890)

--- a/.changeset/nasty-pillows-travel.md
+++ b/.changeset/nasty-pillows-travel.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+Fixed hiding of Unvavailable dates in RangeCalendar (#2890)

--- a/.changeset/nasty-pillows-travel.md
+++ b/.changeset/nasty-pillows-travel.md
@@ -1,5 +1,6 @@
 ---
 "@nextui-org/calendar": patch
+"@nextui-org/theme": patch
 ---
 
 Fixed hiding of unavailable dates in RangeCalendar (#2890)

--- a/.changeset/nasty-pillows-travel.md
+++ b/.changeset/nasty-pillows-travel.md
@@ -2,4 +2,4 @@
 "@nextui-org/calendar": patch
 ---
 
-Fixed hiding of Unvavailable dates in RangeCalendar (#2890)
+Fixed hiding of Unavailable dates in RangeCalendar (#2890)

--- a/packages/components/calendar/src/calendar-cell.tsx
+++ b/packages/components/calendar/src/calendar-cell.tsx
@@ -42,7 +42,7 @@ export function CalendarCell(originalProps: CalendarCellProps) {
     ref,
   );
 
-  const isUnavailable = state.isCellUnavailable(props.date) && !isDisabled;
+  const isUnavailable = state.isCellUnavailable(props.date);
   const isLastSelectedBeforeDisabled =
     !isDisabled && !isInvalid && state.isCellUnavailable(props.date.add({days: 1}));
   const isFirstSelectedAfterDisabled =

--- a/packages/core/theme/src/components/calendar.ts
+++ b/packages/core/theme/src/components/calendar.ts
@@ -106,7 +106,7 @@ const calendar = tv({
     },
     hideDisabledDates: {
       true: {
-        cellButton: "data-[disabled=true]:opacity-0",
+        cellButton: "data-[disabled=true]:data-[outside-month=true]:opacity-0",
       },
       false: {},
     },


### PR DESCRIPTION
Closes #2890

## 📝 Description
The unavailable dates are disabled after the first selection and `cellButton: "data-[disabled=true]:opacity-0"` used to hide them.

## ⛳️ Current behavior (updates)
The unavailable dates are getting hidden after first selection.

![image](https://github.com/nextui-org/nextui/assets/8769408/2f9f0755-11b6-4138-9e46-9b63e186b232)

## 🚀 New behavior
Only the dates outside the month are hidden.

![image](https://github.com/nextui-org/nextui/assets/8769408/4541fe46-25dd-432c-a9d7-e62396f071e3)

## 💣 Is this a breaking change (Yes/No):

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Fixed a bug in the calendar component that incorrectly displayed unavailable dates.
- **Style**
	- Updated calendar styling to better hide disabled dates based on additional conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->