### PR TITLE
fix(date-picker): keep date picker style consistent for different variants

### DIFF
--- a/.changeset/swift-trains-wonder.md
+++ b/.changeset/swift-trains-wonder.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-picker": patch
+---
+
+keep date picker style consistent for different variants (#2901)

--- a/packages/components/date-picker/src/use-date-picker-base.ts
+++ b/packages/components/date-picker/src/use-date-picker-base.ts
@@ -192,13 +192,7 @@ export function useDatePickerBase<T extends DateValue>(originalProps: UseDatePic
         isDateUnavailable,
         showMonthAndYearPickers,
         onHeaderExpandedChange: setIsCalendarHeaderExpanded,
-        color:
-          (originalProps.variant === "bordered" || originalProps.variant === "underlined") &&
-          isDefaultColor
-            ? "foreground"
-            : isDefaultColor
-            ? "primary"
-            : originalProps.color,
+        color: isDefaultColor ? "primary" : originalProps.color,
         disableAnimation,
       },
       userCalendarProps,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2901

## 📝 Description

as titled

## ⛳️ Current behavior (updates)

default (`flat`, `faded`): 

![image](https://github.com/nextui-org/nextui/assets/35857179/7625a875-f5bf-43b9-bb84-434bcb83fb72)

monochrome (`bordered`, `underlined`): 

![image](https://github.com/nextui-org/nextui/assets/35857179/033f523f-c92d-4c9c-962e-2349f61af50d)


## 🚀 New behavior

[pr2908-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/87ba539c-8ce3-4360-863a-ce276c79ec22)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Patched the date picker to maintain consistent styling across different variants.

- **Refactor**
	- Simplified color assignment logic in the date picker for enhanced reliability and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->