### PR TITLE
fix(switch): support uncontrolled switch in react-hook-form

### DIFF
--- a/.changeset/rotten-zoos-decide.md
+++ b/.changeset/rotten-zoos-decide.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/switch": patch
+---
+
+Fixed react-hook-form uncontrolled switch component

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@nextui-org/shared-utils": "workspace:*",
     "@nextui-org/react-utils": "workspace:*",
+    "@nextui-org/use-safe-layout-effect": "workspace:*",
     "@react-aria/focus": "^3.16.2",
     "@react-aria/interactions": "^3.21.1",
     "@react-aria/switch": "^3.6.2",

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -57,7 +57,8 @@
     "@nextui-org/shared-icons": "workspace:*",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "react-hook-form": "^7.51.3"
   },
   "clean-package": "../../../clean-package.config.json"
 }

--- a/packages/components/switch/stories/switch.stories.tsx
+++ b/packages/components/switch/stories/switch.stories.tsx
@@ -5,6 +5,8 @@ import {toggle} from "@nextui-org/theme";
 import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {SunFilledIcon, MoonFilledIcon} from "@nextui-org/shared-icons";
 import {clsx} from "@nextui-org/shared-utils";
+import {button} from "@nextui-org/theme";
+import {useForm} from "react-hook-form";
 
 import {Switch, SwitchProps, SwitchThumbIconProps, useSwitch} from "../src";
 
@@ -131,6 +133,44 @@ const CustomWithHooksTemplate = (args: SwitchProps) => {
   );
 };
 
+const WithReactHookFormTemplate = (args: SwitchProps) => {
+  const {
+    register,
+    formState: {errors},
+    handleSubmit,
+  } = useForm({
+    defaultValues: {
+      defaultTrue: true,
+      defaultFalse: false,
+      requiredField: false,
+    },
+  });
+
+  const onSubmit = (data: any) => {
+    // eslint-disable-next-line no-console
+    console.log(data);
+    alert("Submitted value: " + JSON.stringify(data));
+  };
+
+  return (
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+      <Switch {...args} {...register("defaultTrue")}>
+        By default this switch is true
+      </Switch>
+      <Switch {...args} {...register("defaultFalse")}>
+        By default this switch is false
+      </Switch>
+      <Switch {...args} {...register("requiredField", {required: true})}>
+        This switch is required
+      </Switch>
+      {errors.requiredField && <span className="text-danger">This switch is required</span>}
+      <button className={button({class: "w-fit"})} type="submit">
+        Submit
+      </button>
+    </form>
+  );
+};
+
 export const Default = {
   args: {
     ...defaultProps,
@@ -199,6 +239,14 @@ export const CustomWithClassNames = {
 
 export const CustomWithHooks = {
   render: CustomWithHooksTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const WithReactHookForm = {
+  render: WithReactHookFormTemplate,
 
   args: {
     ...defaultProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2502,6 +2502,9 @@ importers:
       '@nextui-org/shared-utils':
         specifier: workspace:*
         version: link:../../utilities/shared-utils
+      '@nextui-org/use-safe-layout-effect':
+        specifier: workspace:*
+        version: link:../../hooks/use-safe-layout-effect
       '@react-aria/focus':
         specifier: ^3.16.2
         version: 3.16.2(react@18.2.0)
@@ -5952,10 +5955,6 @@ packages:
     peerDependencies:
       '@effect-ts/otel-node': '*'
     peerDependenciesMeta:
-      '@effect-ts/core':
-        optional: true
-      '@effect-ts/otel':
-        optional: true
       '@effect-ts/otel-node':
         optional: true
     dependencies:
@@ -22449,9 +22448,6 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
-    peerDependenciesMeta:
-      '@parcel/core':
-        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(typescript@4.9.5)
       '@parcel/core': 2.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2545,6 +2545,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-hook-form:
+        specifier: ^7.51.3
+        version: 7.51.3(react@18.2.0)
 
   packages/components/table:
     dependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Applied the same fix done in other form input components

## ⛳️ Current behavior (updates)

defaultValues wont work for uncontrolled switch.

## 🚀 New behavior

![image](https://github.com/nextui-org/nextui/assets/35857179/8013427d-68ee-437d-93f9-34996e663255)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with the uncontrolled switch component in forms using `react-hook-form`.

- **New Features**
	- Introduced a new form handling component for switches, enhancing integration with `react-hook-form`.

- **Refactor**
	- Improved synchronization between the switch state and its display in the DOM.
	- Updated switch component to use more efficient reference handling and effects for state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->