### PR TITLE
fix(calendar): scrolling is hidden when changing the month

### DIFF
--- a/.changeset/tough-carpets-marry.md
+++ b/.changeset/tough-carpets-marry.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+Removed scrolling display during month change animation (#2945)

--- a/.changeset/tough-carpets-marry.md
+++ b/.changeset/tough-carpets-marry.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/calendar": patch
+"@nextui-org/theme": patch
 ---
 
 Removed scrolling display during month change animation (#2945)

--- a/packages/core/theme/src/components/calendar.ts
+++ b/packages/core/theme/src/components/calendar.ts
@@ -13,7 +13,7 @@ const calendar = tv({
     prevButton: [],
     nextButton: [],
     headerWrapper: [
-      "px-4 py-2 flex items-center justify-between gap-2 bg-content1",
+      "px-4 py-2 flex items-center justify-between gap-2 bg-content1 overflow-hidden",
       "[&_.chevron-icon]:flex-none",
       // month/year picker wrapper
       "after:content-['']",


### PR DESCRIPTION
Closes #2945

## 📝 Description

Removed scrolling display during month change animation

## ⛳️ Current behavior (updates)


https://github.com/nextui-org/nextui/assets/57824881/feb330ec-bec9-42ae-aa28-87cebec0e3d9


## 🚀 New behavior


https://github.com/nextui-org/nextui/assets/57824881/d2232b2a-f94c-4895-890a-99980cc615bc



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the calendar display by removing the scrolling during month change animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->