### PR TITLE
fix(component): update type definition to prevent primitive values as items

### DIFF
--- a/.changeset/great-singers-repeat.md
+++ b/.changeset/great-singers-repeat.md
@@ -1,0 +1,11 @@
+---
+"@nextui-org/autocomplete": patch
+"@nextui-org/dropdown": patch
+"@nextui-org/listbox": patch
+"@nextui-org/menu": patch
+"@nextui-org/select": patch
+"@nextui-org/tabs": patch
+"@nextui-org/use-aria-multiselect": patch
+---
+
+Fix update type definition to prevent primitive values as items (#2938)

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -58,10 +58,10 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
   );
 }
 
-export type AutocompleteProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type AutocompleteProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(Autocomplete) as <T = object>(
+export default forwardRef(Autocomplete) as <T extends object>(
   props: AutocompleteProps<T>,
 ) => ReactElement;
 

--- a/packages/components/dropdown/src/dropdown-menu.tsx
+++ b/packages/components/dropdown/src/dropdown-menu.tsx
@@ -6,7 +6,7 @@ import {ForwardedRef, ReactElement, Ref} from "react";
 
 import {useDropdownContext} from "./dropdown-context";
 
-interface Props<T> extends Omit<MenuProps<T>, "menuProps"> {}
+interface Props<T extends object = object> extends Omit<MenuProps<T>, "menuProps"> {}
 
 function DropdownMenu<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListElement>) {
   const {getMenuProps} = useDropdownContext();

--- a/packages/components/dropdown/src/dropdown-menu.tsx
+++ b/packages/components/dropdown/src/dropdown-menu.tsx
@@ -20,10 +20,10 @@ function DropdownMenu<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLU
   );
 }
 
-export type DropdownMenuProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type DropdownMenuProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(DropdownMenu) as <T = object>(
+export default forwardRef(DropdownMenu) as <T extends object>(
   props: DropdownMenuProps<T>,
 ) => ReactElement;
 

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -132,7 +132,7 @@ export function useDropdown(props: UseDropdownProps) {
     };
   };
 
-  const getMenuProps = <T>(
+  const getMenuProps = <T extends object>(
     props?: Partial<MenuProps<T>>,
     _ref: Ref<any> | null | undefined = null,
   ) => {

--- a/packages/components/listbox/src/listbox.tsx
+++ b/packages/components/listbox/src/listbox.tsx
@@ -76,7 +76,7 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
 
 Listbox.displayName = "NextUI.Listbox";
 
-export type ListboxProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type ListboxProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(Listbox) as <T = object>(props: ListboxProps<T>) => ReactElement;
+export default forwardRef(Listbox) as <T extends object>(props: ListboxProps<T>) => ReactElement;

--- a/packages/components/menu/src/menu.tsx
+++ b/packages/components/menu/src/menu.tsx
@@ -71,9 +71,9 @@ function Menu<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListElem
   );
 }
 
-export type MenuProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type MenuProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(Menu) as <T = object>(props: MenuProps<T>) => ReactElement;
+export default forwardRef(Menu) as <T extends object>(props: MenuProps<T>) => ReactElement;
 
 Menu.displayName = "NextUI.Menu";

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -144,9 +144,9 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   );
 }
 
-export type SelectProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type SelectProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(Select) as <T = object>(props: SelectProps<T>) => ReactElement;
+export default forwardRef(Select) as <T extends object>(props: SelectProps<T>) => ReactElement;
 
 Select.displayName = "NextUI.Select";

--- a/packages/components/tabs/src/tabs.tsx
+++ b/packages/components/tabs/src/tabs.tsx
@@ -57,9 +57,9 @@ function Tabs<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLDivElemen
   return renderTabs;
 }
 
-export type TabsProps<T = object> = Props<T> & {ref?: Ref<HTMLElement>};
+export type TabsProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
-export default forwardRef(Tabs) as <T = object>(props: TabsProps<T>) => ReactElement;
+export default forwardRef(Tabs) as <T extends object>(props: TabsProps<T>) => ReactElement;
 
 Tabs.displayName = "NextUI.Tabs";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/2938

## 📝 Description

Fixed the type definitions of the component.

The same definition is applied in DatePicker:
https://github.com/nextui-org/nextui/blob/633f9d208b193c22adb549115fa79520d01708d0/packages/components/date-picker/src/date-picker.tsx#L83-L86


## ⛳️ Current behavior (updates)

Arrays that contain non-object values can be passed to `items`, which leads to a runtime error.

## 🚀 New behavior

Passing arrays with non-object values to `items` will now raise a linting warning.

<img width="668" alt="image" src="https://github.com/nextui-org/nextui/assets/76232929/ed4ccf4a-9bc9-4147-8c75-1b4026eb9754">


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed type definitions across various UI components to ensure only object types are used as generic parameters, enhancing type safety and compatibility.

- **Refactor**
	- Updated type constraints in components like Autocomplete, Dropdown Menu, Listbox, Menu, Select, and Tabs to enforce stricter type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->