### PR TITLE
fix(dropdown): focus behaviour on press / enter keydown

### DIFF
--- a/.changeset/heavy-kangaroos-stare.md
+++ b/.changeset/heavy-kangaroos-stare.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/dropdown": patch
+---
+
+Focus on the first item when pressing Space / Enter key on dropdown menu open (#2863)

--- a/.changeset/heavy-kangaroos-stare.md
+++ b/.changeset/heavy-kangaroos-stare.md
@@ -1,5 +1,6 @@
 ---
 "@nextui-org/dropdown": patch
+"@nextui-org/menu": patch
 ---
 
 Focus on the first item when pressing Space / Enter key on dropdown menu open (#2863)

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -538,3 +538,85 @@ describe("Dropdown", () => {
     spy.mockRestore();
   });
 });
+
+describe("Keyboard interactions", () => {
+  it("should focus on the first item on keyDown (Enter)", async () => {
+    const wrapper = render(
+      <Dropdown>
+        <DropdownTrigger>
+          <Button data-testid="trigger-test">Trigger</Button>
+        </DropdownTrigger>
+        <DropdownMenu disallowEmptySelection aria-label="Actions" selectionMode="single">
+          <DropdownItem key="new">New file</DropdownItem>
+          <DropdownItem key="copy">Copy link</DropdownItem>
+          <DropdownItem key="edit">Edit file</DropdownItem>
+          <DropdownItem key="delete" color="danger">
+            Delete file
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    act(() => {
+      triggerButton.focus();
+    });
+
+    expect(triggerButton).toHaveFocus();
+
+    await act(async () => {
+      await userEvent.keyboard("[Enter]");
+    });
+
+    let menu = wrapper.queryByRole("menu");
+
+    expect(menu).toBeTruthy();
+
+    let menuItems = wrapper.getAllByRole("menuitemradio");
+
+    expect(menuItems.length).toBe(4);
+
+    expect(menuItems[0]).toHaveFocus();
+  });
+
+  it("should focus on the first item on keyDown (Space)", async () => {
+    const wrapper = render(
+      <Dropdown>
+        <DropdownTrigger>
+          <Button data-testid="trigger-test">Trigger</Button>
+        </DropdownTrigger>
+        <DropdownMenu disallowEmptySelection aria-label="Actions" selectionMode="single">
+          <DropdownItem key="new">New file</DropdownItem>
+          <DropdownItem key="copy">Copy link</DropdownItem>
+          <DropdownItem key="edit">Edit file</DropdownItem>
+          <DropdownItem key="delete" color="danger">
+            Delete file
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    act(() => {
+      triggerButton.focus();
+    });
+
+    expect(triggerButton).toHaveFocus();
+
+    await act(async () => {
+      await userEvent.keyboard("[Space]");
+    });
+
+    let menu = wrapper.queryByRole("menu");
+
+    expect(menu).toBeTruthy();
+
+    let menuItems = wrapper.getAllByRole("menuitemradio");
+
+    expect(menuItems.length).toBe(4);
+
+    expect(menuItems[0]).toHaveFocus();
+  });
+});

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import {act, render} from "@testing-library/react";
+import {act, render, fireEvent} from "@testing-library/react";
 import {Button} from "@nextui-org/button";
 import userEvent from "@testing-library/user-event";
+import {keyCodes} from "@nextui-org/test-utils";
 import {User} from "@nextui-org/user";
 import {Image} from "@nextui-org/image";
 import {Avatar} from "@nextui-org/avatar";
@@ -565,9 +566,7 @@ describe("Keyboard interactions", () => {
 
     expect(triggerButton).toHaveFocus();
 
-    await act(async () => {
-      await userEvent.keyboard("[Enter]");
-    });
+    fireEvent.keyDown(triggerButton, {key: "Enter", charCode: keyCodes.Enter});
 
     let menu = wrapper.queryByRole("menu");
 
@@ -605,9 +604,7 @@ describe("Keyboard interactions", () => {
 
     expect(triggerButton).toHaveFocus();
 
-    await act(async () => {
-      await userEvent.keyboard("[Space]");
-    });
+    fireEvent.keyDown(triggerButton, {key: " ", charCode: keyCodes.Space});
 
     let menu = wrapper.queryByRole("menu");
 

--- a/packages/components/dropdown/package.json
+++ b/packages/components/dropdown/package.json
@@ -59,6 +59,7 @@
     "@nextui-org/user": "workspace:*",
     "@nextui-org/image": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
+    "@nextui-org/test-utils": "workspace:*",
     "framer-motion": "^11.0.22",
     "clean-package": "2.2.0",
     "react": "^18.0.0",

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -146,7 +146,6 @@ export function useDropdown(props: UseDropdownProps) {
         onAction: () => onMenuAction(props?.closeOnSelect),
         onClose: state.close,
       }),
-      autoFocus: state.focusStrategy || true,
     } as MenuProps;
   };
 

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -144,6 +144,7 @@ export function useDropdown(props: UseDropdownProps) {
         onAction: () => onMenuAction(props?.closeOnSelect),
         onClose: state.close,
       }),
+      autoFocus: "first",
     } as MenuProps;
   };
 

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -126,7 +126,7 @@ export function useDropdown(props: UseDropdownProps) {
   ) => {
     // These props are not needed for the menu trigger since it is handled by the popover trigger.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {onKeyDown, onPress, onPressStart, ...otherMenuTriggerProps} = menuTriggerProps;
+    const {onPress, onPressStart, ...otherMenuTriggerProps} = menuTriggerProps;
 
     return {
       ...mergeProps(otherMenuTriggerProps, {isDisabled}, originalProps),
@@ -146,7 +146,7 @@ export function useDropdown(props: UseDropdownProps) {
         onAction: () => onMenuAction(props?.closeOnSelect),
         onClose: state.close,
       }),
-      autoFocus: "first",
+      autoFocus: state.focusStrategy || true,
     } as MenuProps;
   };
 

--- a/packages/components/menu/src/use-menu.ts
+++ b/packages/components/menu/src/use-menu.ts
@@ -119,11 +119,11 @@ export function useMenu<T extends object>(props: UseMenuProps<T>) {
   const domRef = useDOMRef(ref);
   const shouldFilterDOMProps = typeof Component === "string";
 
-  const innerState = useTreeState({...otherProps, children});
+  const innerState = useTreeState({...otherProps, ...userMenuProps, children});
 
   const state = propState || innerState;
 
-  const {menuProps} = useAriaMenu(otherProps, state, domRef);
+  const {menuProps} = useAriaMenu({...otherProps, ...userMenuProps}, state, domRef);
 
   const slots = useMemo(() => menu({className}), [className]);
   const baseStyles = clsx(classNames?.base, className);
@@ -144,9 +144,7 @@ export function useMenu<T extends object>(props: UseMenuProps<T>) {
     return {
       "data-slot": "list",
       className: slots.list({class: classNames?.list}),
-      ...userMenuProps,
       ...menuProps,
-
       ...props,
     };
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1468,6 +1468,9 @@ importers:
       '@nextui-org/system':
         specifier: workspace:*
         version: link:../../core/system
+      '@nextui-org/test-utils':
+        specifier: workspace:*
+        version: link:../../utilities/test-utils
       '@nextui-org/theme':
         specifier: workspace:*
         version: link:../../core/theme
@@ -5967,10 +5970,6 @@ packages:
     peerDependencies:
       '@effect-ts/otel-node': '*'
     peerDependenciesMeta:
-      '@effect-ts/core':
-        optional: true
-      '@effect-ts/otel':
-        optional: true
       '@effect-ts/otel-node':
         optional: true
     dependencies:
@@ -22464,9 +22463,6 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
-    peerDependenciesMeta:
-      '@parcel/core':
-        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(typescript@4.9.5)
       '@parcel/core': 2.12.0


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2863

## 📝 Description

As the doc stated, when keydown (press /enter) on the trigger, the first menu item should be focused. This PR is to cover this missing behaviour. 

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved keyboard accessibility in dropdown menus: now focuses on the first item when opened with Space or Enter keys.
	- Added `@nextui-org/test-utils` as a dependency for the dropdown component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->