### PR TITLE
fix: show `errorMessage` for inputs without having to pass `isInvalid`

### DIFF
--- a/packages/components/checkbox/src/checkbox-group.tsx
+++ b/packages/components/checkbox/src/checkbox-group.tsx
@@ -29,9 +29,9 @@ const CheckboxGroup = forwardRef<"div", CheckboxGroupProps>((props, ref) => {
       <div {...getWrapperProps()}>
         <CheckboxGroupProvider value={context}>{children}</CheckboxGroupProvider>
       </div>
-      {isInvalid && errorMessageContent ? (
+      {errorMessageContent ? (
         <div {...getErrorMessageProps()}>{errorMessageContent}</div>
-      ) : description ? (
+      ) : isInvalid && description ? (
         <div {...getDescriptionProps()}>{description}</div>
       ) : null}
     </div>

--- a/packages/components/checkbox/src/checkbox-group.tsx
+++ b/packages/components/checkbox/src/checkbox-group.tsx
@@ -21,7 +21,7 @@ const CheckboxGroup = forwardRef<"div", CheckboxGroupProps>((props, ref) => {
     getErrorMessageProps,
   } = useCheckboxGroup({...props, ref});
 
-  const errorMessageContent = useMemo(() => errorMessage, [isInvalid]);
+  const errorMessageContent = useMemo(() => errorMessage, [errorMessage, isInvalid]);
 
   return (
     <div {...getGroupProps()}>
@@ -31,7 +31,7 @@ const CheckboxGroup = forwardRef<"div", CheckboxGroupProps>((props, ref) => {
       </div>
       {errorMessageContent ? (
         <div {...getErrorMessageProps()}>{errorMessageContent}</div>
-      ) : isInvalid && description ? (
+      ) : description ? (
         <div {...getDescriptionProps()}>{description}</div>
       ) : null}
     </div>

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -19,7 +19,6 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
     isOutsideLeft,
     shouldLabelBeOutside,
     errorMessage,
-    isInvalid,
     getBaseProps,
     getLabelProps,
     getInputProps,
@@ -49,14 +48,13 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
       <div {...getHelperWrapperProps()}>
         {errorMessage ? (
           <div {...getErrorMessageProps()}>{errorMessage}</div>
-        ) : isInvalid && description ? (
+        ) : description ? (
           <div {...getDescriptionProps()}>{description}</div>
         ) : null}
       </div>
     );
   }, [
     hasHelper,
-    isInvalid,
     errorMessage,
     description,
     getHelperWrapperProps,

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -47,9 +47,9 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
 
     return (
       <div {...getHelperWrapperProps()}>
-        {isInvalid && errorMessage ? (
+        {errorMessage ? (
           <div {...getErrorMessageProps()}>{errorMessage}</div>
-        ) : description ? (
+        ) : isInvalid && description ? (
           <div {...getDescriptionProps()}>{description}</div>
         ) : null}
       </div>

--- a/packages/components/input/src/textarea.tsx
+++ b/packages/components/input/src/textarea.tsx
@@ -78,7 +78,6 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
       hasHelper,
       shouldLabelBeOutside,
       shouldLabelBeInside,
-      isInvalid,
       errorMessage,
       getBaseProps,
       getLabelProps,
@@ -147,7 +146,7 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
           <div {...getHelperWrapperProps()}>
             {errorMessage ? (
               <div {...getErrorMessageProps()}>{errorMessage}</div>
-            ) : isInvalid && description ? (
+            ) : description ? (
               <div {...getDescriptionProps()}>{description}</div>
             ) : null}
           </div>

--- a/packages/components/input/src/textarea.tsx
+++ b/packages/components/input/src/textarea.tsx
@@ -145,9 +145,9 @@ const Textarea = forwardRef<"textarea", TextAreaProps>(
         </div>
         {hasHelper ? (
           <div {...getHelperWrapperProps()}>
-            {isInvalid && errorMessage ? (
+            {errorMessage ? (
               <div {...getErrorMessageProps()}>{errorMessage}</div>
-            ) : description ? (
+            ) : isInvalid && description ? (
               <div {...getDescriptionProps()}>{description}</div>
             ) : null}
           </div>

--- a/packages/components/input/stories/input.stories.tsx
+++ b/packages/components/input/stories/input.stories.tsx
@@ -632,7 +632,6 @@ export const WithErrorMessage = {
 
   args: {
     ...defaultProps,
-    isInvalid: true,
     errorMessage: "Please enter a valid email address",
   },
 };

--- a/packages/components/radio/src/radio-group.tsx
+++ b/packages/components/radio/src/radio-group.tsx
@@ -27,9 +27,9 @@ const RadioGroup = forwardRef<"div", RadioGroupProps>((props, ref) => {
       <div {...getWrapperProps()}>
         <RadioGroupProvider value={context}>{children}</RadioGroupProvider>
       </div>
-      {isInvalid && errorMessage ? (
+      {errorMessage ? (
         <div {...getErrorMessageProps()}>{errorMessage}</div>
-      ) : description ? (
+      ) : isInvalid && description ? (
         <div {...getDescriptionProps()}>{description}</div>
       ) : null}
     </Component>

--- a/packages/components/radio/src/radio-group.tsx
+++ b/packages/components/radio/src/radio-group.tsx
@@ -12,7 +12,6 @@ const RadioGroup = forwardRef<"div", RadioGroupProps>((props, ref) => {
     label,
     context,
     description,
-    isInvalid,
     errorMessage,
     getGroupProps,
     getLabelProps,
@@ -29,7 +28,7 @@ const RadioGroup = forwardRef<"div", RadioGroupProps>((props, ref) => {
       </div>
       {errorMessage ? (
         <div {...getErrorMessageProps()}>{errorMessage}</div>
-      ) : isInvalid && description ? (
+      ) : description ? (
         <div {...getDescriptionProps()}>{description}</div>
       ) : null}
     </Component>

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -59,7 +59,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
       <div {...getHelperWrapperProps()}>
         {errorMessage ? (
           <div {...getErrorMessageProps()}>{errorMessage}</div>
-        ) : isInvalid && description ? (
+        ) : description ? (
           <div {...getDescriptionProps()}>{description}</div>
         ) : null}
       </div>

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -57,9 +57,9 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
 
     return (
       <div {...getHelperWrapperProps()}>
-        {isInvalid && errorMessage ? (
+        {errorMessage ? (
           <div {...getErrorMessageProps()}>{errorMessage}</div>
-        ) : description ? (
+        ) : isInvalid && description ? (
           <div {...getDescriptionProps()}>{description}</div>
         ) : null}
       </div>


### PR DESCRIPTION
Closes https://github.com/nextui-org/nextui/issues/2835

If user provides an errorMessage to an input, the input is invalid, there is no need to ask the user to also pass the `isInvalid` prop

This change was introduced here: https://github.com/nextui-org/nextui/commit/f724509c83ce1586f08ac1042ccacb7ce54cbe83

This was a breaking change introduced 2 weeks ago

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the conditional rendering logic across various components to improve the visibility of error messages and descriptions. Error messages will now display whenever present, and descriptions will only show when relevant and the component is in an invalid state. This change affects:
		- Checkbox groups
		- Input fields
		- Text areas
		- Radio groups
		- Select dropdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->