### PR TITLE
fix: Corrected invalid TW style on Avatar

### DIFF
--- a/.changeset/two-eggs-give.md
+++ b/.changeset/two-eggs-give.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-correct avatar group based style
+correct avatar group-based style

--- a/.changeset/two-eggs-give.md
+++ b/.changeset/two-eggs-give.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+correct avatar group based style

--- a/packages/core/theme/src/components/avatar.ts
+++ b/packages/core/theme/src/components/avatar.ts
@@ -195,7 +195,7 @@ const avatar = tv({
  */
 const avatarGroup = tv({
   slots: {
-    base: "flex items-center justify-center h-auto w-max-content",
+    base: "flex items-center justify-center h-auto w-max",
     count: "hover:-translate-x-0",
   },
   variants: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> w-max-content doesn't exist, but w-max does. 👍

## ⛳️ Current behavior (updates)

> Tailwind doesn't have `w-max-content`, so it does nothing.

## 🚀 New behavior

> Fixed it to `w-max` allowing the correct behaviours.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information 

> Yes, this could be a breaking change in styling for existing NextUI users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
  - Improved layout consistency for avatar groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->