### PR TITLE
feat(docs): revise breaking changes content

### DIFF
--- a/apps/docs/content/blog/v2.3.0.mdx
+++ b/apps/docs/content/blog/v2.3.0.mdx
@@ -299,7 +299,7 @@ export function Providers({children}: ProvidersProps) {
 
 ### Removal of the `units` creation
 
-In order to improve the performance and reduce the bundle size, we have removed the `units` creation from the 
+To improve performance and reduce bundle size, we have removed the `units` creation from the 
 `nextui` plugin. [TailwindCSS v3.4](https://tailwindcss.com/blog/tailwindcss-v3-4) added support for `min-h-*` and `min-w-*` classes, so it is no longer needed.
 
 How to upgrade:
@@ -344,7 +344,7 @@ Due to this reason, the requirements for displaying error messages have become m
 
 How to upgrade:
 
-1. In order to display `errorMessage`, `isInvalid` has to be set to `true`. Therefore, you can add `isInvalid` props and set it to `true`.
+1. To display `errorMessage`, `isInvalid` must be set to `true`.
 
 ```diff-jsx
 <Input

--- a/apps/docs/content/blog/v2.3.0.mdx
+++ b/apps/docs/content/blog/v2.3.0.mdx
@@ -297,6 +297,8 @@ export function Providers({children}: ProvidersProps) {
 
 ## Breaking Changes
 
+### Removal of the `units` creation
+
 In order to improve the performance and reduce the bundle size, we have removed the `units` creation from the 
 `nextui` plugin. [TailwindCSS v3.4](https://tailwindcss.com/blog/tailwindcss-v3-4) added support for `min-h-*` and `min-w-*` classes, so it is no longer needed.
 
@@ -335,8 +337,28 @@ export const MyButton = () => {
 };
 ```
 
-That's it! Your project should now be using the latest version of TailwindCSS and NextUI.
+### Separation for `errorMessage` and `isInvalid`
 
+We are currently working on supporting multiple types of validation, including native HTML constraint validation, custom validation, and real-time validation. 
+Due to this reason, the requirements for displaying error messages have become more varied, and it is necessary to handle validation conditions separately from the `errorMessage`.
+
+How to upgrade:
+
+1. In order to display `errorMessage`, `isInvalid` has to be set to `true`. Therefore, you can add `isInvalid` props and set it to `true`.
+
+```diff-jsx
+<Input
+  type="email"
+  label="Email"
+  variant="bordered"
+  defaultValue="junior2nextui.org"
++ isInvalid={true}
+  errorMessage="Please enter a valid email"
+  className="max-w-xs"
+/>
+```
+
+That's it! Your project should now be using the latest version of TailwindCSS and NextUI.
 
 <Spacer y={4} />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
  - Enhanced performance and reduced bundle size by removing `units` creation from the `nextui` plugin, leveraging TailwindCSS v3.4 support for `min-h-*` and `min-w-*` classes.
  - Improved validation handling by separating `errorMessage` and `isInvalid`, allowing for more precise validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->