### PR TITLE
fix(theme): revise input isInvalid styles

### DIFF
--- a/.changeset/forty-adults-tan.md
+++ b/.changeset/forty-adults-tan.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+revise isInvalid input styles (#3007)

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -535,9 +535,9 @@ const input = tv({
       variant: "flat",
       class: {
         inputWrapper: [
-          "bg-danger-50",
-          "data-[hover=true]:bg-danger-100",
-          "group-data-[focus=true]:bg-danger-50",
+          "!bg-danger-50",
+          "data-[hover=true]:!bg-danger-100",
+          "group-data-[focus=true]:!bg-danger-50",
         ],
       },
     },
@@ -545,14 +545,14 @@ const input = tv({
       isInvalid: true,
       variant: "bordered",
       class: {
-        inputWrapper: "!border-danger group-data-[focus=true]:border-danger",
+        inputWrapper: "!border-danger group-data-[focus=true]:!border-danger",
       },
     },
     {
       isInvalid: true,
       variant: "underlined",
       class: {
-        inputWrapper: "after:bg-danger",
+        inputWrapper: "after:!bg-danger",
       },
     },
     // size & labelPlacement


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3007

## 📝 Description

revise input `isInvalid` styles

## ⛳️ Current behavior (updates)

if users have custom styles on input, when the input is isInvalid, some styles got overrode by the custom styles while some are using danger ones. 

![image](https://github.com/nextui-org/nextui/assets/35857179/51057b48-4b40-476b-9a24-51d6d51b519c)

## 🚀 New behavior

The original `isInvalid` styles should be applied. users can override them with important property if necessary.

![image](https://github.com/nextui-org/nextui/assets/35857179/0b3b8c14-318a-4518-b934-57faf3ac47ab)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved input styles for invalid states to address issue #3007, enhancing visual feedback for users during form validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->