### PR TITLE
feat(date-picker): add missing ref to input wrapper

### DIFF
--- a/.changeset/modern-eels-march.md
+++ b/.changeset/modern-eels-march.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-picker": patch
+---
+
+add missing ref to input wrapper (#3008)

--- a/packages/components/date-picker/src/use-date-range-picker.ts
+++ b/packages/components/date-picker/src/use-date-range-picker.ts
@@ -315,6 +315,7 @@ export function useDateRangePicker<T extends DateValue>({
 
   const getInputWrapperProps = (props = {}) => {
     return {
+      ref: domRef,
       ...props,
       ...groupProps,
       "data-slot": "input-wrapper",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3008

## 📝 Description

ref: https://react-spectrum.adobe.com/react-aria/useDateRangePicker.html#example

## ⛳️ Current behavior (updates)

currently there is no ref in the input wrapper, so internally `document.createTreeWalker` is called with an `undefined` root variable.

## 🚀 New behavior

adding the missing ref back. no error is shown. see the above reference. 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a missing reference issue in the date picker component, ensuring smoother functionality and addressing issue #3008.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->