### PR TITLE
fix: make VisuallyHidden's element type as span when it's inside phrasing element

### DIFF
--- a/.changeset/fluffy-seals-complain.md
+++ b/.changeset/fluffy-seals-complain.md
@@ -1,5 +1,0 @@
----
-"@nextui-org/checkbox": patch
----
-
-make VisuallyHidden's element type as span

--- a/.changeset/fluffy-seals-complain.md
+++ b/.changeset/fluffy-seals-complain.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/checkbox": patch
+---
+
+make VisuallyHidden's element type as span

--- a/.changeset/thick-frogs-jog.md
+++ b/.changeset/thick-frogs-jog.md
@@ -1,0 +1,8 @@
+---
+"@nextui-org/checkbox": patch
+"@nextui-org/radio": patch
+"@nextui-org/select": patch
+"@nextui-org/switch": patch
+---
+
+make the VisuallyHidden `elementType` as span when the default parent element accepts only phrasing elements

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -26,7 +26,7 @@ const Checkbox = forwardRef<"input", CheckboxProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...getInputProps()} />
       </VisuallyHidden>
       <span {...getWrapperProps()}>{clonedIcon}</span>

--- a/packages/components/radio/src/radio.tsx
+++ b/packages/components/radio/src/radio.tsx
@@ -22,7 +22,7 @@ const Radio = forwardRef<"input", RadioProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...getInputProps()} />
       </VisuallyHidden>
       <span {...getWrapperProps()}>

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -131,7 +131,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
             {startContent}
             <span {...getValueProps()}>
               {renderSelectedItem}
-              {state.selectedItems && <VisuallyHidden>,</VisuallyHidden>}
+              {state.selectedItems && <VisuallyHidden elementType="span">,</VisuallyHidden>}
             </span>
             {endContent}
           </div>

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -130,7 +130,9 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
           <div {...getInnerWrapperProps()}>
             {startContent}
             <span {...getValueProps()}>{renderSelectedItem}</span>
-            {endContent && state.selectedItems && <VisuallyHidden elementType="span">,</VisuallyHidden>}
+            {endContent && state.selectedItems && (
+              <VisuallyHidden elementType="span">,</VisuallyHidden>
+            )}
             {endContent}
           </div>
           {renderIndicator}

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -35,7 +35,7 @@ const Switch = forwardRef<"input", SwitchProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden>
+      <VisuallyHidden elementType="span">
         <input {...getInputProps()} />
       </VisuallyHidden>
       <span {...getWrapperProps()}>


### PR DESCRIPTION
## 📝 Description

The Checkbox has a `VisuallyHidden` component, that wraps the input. By default, it renders the `div` wrapper, but `div` is not allowed as a child of the `label` element (since `label` [accepts only phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#technical_summary))

## ⛳️ Current behavior (updates)

The Checkbox currently renders this content (with a child of the disallowed `div` type):

```html
<label>
  <div style="...">
    <input />
  </div>
  ...
</label>
```

## 🚀 New behavior

Now the Checkbox renders `span` instead of `div` for `VisuallyHidden`, which is the allowed child of the `label` element:

```html
<label>
  <span style="...">
    <input />
  </span>
  ...
</label>
```

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved accessibility by updating the `VisuallyHidden` component to use `elementType="span"` across Checkbox, Radio, Select, and Switch components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->