### PR TITLE
fix: error peerDep in pkg

### DIFF
--- a/.changeset/tidy-numbers-talk.md
+++ b/.changeset/tidy-numbers-talk.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/calendar": patch
+"@nextui-org/date-input": patch
+"@nextui-org/date-picker": patch
+---
+
+add the correct peerDep version

--- a/packages/components/calendar/package.json
+++ b/packages/components/calendar/package.json
@@ -34,8 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "@nextui-org/system": ">=2.0.0",
-    "@nextui-org/theme": ">=2.0.0",
+    "@nextui-org/system": ">=2.1.0",
+    "@nextui-org/theme": ">=2.2.0",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/components/date-input/package.json
+++ b/packages/components/date-input/package.json
@@ -34,8 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "@nextui-org/system": ">=2.0.0",
-    "@nextui-org/theme": ">=2.0.0",
+    "@nextui-org/system": ">=2.1.0",
+    "@nextui-org/theme": ">=2.2.0",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -34,8 +34,8 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "@nextui-org/system": ">=2.0.0",
-    "@nextui-org/theme": ">=2.0.0",
+    "@nextui-org/system": ">=2.1.0",
+    "@nextui-org/theme": ">=2.2.0",
     "react": ">=18",
     "react-dom": ">=18"
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->
#2954

## 📝 Description

The correct peerDep in pkg should include itself component export

And after thar will add doctor check in nextui-cli

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Updated peer dependencies for `@nextui-org/system` and `@nextui-org/theme` in calendar, date-input, and date-picker components to versions `>=2.1.0` and `>=2.2.0`, respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->