### PR TITLE
fix(slider): calculate the correct value on mark click

### DIFF
--- a/.changeset/olive-kids-hide.md
+++ b/.changeset/olive-kids-hide.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/slider": patch
+---
+
+calculate the correct value on mark click (#2980)

--- a/packages/components/slider/__tests__/slider.test.tsx
+++ b/packages/components/slider/__tests__/slider.test.tsx
@@ -287,4 +287,87 @@ describe("Slider", () => {
 
     expect(marks).toHaveLength(3);
   });
+
+  it("should move thumb after clicking mark (single thumb)", async function () {
+    const {getByRole, container} = render(
+      <Slider
+        hideThumb
+        defaultValue={0.2}
+        label="The Label"
+        marks={[
+          {
+            value: 0.2,
+            label: "20%",
+          },
+          {
+            value: 0.5,
+            label: "50%",
+          },
+          {
+            value: 0.8,
+            label: "80%",
+          },
+        ]}
+        maxValue={1}
+        minValue={0}
+        step={0.1}
+      />,
+    );
+
+    const marks = container.querySelectorAll("[data-slot='mark']");
+
+    expect(marks).toHaveLength(3);
+
+    await act(async () => {
+      await userEvent.click(marks[1]);
+    });
+
+    const slider = getByRole("slider");
+
+    expect(slider).toHaveProperty("value", "0.5");
+    expect(slider).toHaveAttribute("aria-valuetext", "0.5");
+  });
+
+  it("should move thumb after clicking mark (left and right thumbs)", async function () {
+    const {getAllByRole, container} = render(
+      <Slider
+        hideThumb
+        defaultValue={[0.2, 0.8]}
+        label="The Label"
+        marks={[
+          {
+            value: 0.2,
+            label: "20%",
+          },
+          {
+            value: 0.5,
+            label: "50%",
+          },
+          {
+            value: 0.8,
+            label: "80%",
+          },
+        ]}
+        maxValue={1}
+        minValue={0}
+        step={0.1}
+      />,
+    );
+
+    const marks = container.querySelectorAll("[data-slot='mark']");
+
+    expect(marks).toHaveLength(3);
+
+    await act(async () => {
+      await userEvent.click(marks[1]);
+    });
+
+    const [leftSlider, rightSlider] = getAllByRole("slider");
+
+    expect(leftSlider).toHaveProperty("value", "0.5");
+    expect(leftSlider).toHaveAttribute("aria-valuetext", "0.5");
+
+    expect(rightSlider).toHaveProperty("value", "0.8");
+    expect(rightSlider).toHaveAttribute("aria-valuetext", "0.8");
+  });
 });

--- a/packages/components/slider/__tests__/slider.test.tsx
+++ b/packages/components/slider/__tests__/slider.test.tsx
@@ -213,78 +213,78 @@ describe("Slider", () => {
 
     expect(setValues).toStrictEqual([[15, 25]]);
   });
-});
 
-it("should supports hideThumb", async function () {
-  const {container} = render(<Slider hideThumb defaultValue={20} label="The Label" />);
+  it("should supports hideThumb", async function () {
+    const {container} = render(<Slider hideThumb defaultValue={20} label="The Label" />);
 
-  const track = container.querySelector("[data-slot='track']");
+    const track = container.querySelector("[data-slot='track']");
 
-  expect(track).toHaveAttribute("data-thumb-hidden", "true");
-});
+    expect(track).toHaveAttribute("data-thumb-hidden", "true");
+  });
 
-it("should supports marks", async function () {
-  const {container} = render(
-    <Slider
-      hideThumb
-      defaultValue={20}
-      label="The Label"
-      marks={[
-        {
-          value: 0.2,
-          label: "20%",
-        },
-        {
-          value: 0.5,
-          label: "50%",
-        },
-        {
-          value: 0.8,
-          label: "80%",
-        },
-      ]}
-      maxValue={1}
-      minValue={0}
-      step={0.1}
-    />,
-  );
+  it("should supports marks", async function () {
+    const {container} = render(
+      <Slider
+        hideThumb
+        defaultValue={20}
+        label="The Label"
+        marks={[
+          {
+            value: 0.2,
+            label: "20%",
+          },
+          {
+            value: 0.5,
+            label: "50%",
+          },
+          {
+            value: 0.8,
+            label: "80%",
+          },
+        ]}
+        maxValue={1}
+        minValue={0}
+        step={0.1}
+      />,
+    );
 
-  const marks = container.querySelectorAll("[data-slot='mark']");
+    const marks = container.querySelectorAll("[data-slot='mark']");
 
-  expect(marks).toHaveLength(3);
-});
+    expect(marks).toHaveLength(3);
+  });
 
-it("should supports marks with hideThumb", async function () {
-  const {container} = render(
-    <Slider
-      hideThumb
-      defaultValue={20}
-      label="The Label"
-      marks={[
-        {
-          value: 0.2,
-          label: "20%",
-        },
-        {
-          value: 0.5,
-          label: "50%",
-        },
-        {
-          value: 0.8,
-          label: "80%",
-        },
-      ]}
-      maxValue={1}
-      minValue={0}
-      step={0.1}
-    />,
-  );
+  it("should supports marks with hideThumb", async function () {
+    const {container} = render(
+      <Slider
+        hideThumb
+        defaultValue={20}
+        label="The Label"
+        marks={[
+          {
+            value: 0.2,
+            label: "20%",
+          },
+          {
+            value: 0.5,
+            label: "50%",
+          },
+          {
+            value: 0.8,
+            label: "80%",
+          },
+        ]}
+        maxValue={1}
+        minValue={0}
+        step={0.1}
+      />,
+    );
 
-  const track = container.querySelector("[data-slot='track']");
+    const track = container.querySelector("[data-slot='track']");
 
-  expect(track).toHaveAttribute("data-thumb-hidden", "true");
+    expect(track).toHaveAttribute("data-thumb-hidden", "true");
 
-  const marks = container.querySelectorAll("[data-slot='mark']");
+    const marks = container.querySelectorAll("[data-slot='mark']");
 
-  expect(marks).toHaveLength(3);
+    expect(marks).toHaveLength(3);
+  });
 });

--- a/packages/components/slider/src/use-slider.ts
+++ b/packages/components/slider/src/use-slider.ts
@@ -399,14 +399,14 @@ export function useSlider(originalProps: UseSliderProps) {
         if (state.values.length === 1) {
           state.setThumbPercent(0, percent);
         } else {
-          const leftThumbPos = state.values[0];
-          const rightThumbPos = state.values[1];
+          const leftThumbVal = state.values[0];
+          const rightThumbVal = state.values[1];
 
-          if (mark.value < leftThumbPos) {
+          if (mark.value < leftThumbVal) {
             state.setThumbPercent(0, percent);
-          } else if (mark.value > rightThumbPos) {
+          } else if (mark.value > rightThumbVal) {
             state.setThumbPercent(1, percent);
-          } else if (Math.abs(mark.value - leftThumbPos) < Math.abs(mark.value - rightThumbPos)) {
+          } else if (Math.abs(mark.value - leftThumbVal) < Math.abs(mark.value - rightThumbVal)) {
             state.setThumbPercent(0, percent);
           } else {
             state.setThumbPercent(1, percent);

--- a/packages/components/slider/src/use-slider.ts
+++ b/packages/components/slider/src/use-slider.ts
@@ -389,6 +389,30 @@ export function useSlider(originalProps: UseSliderProps) {
       style: {
         [isVertical ? "bottom" : direction === "rtl" ? "right" : "left"]: `${percent * 100}%`,
       },
+      // avoid `onDownTrack` is being called since when you click the mark,
+      // `onDownTrack` will calculate the percent based on the position you click
+      // the calculated value will be set instead of the actual value defined in `marks`
+      onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+      onPointerDown: (e: React.PointerEvent) => e.stopPropagation(),
+      onClick: (e: any) => {
+        e.stopPropagation();
+        if (state.values.length === 1) {
+          state.setThumbPercent(0, percent);
+        } else {
+          const leftThumbPos = state.values[0];
+          const rightThumbPos = state.values[1];
+
+          if (mark.value < leftThumbPos) {
+            state.setThumbPercent(0, percent);
+          } else if (mark.value > rightThumbPos) {
+            state.setThumbPercent(1, percent);
+          } else if (Math.abs(mark.value - leftThumbPos) < Math.abs(mark.value - rightThumbPos)) {
+            state.setThumbPercent(0, percent);
+          } else {
+            state.setThumbPercent(1, percent);
+          }
+        }
+      },
     };
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2980

## 📝 Description

In react aria, the click on track on `onDownTrack` would calculate the percent based on the position of the click. However, when we click the mark, it should jump to the corresponding value defined in `marks` prop.

## ⛳️ Current behavior (updates)

see the video in linked issue

## 🚀 New behavior

[pr3017-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/cc64533c-f9e9-4c85-9be1-b8866a821448)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Resolved issue with calculating the correct value on mark click for the slider component.

- **Tests**
  - Improved and expanded test cases for the slider component, including scenarios for `hideThumb`, `marks`, and thumb movement after clicking a mark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->