### PR TITLE
fix(core): incorrect tailwind classnames

### DIFF
--- a/.changeset/giant-avocados-type.md
+++ b/.changeset/giant-avocados-type.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/system-rsc": patch
+"@nextui-org/theme": patch
+---
+
+fix incorrect tailwind classnames

--- a/packages/core/system-rsc/test-utils/slots-component.tsx
+++ b/packages/core/system-rsc/test-utils/slots-component.tsx
@@ -15,7 +15,7 @@ const card = tv({
       "flex-col",
       "relative",
       "overflow-hidden",
-      "height-auto",
+      "h-auto",
       "outline-none",
       "text-foreground",
       "box-border",

--- a/packages/core/theme/src/components/avatar.ts
+++ b/packages/core/theme/src/components/avatar.ts
@@ -195,7 +195,7 @@ const avatar = tv({
  */
 const avatarGroup = tv({
   slots: {
-    base: "flex items-center justify-center h-auto w-max-content",
+    base: "flex items-center justify-center h-auto w-max",
     count: "hover:-translate-x-0",
   },
   variants: {

--- a/packages/core/theme/src/components/card.ts
+++ b/packages/core/theme/src/components/card.ts
@@ -24,7 +24,7 @@ const card = tv({
       "flex-col",
       "relative",
       "overflow-hidden",
-      "height-auto",
+      "h-auto",
       "outline-none",
       "text-foreground",
       "box-border",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected incorrect Tailwind classnames in the `@nextui-org/system-rsc` and `@nextui-org/theme` packages to ensure proper styling.
  - Updated CSS classes in various components to use the correct Tailwind shorthand for consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->