### PR TITLE
fix(table): v2 input/textarea don't allow spaces inside a table

### DIFF
--- a/.changeset/tidy-coins-call.md
+++ b/.changeset/tidy-coins-call.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": patch
+---
+
+set `onKeyDownCapture` to `undefined` so that users can type with spaces in input or textarea inside a table component (#1968)

--- a/packages/components/table/src/use-table.ts
+++ b/packages/components/table/src/use-table.ts
@@ -269,6 +269,9 @@ export function useTable<T extends object>(originalProps: UseTableProps<T>) {
         }),
         props,
       ),
+      // avoid typeahead debounce wait for input / textarea
+      // so that typing with space won't be blocked
+      onKeyDownCapture: undefined,
       ref: domRef,
       className: slots.table({class: clsx(classNames?.table, props?.className)}),
     }),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1968

## 📝 Description

In react aria, there is a timeout for typeahead debounce wait on key down when `keyboardDelegate.getKeyForSearch` is `true`. In table, we don't need such selection so setting it to undefined.

## ⛳️ Current behavior (updates)

The spacebar press works only when

- it is the first input after selecting the textarea
- it is the first input after pausing for ~1 second
- the previous input was a spacebar press

## 🚀 New behavior

[pr3020.webm](https://github.com/nextui-org/nextui/assets/35857179/11200700-3caf-4a1e-8168-ffaccb8bc2ab)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue that prevented users from typing spaces in input or textarea fields within a table component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->