### PR TITLE
Update dependency array on setPage useCallback hook

### DIFF
--- a/packages/hooks/use-pagination/src/index.ts
+++ b/packages/hooks/use-pagination/src/index.ts
@@ -82,7 +82,7 @@ export function usePagination(props: UsePaginationProps) {
         onChangeActivePage(pageNumber);
       }
     },
-    [total, activePage],
+    [total, activePage, onChangeActivePage],
   );
 
   const next = () => (isRTL ? setPage(activePage - 1) : setPage(activePage + 1));


### PR DESCRIPTION
Changes:


Impact:
This fix ensures that the pagination component accurately reflects the current state when triggering onChangeActivePage.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Add the onChangeActivePage function to the dependency array of the setPage useCallback hook to ensure it always reflects the latest state.

## ⛳️ Current behavior (updates)

Currently, state is memoized during onChangeActivePage after page changes, meaning that writing onChangeActivePage handlers do not always contain current state. This was causing issues with hooks such as useSearchParams, where the search params would not be fully up-to-date

## 🚀 New behavior

Adding onChangeActivePage to the callback dependencies ensures state is refreshed.

## 💣 Is this a breaking change (Yes/No):

Should not break anything.

## 📝 Additional Information
