### PR TITLE
fix(hooks): optimize useScrollPosition with useCallback and useRef

### DIFF
--- a/.changeset/lucky-cobras-jog.md
+++ b/.changeset/lucky-cobras-jog.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/use-scroll-position": major
+"@nextui-org/use-scroll-position": patch
 ---
 
 WHAT: Refactored the useScrollPosition hook to improve performance and stability by using useCallback for the handler function and useRef for throttleTimeout.

--- a/.changeset/lucky-cobras-jog.md
+++ b/.changeset/lucky-cobras-jog.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-scroll-position": major
+---
+
+WHAT: Refactored the useScrollPosition hook to improve performance and stability by using useCallback for the handler function and useRef for throttleTimeout.

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -77,7 +77,7 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
         clearTimeout(throttleTimeout.current);
       }
     };
-  }, [elementRef?.current, delay, isEnabled]);
+  }, [elementRef?.current, delay, handler, isEnabled]);
 
   return position.current;
 };

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -60,9 +60,7 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
     const handleScroll = () => {
       if (delay) {
         if (throttleTimeout.current === null) {
-          throttleTimeout.current = setTimeout(() => {
-            handler();
-          }, delay);
+          throttleTimeout.current = setTimeout(handler, delay);
         }
       } else {
         handler();

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -1,8 +1,8 @@
-import {useRef, useEffect} from "react";
+import {useRef, useEffect, useCallback} from "react";
 
 const isBrowser = typeof window !== "undefined";
 
-export type ScrollValue = {x: any; y: any};
+export type ScrollValue = {x: number; y: number};
 
 function getScrollPosition(element: HTMLElement | undefined | null): ScrollValue {
   if (!isBrowser) return {x: 0, y: 0};
@@ -41,9 +41,9 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
     isEnabled ? getScrollPosition(elementRef?.current) : {x: 0, y: 0},
   );
 
-  let throttleTimeout: ReturnType<typeof setTimeout> | null = null;
+  const throttleTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handler = () => {
+  const handler = useCallback(() => {
     const currPos = getScrollPosition(elementRef?.current);
 
     if (typeof callback === "function") {
@@ -51,16 +51,18 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
     }
 
     position.current = currPos;
-    throttleTimeout = null;
-  };
+    throttleTimeout.current = null;
+  }, [callback, elementRef]);
 
   useEffect(() => {
     if (!isEnabled) return;
 
     const handleScroll = () => {
       if (delay) {
-        if (throttleTimeout === null) {
-          throttleTimeout = setTimeout(handler, delay);
+        if (throttleTimeout.current === null) {
+          throttleTimeout.current = setTimeout(() => {
+            handler();
+          }, delay);
         }
       } else {
         handler();
@@ -71,7 +73,12 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
 
     target.addEventListener("scroll", handleScroll);
 
-    return () => target.removeEventListener("scroll", handleScroll);
+    return () => {
+      target.removeEventListener("scroll", handleScroll);
+      if (throttleTimeout.current) {
+        clearTimeout(throttleTimeout.current);
+      }
+    };
   }, [elementRef?.current, delay, isEnabled]);
 
   return position.current;


### PR DESCRIPTION
## 📝 Description

Refactored the useScrollPosition hook to improve performance and stability by using useCallback for the handler function and useRef for throttleTimeout.

## ⛳️ Current behavior (updates)

The current implementation of the useScrollPosition hook:
- Uses a local variable for throttleTimeout, which may cause issues with maintaining state between renders, leading to potential memory leaks and redundant timeout calls.
- Does not use useCallback for the handler function, which can lead to unnecessary re-renders as the handler function reference changes on each render.
- Event listeners might not be properly cleaned up, potentially causing multiple listeners to accumulate over time, which can degrade performance.

## 🚀 New behavior

- Wrapped the handler function with useCallback to ensure it does not cause unnecessary re-renders and always uses the latest values.
- Used useRef for throttleTimeout to maintain its value between renders and avoid resetting the timeout on every render.
- Added cleanup for throttleTimeout in useEffect's return function to prevent potential memory leaks.
- Ensured that event listeners are properly added and removed to avoid redundant event handlers.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

These changes enhance the performance and stability of the useScrollPosition hook without introducing breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Enhanced the `useScrollPosition` hook for better performance and reliability by utilizing `useCallback` and `useRef`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->