### PR TITLE
fix(date-picker): corrected inert value for true condition #3044

### DIFF
--- a/packages/components/calendar/src/calendar-month.tsx
+++ b/packages/components/calendar/src/calendar-month.tsx
@@ -41,7 +41,7 @@ export function CalendarMonth(props: CalendarMonthProps) {
       data-slot="grid-body-row"
       // makes the browser ignore the element and its children when tabbing
       // @ts-ignore
-      inert={isHeaderExpanded ? true : undefined}
+      inert={isHeaderExpanded ? "" : undefined}
     >
       {state
         .getDatesInWeek(weekIndex, startDate)

--- a/packages/components/calendar/src/calendar-picker.tsx
+++ b/packages/components/calendar/src/calendar-picker.tsx
@@ -67,7 +67,7 @@ export function CalendarPicker(props: CalendarPickerProps) {
       data-slot="picker-wrapper"
       // makes the browser ignore the element and its children when tabbing
       // @ts-ignore
-      inert={isHeaderExpanded ? true : undefined}
+      inert={isHeaderExpanded ? undefined : ""}
     >
       <div
         ref={highlightRef}


### PR DESCRIPTION
Closes #3044

## 📝 Description

- The value of inert is set to true when `inert=''` and to false when `inert=undefined`. Please do refer this https://github.com/facebook/react/issues/17157
- And also the condition for inert in `calendar-picker` should be opposite which is  `inert={isHeaderExpanded ? undefined : ""}` instead of `inert={isHeaderExpanded ? true : undefined}`

## ⛳️ Current behavior (updates)

- I did not face any scrolling issue, it worked fine for me.
- I got the following warnings in the console when the calendar month picker was opened.

![image](https://github.com/nextui-org/nextui/assets/8769408/e8858444-9765-4234-9f27-aafaf6f1f444)


## 🚀 New behavior
- `inert` property is set to correct value, could be verified from the properties tab.
- No warnings

## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information
If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.