### PR TITLE
fix:(input): label element displays incorrectly

### DIFF
--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -17,6 +17,7 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
     labelPlacement,
     hasHelper,
     isOutsideLeft,
+    isMultiline,
     shouldLabelBeOutside,
     errorMessage,
     isInvalid,
@@ -78,8 +79,9 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
     if (shouldLabelBeOutside) {
       return (
         <div {...getMainWrapperProps()}>
+          {!isOutsideLeft && isMultiline ? labelContent : null}
           <div {...getInputWrapperProps()}>
-            {!isOutsideLeft ? labelContent : null}
+            {!isOutsideLeft && !isMultiline ? labelContent : null}
             {innerWrapper}
           </div>
           {helperWrapper}

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -492,6 +492,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     hasStartContent,
     isLabelOutside,
     isOutsideLeft,
+    isMultiline,
     isLabelOutsideAsPlaceholder,
     shouldLabelBeOutside,
     shouldLabelBeInside,

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -826,6 +826,7 @@ const input = tv({
       isMultiline: true,
       class: {
         inputWrapper: "py-2",
+        label: "text-foreground",
       },
     },
     // isMultiline & labelPlacement="outside"

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -214,7 +214,7 @@ const input = tv({
       true: {
         label: "relative",
         inputWrapper: "!h-auto",
-        innerWrapper: "items-start group-data-[has-label=true]:items-start",
+        innerWrapper: "items-center group-data-[has-label=true]:items-center",
         input: "resize-none data-[hide-scroll=true]:scrollbar-hide",
       },
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

1. With `labelPlacement` set to `outside` and `isMultiline` set to `true`, the `label` element displays incorrectly.

![outside placement](https://github.com/nextui-org/nextui/assets/10345518/9b18f272-92db-4203-8b39-7898003baa2f)

2. The input element is not centered with the `endContent` element.

![CleanShot 2024-05-23 at 11 25 58@2x](https://github.com/nextui-org/nextui/assets/10345518/12795efe-764a-45a7-a9cf-63371127d557)

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Renamed the `isOutsideLeft` prop to `isLabelOutside` for improved labeling consistency.
  - Added a new `isMultiline` prop for multiline input support.

- **Enhancements**
  - Updated label placement logic to consider multiline inputs and start content.

- **Style**
  - Refined input component styles for improved layout and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->