### PR TITLE
fix(select): placeholder text display for controlled component

### DIFF
--- a/.changeset/proud-baboons-cough.md
+++ b/.changeset/proud-baboons-cough.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Fix: display placeholder text when unselected for controlled (#3062)

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -506,6 +506,47 @@ describe("Select", () => {
     // assert that the second select listbox is open
     expect(select2).toHaveAttribute("aria-expanded", "true");
   });
+
+  it("should display placeholder text when unselected", async () => {
+    const wrapper = render(
+      <Select
+        aria-label="Favorite Animal"
+        data-testid="test-select"
+        label="Favorite Animal"
+        placeholder="Select an animal"
+      >
+        <SelectItem key="penguin">Penguin</SelectItem>
+        <SelectItem key="zebra">Zebra</SelectItem>
+        <SelectItem key="shark">Shark</SelectItem>
+      </Select>,
+    );
+
+    const select = wrapper.getByTestId("test-select");
+
+    expect(select).toHaveTextContent("Select an animal");
+  });
+
+  it("should display placeholder text when unselected (controlled)", async () => {
+    const onSelectionChange = jest.fn();
+    const wrapper = render(
+      <Select
+        isOpen
+        aria-label="Favorite Animal"
+        data-testid="test-select"
+        placeholder="Select an animal"
+        selectedKeys={[]}
+        onSelectionChange={onSelectionChange}
+      >
+        <SelectItem key="penguin">Penguin</SelectItem>
+        <SelectItem key="zebra">Zebra</SelectItem>
+        <SelectItem key="shark">Shark</SelectItem>
+      </Select>,
+    );
+
+    const select = wrapper.getByTestId("test-select");
+
+    expect(select).toHaveTextContent("Select an animal");
+  });
 });
 
 describe("Select with React Hook Form", () => {

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -75,7 +75,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   ]);
 
   const renderSelectedItem = useMemo(() => {
-    if (!state.selectedItems) return placeholder;
+    if (!state.selectedItems?.length) return placeholder;
 
     if (renderValue && typeof renderValue === "function") {
       const mappedItems = [...state.selectedItems].map((item) => ({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/3062

## 📝 Description

Fixes the display of placeholder text when the Select component is unselected.

## ⛳️ Current behavior (updates)

Placeholder text is not displayed.

## 🚀 New behavior

Placeholder text is displayed correctly.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed issue with placeholder text not displaying correctly in the `Select` component when unselected in controlled components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->