### PR TITLE
fix(utilities): resolve TypeScript index signature issues in filterDOMProps

### DIFF
--- a/.changeset/fuzzy-goats-train.md
+++ b/.changeset/fuzzy-goats-train.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/react-rsc-utils": patch
+---
+
+WHAT: Previously, @ts-ignore was used to bypass type errors. 
+Refactor the filterDOMProps function to properly handle TypeScript index signature issues by introducing a new type alias, DOMAndAriaProps. 

--- a/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
+++ b/packages/utilities/react-rsc-utils/src/filter-dom-props.ts
@@ -37,16 +37,15 @@ const propRe = /^(data-.*)$/;
 const ariaRe = /^(aria-.*)$/;
 const funcRe = /^(on[A-Z].*)$/;
 
+type DOMAndAriaProps = DOMProps & AriaLabelingProps;
+
 /**
  * Filters out all props that aren't valid DOM props or defined via override prop obj.
  * @param props - The component props to be filtered.
  * @param opts - Props to override.
  */
-export function filterDOMProps(
-  props: DOMProps & AriaLabelingProps,
-  opts: Options = {},
-): DOMProps & AriaLabelingProps {
-  let {
+export function filterDOMProps(props: DOMAndAriaProps, opts: Options = {}): DOMAndAriaProps {
+  const {
     labelable = true,
     enabled = true,
     propNames,
@@ -55,7 +54,7 @@ export function filterDOMProps(
     omitDataProps,
     omitEventProps,
   } = opts;
-  let filteredProps = {};
+  const filteredProps: Partial<DOMAndAriaProps> = {};
 
   if (!enabled) {
     return props;
@@ -89,8 +88,7 @@ export function filterDOMProps(
           propRe.test(prop))) ||
       funcRe.test(prop)
     ) {
-      // @ts-ignore
-      filteredProps[prop] = props[prop];
+      filteredProps[prop as keyof DOMAndAriaProps] = props[prop as keyof DOMAndAriaProps];
     }
   }
 


### PR DESCRIPTION
## 📝 Description

Refactor the filterDOMProps function to properly handle TypeScript index signature issues by introducing a new type alias, DOMAndAriaProps. 
type assertions are used to ensure type safety without using @ts-ignore.

## ⛳️ Current behavior (updates)

- The function filterDOMProps uses @ts-ignore to bypass TypeScript index signature issues.

## 🚀 New behavior

- Removed @ts-ignore by using type assertions to handle dynamic property access.
- Updated filterDOMProps to use DOMAndAriaProps for both props and filteredProps.

## 💣 Is this a breaking change (Yes/No):

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved TypeScript handling within the `@nextui-org/react-rsc-utils` package for better code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->