### PR TITLE
fix(datePicker): prevent year, month change in showMonthAndYearPickers mode

### DIFF
--- a/.changeset/tidy-squids-knock.md
+++ b/.changeset/tidy-squids-knock.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+fix hours, month clear issue in showMonthAndYearPickers mode.

--- a/.changeset/tidy-squids-knock.md
+++ b/.changeset/tidy-squids-knock.md
@@ -1,5 +1,6 @@
 ---
+"@nextui-org/calendar": patch
 "@nextui-org/date-picker": patch
 ---
 
-fix hours, month clear issue in showMonthAndYearPickers mode.
+fix hours, month clear issue in `showMonthAndYearPickers` mode (#3072).

--- a/.changeset/tidy-squids-knock.md
+++ b/.changeset/tidy-squids-knock.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/calendar": patch
+"@nextui-org/date-picker": patch
 ---
 
 fix hours, month clear issue in showMonthAndYearPickers mode.

--- a/packages/components/calendar/src/use-calendar-picker.ts
+++ b/packages/components/calendar/src/use-calendar-picker.ts
@@ -115,6 +115,8 @@ export function useCalendarPicker(props: CalendarPickerProps) {
 
   // scroll to the selected month/year when the component is mounted/opened/closed
   useEffect(() => {
+    if (!isHeaderExpanded) return;
+
     scrollTo(date.month, "months", false);
     scrollTo(date.year, "years", false);
   }, [isHeaderExpanded]);

--- a/packages/components/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-picker.test.tsx
@@ -475,7 +475,9 @@ describe("DatePicker", () => {
 
       expect(dialog).toBeVisible();
 
-      expect(getTextValue(combobox)).toBe("5/1/2024");
+      const content = getByRole("application");
+
+      expect(content).toHaveAttribute("aria-label", "May 2024");
     });
   });
 });

--- a/packages/components/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-picker.test.tsx
@@ -458,7 +458,7 @@ describe("DatePicker", () => {
       expect(getTextValue(combobox)).toBe("2/4/2019"); // uncontrolled
     });
 
-    it("should keep the selected date when the picker is toggled, in showMonthAndYearPickers mode", function () {
+    it("should keep the selected date when the picker is opened, in showMonthAndYearPickers mode", function () {
       const {getByRole, getAllByRole} = render(
         <DatePicker showMonthAndYearPickers label="Date" value={new CalendarDate(2024, 5, 1)} />,
       );
@@ -474,10 +474,6 @@ describe("DatePicker", () => {
       let dialog = getByRole("dialog");
 
       expect(dialog).toBeVisible();
-
-      triggerPress(button);
-
-      expect(dialog).not.toBeVisible();
 
       expect(getTextValue(combobox)).toBe("5/1/2024");
     });

--- a/packages/components/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-picker.test.tsx
@@ -457,5 +457,29 @@ describe("DatePicker", () => {
       expect(onChange).toHaveBeenCalledWith(new CalendarDate(2019, 2, 4));
       expect(getTextValue(combobox)).toBe("2/4/2019"); // uncontrolled
     });
+
+    it("should keep the selected date when the picker is toggled, in showMonthAndYearPickers mode", function () {
+      const {getByRole, getAllByRole} = render(
+        <DatePicker showMonthAndYearPickers label="Date" value={new CalendarDate(2024, 5, 1)} />,
+      );
+
+      let combobox = getAllByRole("group")[0];
+
+      expect(getTextValue(combobox)).toBe("5/1/2024");
+
+      let button = getByRole("button");
+
+      triggerPress(button);
+
+      let dialog = getByRole("dialog");
+
+      expect(dialog).toBeVisible();
+
+      triggerPress(button);
+
+      expect(dialog).not.toBeVisible();
+
+      expect(getTextValue(combobox)).toBe("5/1/2024");
+    });
   });
 });


### PR DESCRIPTION
## 📝 Description
> fix issue (https://github.com/nextui-org/nextui/issues/3072)
- There is an issue that the year and month change when repeatedly opening and closing the datePicker component in showMonthAndYearPickers mode.
- This issue occurs when opening and closing the datePicker, causing the month and year information to be lost and default values to be set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues with hours and month clearing in `showMonthAndYearPickers` mode for `@nextui-org/calendar` and `@nextui-org/date-picker` packages.
  - Ensured the selected date remains unchanged when the picker is toggled in `showMonthAndYearPickers` mode.

- **Improvements**
  - Added a conditional check to prevent unnecessary scrolling to the selected month/year when the calendar component is mounted/opened/closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->