### PR TITLE
fix(utilities): resolve assignRef TypeScript ref assignment issue

### DIFF
--- a/.changeset/violet-oranges-teach.md
+++ b/.changeset/violet-oranges-teach.md
@@ -2,4 +2,4 @@
 "@nextui-org/react-utils": patch
 ---
 
-WHAT: refactored the signRef function to remove @ts-ignore and properly handle reference assignment using MutableRefObject
+refactored the assignRef function to remove @ts-ignore and properly handle reference assignment using MutableRefObject

--- a/.changeset/violet-oranges-teach.md
+++ b/.changeset/violet-oranges-teach.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/react-utils": patch
+---
+
+WHAT: refactored the signRef function to remove @ts-ignore and properly handle reference assignment using MutableRefObject

--- a/packages/utilities/react-utils/src/refs.ts
+++ b/packages/utilities/react-utils/src/refs.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import {isFunction} from "@nextui-org/shared-utils";
+import {MutableRefObject} from "react";
 
 export type ReactRef<T> = React.RefObject<T> | React.MutableRefObject<T> | React.Ref<T>;
 
@@ -19,8 +20,7 @@ export function assignRef<T = any>(ref: ReactRef<T> | undefined, value: T) {
   }
 
   try {
-    // @ts-ignore
-    ref.current = value;
+    (ref as MutableRefObject<T>).current = value;
   } catch (error) {
     throw new Error(`Cannot assign value '${value}' to ref '${ref}'`);
   }


### PR DESCRIPTION
## 📝 Description

Refactor `assignRef` function to remove `@ts-ignore` and properly handle ref assignment using `MutableRefObject`.

## ⛳️ Current behavior (updates)

- Using `@ts-ignore` to bypass TypeScript error when assigning value to `ref.current`.

## 🚀 New behavior

- Refactored to use `(ref as MutableRefObject<T>).current = value` to properly assign value to ref without TypeScript errors.

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of reference assignments in the `@nextui-org/react-utils` package for better type safety and code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->