### PR TITLE
fix(radio): remove required attribute for Radio with validationBehavior="aria"

### DIFF
--- a/.changeset/sour-starfishes-lick.md
+++ b/.changeset/sour-starfishes-lick.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/radio": patch
+---
+
+Remove required attribute for Radio with validationBehavior="aria"

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -144,7 +144,7 @@ describe("Radio", () => {
     expect(onFocus).toBeCalled();
   });
 
-  it('should work correctly with "isRequired" prop', () => {
+  it("should have required attribute when isRequired with native validationBehavior", () => {
     const {getByRole, getAllByRole} = render(
       <RadioGroup isRequired label="Options" validationBehavior="native">
         <Radio value="1">Option 1</Radio>
@@ -159,6 +159,23 @@ describe("Radio", () => {
     const radios = getAllByRole("radio");
 
     expect(radios[0]).toHaveAttribute("required");
+  });
+
+  it("should not have required attribute when isRequired with aria validationBehavior", () => {
+    const {getByRole, getAllByRole} = render(
+      <RadioGroup isRequired label="Options" validationBehavior="aria">
+        <Radio value="1">Option 1</Radio>
+        <Radio value="2">Option 2</Radio>
+      </RadioGroup>,
+    );
+
+    const group = getByRole("radiogroup");
+
+    expect(group).toHaveAttribute("aria-required", "true");
+
+    const radios = getAllByRole("radio");
+
+    expect(radios[0]).not.toHaveAttribute("required");
   });
 
   it("should work correctly with controlled value", () => {

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -219,11 +219,11 @@ export function useRadio(props: UseRadioProps) {
     (props = {}) => {
       return {
         ref: inputRef,
-        ...mergeProps(props, inputProps, focusProps, {required: isRequired}),
+        ...mergeProps(props, inputProps, focusProps),
         onChange: chain(inputProps.onChange, onChange),
       };
     },
-    [inputProps, focusProps, isRequired, onChange],
+    [inputProps, focusProps, onChange],
   );
 
   const getLabelProps: PropGetter = useCallback(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Fixes the issue where the `required` attribute was added to Radio buttons when `validationBehavior` was set to `aria`.
RadioGroup already has `aria-required` added.

## ⛳️ Current behavior (updates)

Radio buttons have the `required` attribute even when `validationBehavior` is set to `aria`.

## 🚀 New behavior

Radio buttons no longer have the `required` attribute when `validationBehavior` is set to `aria`.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the required attribute for Radio components with validationBehavior set to "aria," ensuring better accessibility and validation behavior.

- **Tests**
  - Updated test cases to reflect changes in the "isRequired" prop and validation behavior for Radio components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->