### PR TITLE
fix(avatar): avoid passing `disableAnimation` prop to a DOM element

### DIFF
--- a/.changeset/hungry-garlics-kiss.md
+++ b/.changeset/hungry-garlics-kiss.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/avatar": patch
+---
+
+avoid passing `disableAnimation` prop to a DOM element (#3109)

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -1,11 +1,16 @@
 import type {AvatarSlots, AvatarVariantProps, SlotsToClasses} from "@nextui-org/theme";
 
 import {avatar} from "@nextui-org/theme";
-import {HTMLNextUIProps, PropGetter, useProviderContext} from "@nextui-org/system";
+import {
+  DOMAttributes,
+  DOMElement,
+  HTMLNextUIProps,
+  PropGetter,
+  useProviderContext,
+} from "@nextui-org/system";
 import {mergeProps} from "@react-aria/utils";
-import {useDOMRef} from "@nextui-org/react-utils";
+import {ReactRef, useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {clsx, safeText, dataAttr} from "@nextui-org/shared-utils";
-import {ReactRef} from "@nextui-org/react-utils";
 import {useFocusRing} from "@react-aria/focus";
 import {useMemo, useCallback} from "react";
 import {useImage} from "@nextui-org/use-image";
@@ -141,6 +146,8 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
 
   const isImgLoaded = imageStatus === "loaded";
 
+  const shouldFilterDOMProps = typeof ImgComponent === "string";
+
   /**
    * Fallback avatar applies under 2 conditions:
    * - If `src` was passed and the image has not loaded or failed to load
@@ -196,26 +203,20 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
   );
 
   const getImageProps = useCallback<PropGetter>(
-    (props = {}) => {
-      let allowDisableAnimation = false;
-
-      if (
-        typeof ImgComponent !== "string" &&
-        (ImgComponent as any)?.render?.displayName === "NextUI.Image"
-      ) {
-        allowDisableAnimation = true;
-      }
-
-      return {
-        ref: imgRef,
-        src: src,
-        ...(allowDisableAnimation && {disableAnimation}),
-        "data-loaded": dataAttr(isImgLoaded),
-        className: slots.img({class: classNames?.img}),
-        ...mergeProps(imgProps, props),
-      };
-    },
-    [slots, isImgLoaded, imgProps, disableAnimation, src, imgRef],
+    (props = {}) => ({
+      ref: imgRef,
+      src: src,
+      "data-loaded": dataAttr(isImgLoaded),
+      className: slots.img({class: classNames?.img}),
+      ...mergeProps(
+        imgProps,
+        props,
+        filterDOMProps({disableAnimation} as DOMAttributes<DOMElement>, {
+          enabled: shouldFilterDOMProps,
+        }),
+      ),
+    }),
+    [slots, isImgLoaded, imgProps, disableAnimation, src, imgRef, filterDOMProps],
   );
 
   return {

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -1,13 +1,8 @@
 import type {AvatarSlots, AvatarVariantProps, SlotsToClasses} from "@nextui-org/theme";
+import type {DOMElement, DOMAttributes, HTMLNextUIProps, PropGetter} from "@nextui-org/system";
 
 import {avatar} from "@nextui-org/theme";
-import {
-  DOMAttributes,
-  DOMElement,
-  HTMLNextUIProps,
-  PropGetter,
-  useProviderContext,
-} from "@nextui-org/system";
+import {useProviderContext} from "@nextui-org/system";
 import {mergeProps} from "@react-aria/utils";
 import {ReactRef, useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {clsx, safeText, dataAttr} from "@nextui-org/shared-utils";

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -196,14 +196,25 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
   );
 
   const getImageProps = useCallback<PropGetter>(
-    (props = {}) => ({
-      ref: imgRef,
-      src: src,
-      disableAnimation,
-      "data-loaded": dataAttr(isImgLoaded),
-      className: slots.img({class: classNames?.img}),
-      ...mergeProps(imgProps, props),
-    }),
+    (props = {}) => {
+      let allowDisableAnimation = false;
+
+      if (
+        typeof ImgComponent !== "string" &&
+        (ImgComponent as any)?.render?.displayName === "NextUI.Image"
+      ) {
+        allowDisableAnimation = true;
+      }
+
+      return {
+        ref: imgRef,
+        src: src,
+        ...(allowDisableAnimation && {disableAnimation}),
+        "data-loaded": dataAttr(isImgLoaded),
+        className: slots.img({class: classNames?.img}),
+        ...mergeProps(imgProps, props),
+      };
+    },
     [slots, isImgLoaded, imgProps, disableAnimation, src, imgRef],
   );
 

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -211,7 +211,7 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
         }),
       ),
     }),
-    [slots, isImgLoaded, imgProps, disableAnimation, src, imgRef, filterDOMProps],
+    [slots, isImgLoaded, imgProps, disableAnimation, src, imgRef, shouldFilterDOMProps],
   );
 
   return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3109

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in the avatar component to prevent passing the `disableAnimation` prop to a DOM element, ensuring better compatibility and performance.
  
- **Improvements**
  - Enhanced the avatar component with improved logic for filtering DOM properties based on the type of image component, leading to more robust and flexible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->