### PR TITLE
fix(pagination): missing animation in pagination

### DIFF
--- a/.changeset/famous-mice-approve.md
+++ b/.changeset/famous-mice-approve.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/pagination": patch
+---
+
+Fixed pagination missing animation (#3138)

--- a/packages/components/pagination/src/use-pagination.ts
+++ b/packages/components/pagination/src/use-pagination.ts
@@ -298,7 +298,8 @@ export function usePagination(originalProps: UsePaginationProps) {
     () =>
       pagination({
         ...variantProps,
-        disableCursorAnimation: disableCursorAnimation || disableAnimation,
+        disableAnimation,
+        disableCursorAnimation,
       }),
     [objectToDeps(variantProps), disableCursorAnimation, disableAnimation],
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3138

## 📝 Description

This PR only includes two changes

- the animation is missing because `disableAnimation` hasn't been passed to `pagination` tv. Therefore, just add it back.
- if `disableCursorAnimation` is not specified, `disableAnimation` will be used by default in L203. Therefore, `disableCursorAnimation: disableCursorAnimation || disableAnimation` can be simplified as `disableCursorAnimation`

## ⛳️ Current behavior (updates)

retrieved from the reported issue

[issue](https://github.com/nextui-org/nextui/assets/55749040/2963c0f1-5925-4d84-9751-d21ce114bb9c)

## 🚀 New behavior

[pr3144-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/76284d12-8169-43e6-afc6-05f5c7e32398)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved the issue of missing animation in pagination for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->