### PR TITLE
fix(select): unset form value after unselecting an item

### DIFF
--- a/.changeset/thirty-timers-press.md
+++ b/.changeset/thirty-timers-press.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+set empty string instead of undefined for unsetting value (#3156)

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -547,6 +547,75 @@ describe("Select", () => {
 
     expect(select).toHaveTextContent("Select an animal");
   });
+
+  it("should unset form value", async () => {
+    const logSpy = jest.spyOn(console, "log");
+
+    const user = userEvent.setup();
+
+    const wrapper = render(
+      <form
+        className="w-full max-w-xs items-end flex flex-col gap-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const formData = new FormData(e.target as HTMLFormElement);
+
+          /* eslint-disable no-console */
+          console.log(JSON.stringify(Object.fromEntries(formData)));
+        }}
+      >
+        <Select data-testid="select" label="test select" name="select" size="sm">
+          <SelectItem key="foo">foo</SelectItem>
+          <SelectItem key="bar">bar</SelectItem>
+        </Select>
+        <button data-testid="submit-button" type="submit">
+          Submit
+        </button>
+      </form>,
+    );
+
+    const select = wrapper.getByTestId("select");
+
+    expect(select).not.toBeNull();
+
+    await act(async () => {
+      await user.click(select);
+    });
+
+    let listbox = wrapper.getByRole("listbox");
+
+    expect(listbox).toBeTruthy();
+
+    let listboxItems = wrapper.getAllByRole("option");
+
+    expect(listboxItems.length).toBe(2);
+
+    await act(async () => {
+      await user.click(listboxItems[1]);
+    });
+
+    let submitButton = wrapper.getByTestId("submit-button");
+
+    await act(async () => {
+      await user.click(submitButton);
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({select: "bar"}));
+
+    await act(async () => {
+      await user.click(select);
+    });
+
+    await act(async () => {
+      await user.click(listboxItems[1]);
+    });
+
+    await act(async () => {
+      await user.click(submitButton);
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify({select: ""}));
+  });
 });
 
 describe("Select with React Hook Form", () => {

--- a/packages/components/select/src/hidden-select.tsx
+++ b/packages/components/select/src/hidden-select.tsx
@@ -113,7 +113,7 @@ export function useHiddenSelect<T>(
       value:
         selectionMode === "multiple"
           ? [...state.selectedKeys].map((k) => String(k))
-          : [...state.selectedKeys][0],
+          : [...state.selectedKeys][0] ?? "",
       multiple: selectionMode === "multiple",
       onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
         state.setSelectedKeys(e.target.value);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3156

## 📝 Description

as titled

## ⛳️ Current behavior (updates)

currently, when we unselect an item, the value will be undefined which won't match any option in the hidden select. Therefore, the previous selected item was used. e.g: select `foo` -> unselect `foo` -> value: `'foo'`

## 🚀 New behavior

if it is `undefined`, we use empty string instead, which keeps consistent with the one in `inputProps` as well (L96). e.g: select `foo` -> unselect `foo` -> value: `''`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
