### PR TITLE
fix tsup domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Hello!, I am very excited that you are interested in contributing with Next UI. 
 ### Tooling
 
 - [PNPM](https://pnpm.io/) to manage packages and dependencies
-- [Tsup](https://tsup.egoist.sh/) to bundle packages
+- [Tsup](https://tsup.egoist.dev/) to bundle packages
 - [Storybook](https://storybook.js.org/) for rapid UI component development and
   testing
 - [Testing Library](https://testing-library.com/) for testing components and


### PR DESCRIPTION
this PR fixes the tsup domain as the one used here has expired and is pointing to a badware website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL for the `Tsup` tool in the `CONTRIBUTING.md` file to reflect the new address: `https://tsup.egoist.dev/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->