### PR TITLE
fix(input): input display with hidden type

### DIFF
--- a/.changeset/selfish-tips-joke.md
+++ b/.changeset/selfish-tips-joke.md
@@ -1,5 +1,6 @@
 ---
 "@nextui-org/input": patch
+"@nextui-org/theme": patch
 ---
 
 Fix input display with hidden type (#3170)

--- a/.changeset/selfish-tips-joke.md
+++ b/.changeset/selfish-tips-joke.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fix input display with hidden type (#3170)

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -153,6 +153,33 @@ describe("Input", () => {
 
     expect(onClear).toHaveBeenCalledTimes(1);
   });
+
+  it("should not display input with hidden type", async () => {
+    const wrapper = render(
+      <>
+        <Input data-testid="input-1" type="hidden" />
+        <Input data-testid="input-2" />
+      </>,
+    );
+
+    const {container} = wrapper;
+
+    const inputBaseWrappers = container.querySelectorAll("[data-slot='base']");
+
+    expect(inputBaseWrappers).toHaveLength(2);
+
+    const inputs = container.querySelectorAll("input");
+
+    expect(inputs).toHaveLength(2);
+
+    expect(inputBaseWrappers[0]).not.toBeVisible();
+
+    expect(inputBaseWrappers[1]).toBeVisible();
+
+    expect(inputs[0]).not.toBeVisible();
+
+    expect(inputs[1]).toBeVisible();
+  });
 });
 
 describe("Input with React Hook Form", () => {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -172,9 +172,9 @@ describe("Input", () => {
 
     expect(inputs).toHaveLength(2);
 
-    expect(inputBaseWrappers[0]).not.toBeVisible();
+    expect(inputBaseWrappers[0]).toHaveAttribute("data-hidden");
 
-    expect(inputBaseWrappers[1]).toBeVisible();
+    expect(inputBaseWrappers[1]).not.toHaveAttribute("data-hidden");
 
     expect(inputs[0]).not.toBeVisible();
 

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -253,7 +253,6 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         labelPlacement,
         isClearable,
         disableAnimation,
-        isHiddenType,
       }),
     [
       objectToDeps(variantProps),

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -312,6 +312,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       isFilledWithin,
       hasPlaceholder,
       focusWithinProps,
+      isHiddenType,
       originalProps.isReadOnly,
       originalProps.isRequired,
       originalProps.isDisabled,

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -148,9 +148,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const isHiddenType = type === "hidden";
   const isMultiline = originalProps.isMultiline;
 
-  const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "", {
-    hidden: isHiddenType,
-  });
+  const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "");
 
   const handleClear = useCallback(() => {
     setInputValue("");
@@ -255,6 +253,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         labelPlacement,
         isClearable,
         disableAnimation,
+        isHiddenType,
       }),
     [
       objectToDeps(variantProps),
@@ -290,9 +289,9 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "data-has-helper": dataAttr(hasHelper),
         "data-has-label": dataAttr(hasLabel),
         "data-has-value": dataAttr(!isPlaceholderShown),
+        "data-hidden": dataAttr(isHiddenType),
         ...focusWithinProps,
         ...props,
-        hidden: isHiddenType,
       };
     },
     [

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -145,8 +145,12 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const isFilledByDefault = ["date", "time", "month", "week", "range"].includes(type!);
   const isFilled = !isEmpty(inputValue) || isFilledByDefault;
   const isFilledWithin = isFilled || isFocusWithin;
-  const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "");
+  const isHiddenType = type === "hidden";
   const isMultiline = originalProps.isMultiline;
+
+  const baseStyles = clsx(classNames?.base, className, isFilled ? "is-filled" : "", {
+    hidden: isHiddenType,
+  });
 
   const handleClear = useCallback(() => {
     setInputValue("");
@@ -288,6 +292,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "data-has-value": dataAttr(!isPlaceholderShown),
         ...focusWithinProps,
         ...props,
+        hidden: isHiddenType,
       };
     },
     [

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -23,7 +23,7 @@ import {dataFocusVisibleClasses, groupDataFocusVisibleClasses} from "../utils";
  */
 const input = tv({
   slots: {
-    base: "group flex flex-col",
+    base: "group flex flex-col data-[hidden=true]:hidden",
     label: [
       "absolute",
       "z-10",
@@ -234,11 +234,6 @@ const input = tv({
           "transition-[transform,color,left,opacity]",
         ],
         clearButton: ["transition-opacity", "motion-reduce:transition-none"],
-      },
-    },
-    isHiddenType: {
-      true: {
-        base: "hidden",
       },
     },
   },

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -236,6 +236,11 @@ const input = tv({
         clearButton: ["transition-opacity", "motion-reduce:transition-none"],
       },
     },
+    isHiddenType: {
+      true: {
+        base: "hidden",
+      },
+    },
   },
   defaultVariants: {
     variant: "flat",
@@ -245,6 +250,7 @@ const input = tv({
     labelPlacement: "inside",
     isDisabled: false,
     isMultiline: false,
+    isHiddenType: false,
   },
   compoundVariants: [
     // flat & color

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -245,7 +245,6 @@ const input = tv({
     labelPlacement: "inside",
     isDisabled: false,
     isMultiline: false,
-    isHiddenType: false,
   },
   compoundVariants: [
     // flat & color


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3170

## 📝 Description

- handle the display of the input for hidden type

## ⛳️ Current behavior (updates)

a readonly input is shown

## 🚀 New behavior

input is not shown if `type` is `hidden`

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where `Input` components with a hidden type were incorrectly displayed.

- **Tests**
  - Added a new test case to verify the correct visibility behavior of `Input` components with a hidden type.

- **Refactor**
  - Updated base CSS classes for `Input` components to conditionally include a hidden class based on data attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->