### PR TITLE
fix(docs): fix typo in autocomplete documentation page

### DIFF
--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -254,7 +254,7 @@ The following example uses the `defaultFilter` prop to filter the list of option
 
 ### Asynchronous Filtering
 
-Autocomplete supports asynchronous filtering, in the example below we are using the [useAyncList](https://react-spectrum.adobe.com/react-stately/useAsyncList.html) function
+Autocomplete supports asynchronous filtering, in the example below we are using the [useAsyncList](https://react-spectrum.adobe.com/react-stately/useAsyncList.html) function
 from [react-aria](https://react-spectrum.adobe.com) to handle asynchronous loading and filtering of data from a server.
 
 <PackageManagers


### PR DESCRIPTION
## 📝 Description

Fix a typo in documentation, autocomplete page, `useAyncList` -> `useAsyncList`

## ⛳️ Current behavior (updates)

/

## 🚀 New behavior

/

## 💣 Is this a breaking change (Yes/No):

No breaking change

## 📝 Additional Information

/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in a URL link within the documentation example for asynchronous filtering in the Autocomplete component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->