### PR TITLE
docs(tooltip): supplement correct style path

### DIFF
--- a/apps/docs/config/routes.json
+++ b/apps/docs/config/routes.json
@@ -397,7 +397,8 @@
           "key": "tooltip",
           "title": "Tooltip",
           "keywords": "tooltip, hint, descriptive message, hover info",
-          "path": "/docs/components/tooltip.mdx"
+          "path": "/docs/components/tooltip.mdx",
+          "updated": true
         },
         {
           "key": "user",

--- a/apps/docs/content/docs/components/tooltip.mdx
+++ b/apps/docs/content/docs/components/tooltip.mdx
@@ -28,6 +28,8 @@ Tooltips display a brief, informative message that appears when a user interacts
   }}
 />
 
+> For individual installation, please note that you should add `./node_modules/@nextui-org/theme/dist/components/popover.js` to your `tailwind.config.js` file instead since tooltip reuses popover styles.
+
 
 ## Import
 

--- a/apps/docs/content/docs/components/tooltip.mdx
+++ b/apps/docs/content/docs/components/tooltip.mdx
@@ -28,9 +28,6 @@ Tooltips display a brief, informative message that appears when a user interacts
   }}
 />
 
-> For individual installation, please note that you should add `./node_modules/@nextui-org/theme/dist/components/popover.js` to your `tailwind.config.js` file instead since tooltip reuses popover styles.
-
-
 ## Import
 
 <ImportTabs
@@ -39,6 +36,8 @@ Tooltips display a brief, informative message that appears when a user interacts
     individual: 'import {Tooltip} from "@nextui-org/tooltip";',
   }}
 />
+
+> For individual installation, please note that you should add `./node_modules/@nextui-org/theme/dist/components/popover.js` to your `tailwind.config.js` file instead since tooltip reuses popover styles.
 
 ## Usage
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2378

## 📝 Description

For individual installation, users would import tooltip style in `tailwind.config.js` based on the example while popover style is used in tooltip. Therefore, this PR is to supplement this info so that they know how to import the correct styles.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a note on individual installation instructions for tooltips, highlighting the need to update `tailwind.config.js` due to the reuse of popover styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->