### PR TITLE
fix: use StringMap type for better type safety in utility functions

### DIFF
--- a/.changeset/late-buttons-fail.md
+++ b/.changeset/late-buttons-fail.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Used `@ts-ignore` to bypass type checking, and used `Object`, leading to potential type problems and limited flexibility. The function now uses the `StringMap` type for better type safety and flexibility.

--- a/packages/core/theme/src/utils/object.ts
+++ b/packages/core/theme/src/utils/object.ts
@@ -1,9 +1,10 @@
 import flatten from "flat";
 
-type StringMap = Record<string, string>;
+type ColorValue = string | boolean;
+type ColorMap = Record<string, ColorValue>;
 
-export function swapColorValues<T extends StringMap>(colors: T) {
-  const swappedColors: StringMap = {};
+export function swapColorValues<T extends ColorMap>(colors: T) {
+  const swappedColors: ColorMap = {};
   const keys = Object.keys(colors);
   const length = keys.length;
 
@@ -23,8 +24,8 @@ export function swapColorValues<T extends StringMap>(colors: T) {
   return swappedColors;
 }
 
-export function removeDefaultKeys<T extends StringMap>(obj: T): StringMap {
-  const newObj: StringMap = {};
+export function removeDefaultKeys<T extends ColorMap>(obj: T): ColorMap {
+  const newObj: ColorMap = {};
 
   for (const key in obj) {
     if (key.endsWith("-DEFAULT")) {
@@ -49,5 +50,5 @@ export const flattenThemeObject = <TTarget>(obj: TTarget) =>
     flatten(obj, {
       safe: true,
       delimiter: "-",
-    }) as StringMap,
+    }) as ColorMap,
   );

--- a/packages/core/theme/src/utils/object.ts
+++ b/packages/core/theme/src/utils/object.ts
@@ -1,7 +1,9 @@
 import flatten from "flat";
 
-export function swapColorValues<T extends Object>(colors: T) {
-  const swappedColors = {};
+type StringMap = Record<string, string>;
+
+export function swapColorValues<T extends StringMap>(colors: T) {
+  const swappedColors: StringMap = {};
   const keys = Object.keys(colors);
   const length = keys.length;
 
@@ -9,31 +11,26 @@ export function swapColorValues<T extends Object>(colors: T) {
     const key1 = keys[i];
     const key2 = keys[length - 1 - i];
 
-    // @ts-ignore
     swappedColors[key1] = colors[key2];
-    // @ts-ignore
     swappedColors[key2] = colors[key1];
   }
   if (length % 2 !== 0) {
     const middleKey = keys[Math.floor(length / 2)];
 
-    // @ts-ignore
     swappedColors[middleKey] = colors[middleKey];
   }
 
   return swappedColors;
 }
 
-export function removeDefaultKeys<T extends Object>(obj: T) {
-  const newObj = {};
+export function removeDefaultKeys<T extends StringMap>(obj: T): StringMap {
+  const newObj: StringMap = {};
 
   for (const key in obj) {
     if (key.endsWith("-DEFAULT")) {
-      // @ts-ignore
       newObj[key.replace("-DEFAULT", "")] = obj[key];
       continue;
     }
-    // @ts-ignore
     newObj[key] = obj[key];
   }
 
@@ -52,5 +49,5 @@ export const flattenThemeObject = <TTarget>(obj: TTarget) =>
     flatten(obj, {
       safe: true,
       delimiter: "-",
-    }) as Object,
+    }) as StringMap,
   );


### PR DESCRIPTION
## 📝 Description

Refactored utility functions to use `UnknownMap` type (`Record<string, unknown>`) for better type safety and flexibility.

## ⛳️ Current behavior (updates)

- Functions used `Record<string, string>` or `Object`, causing potential type issues and limited flexibility.
- Used `@ts-ignore` to bypass type checking.

## 🚀 New behavior

- Functions now use `UnknownMap` type for better type safety and flexibility.
- Removed `@ts-ignore` comments by addressing type issues directly.
- Updated function signatures to handle unknown values more robustly.

## 💣 Is this a breaking change (Yes/No):

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced type safety and clarity by updating internal functions to utilize more specific type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->