### PR TITLE
fix(tabs): set tab panel id correctly

### DIFF
--- a/.changeset/rich-shirts-turn.md
+++ b/.changeset/rich-shirts-turn.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": patch
+---
+
+Fixed set tab panel id correctly (#2809)

--- a/apps/docs/content/components/tabs/placement.ts
+++ b/apps/docs/content/components/tabs/placement.ts
@@ -7,7 +7,6 @@ export default function App() {
       <RadioGroup
         className="mb-4"
         label="Placement"
-        orientation="top"
         value={placement}
         onValueChange={(value) => setPlacement(value)}
       >

--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {act, render, fireEvent} from "@testing-library/react";
+import {act, render, fireEvent, within} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {focus} from "@nextui-org/test-utils";
 
@@ -11,7 +11,7 @@ type Item = {
   content?: React.ReactNode;
 };
 
-let tabs: Item[] = [
+let defaultItems: Item[] = [
   {
     id: "item1",
     label: "Item1 ",
@@ -76,7 +76,7 @@ describe("Tabs", () => {
 
   it("should render correctly (dynamic)", () => {
     const wrapper = render(
-      <Tabs aria-label="Tabs static test" items={tabs}>
+      <Tabs aria-label="Tabs static test" items={defaultItems}>
         {(item) => (
           <Tab key={item.id} title={item.label}>
             <div>{item.content}</div>
@@ -86,6 +86,40 @@ describe("Tabs", () => {
     );
 
     expect(() => wrapper.unmount()).not.toThrow();
+  });
+
+  it("renders property", () => {
+    const wrapper = render(
+      <Tabs aria-label="Tabs property test">
+        {defaultItems.map((item) => (
+          <Tab key={item.id} title={item.label}>
+            <div>{item.content}</div>
+          </Tab>
+        ))}
+      </Tabs>,
+    );
+    const tablist = wrapper.getByRole("tablist");
+
+    expect(tablist).toBeTruthy();
+    const tabs = within(tablist).getAllByRole("tab");
+
+    expect(tabs.length).toBe(3);
+
+    for (let tab of tabs) {
+      expect(tab).toHaveAttribute("tabindex");
+      expect(tab).toHaveAttribute("aria-selected");
+      const isSelected = tab.getAttribute("aria-selected") === "true";
+
+      if (isSelected) {
+        expect(tab).toHaveAttribute("aria-controls");
+        const tabpanel = document.getElementById(tab.getAttribute("aria-controls")!);
+
+        expect(tabpanel).toBeTruthy();
+        expect(tabpanel).toHaveAttribute("aria-labelledby", tab.id);
+        expect(tabpanel).toHaveAttribute("role", "tabpanel");
+        expect(tabpanel).toHaveTextContent(defaultItems[0]?.content as string);
+      }
+    }
   });
 
   it("ref should be forwarded", () => {

--- a/packages/components/tabs/src/tab-panel.tsx
+++ b/packages/components/tabs/src/tab-panel.tsx
@@ -47,7 +47,7 @@ const TabPanel = forwardRef<"div", TabPanelProps>((props, ref) => {
 
   const domRef = useDOMRef(ref);
 
-  const {tabPanelProps} = useTabPanel(props, state, domRef);
+  const {tabPanelProps} = useTabPanel({...props, id: String(tabKey)}, state, domRef);
 
   const {focusProps, isFocused, isFocusVisible} = useFocusRing();
 

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -61,6 +61,10 @@ const Tab = forwardRef<"button", TabItemProps>((props, ref) => {
     isPressed,
   } = useTab({key, isDisabled: isDisabledProp, shouldSelectOnPressUp}, state, domRef);
 
+  if (props.children == null) {
+    delete tabProps["aria-controls"];
+  }
+
   const isDisabled = isDisabledProp || isDisabledItem;
 
   const {focusProps, isFocused, isFocusVisible} = useFocusRing();


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/2809

## 📝 Description

Fixes the issue where tab panel IDs were not set correctly.

## ⛳️ Current behavior (updates)

Tab panel IDs are incorrect, causing ARIA attribute issues.

<img width="469" alt="image" src="https://github.com/nextui-org/nextui/assets/76232929/7c926a61-752c-4356-b546-31698c539780">

## 🚀 New behavior

Tab panel IDs are now set correctly.

<img width="440" alt="image" src="https://github.com/nextui-org/nextui/assets/76232929/32e3935f-f314-4282-8596-0b77ceb65b36">


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the setting of tab panel IDs in tabs module to ensure proper functionality.
  - Removed unnecessary `orientation="top"` attribute from the `RadioGroup` component declaration.

- **Tests**
  - Updated test cases to enhance clarity and added new tests for improved coverage.

- **Refactor**
  - Improved the logic for handling the `aria-controls` attribute based on the presence of children in the `Tab` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->