### PR TITLE
fix(avatar): remove extra `disableAnimation` prop in `getImageProps`

### DIFF
--- a/.changeset/eleven-panthers-remain.md
+++ b/.changeset/eleven-panthers-remain.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/avatar": patch
+---
+
+Removed extra `disableAnimation` prop in `getImageProps` (#3257)

--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -201,7 +201,6 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
     (props = {}) => ({
       ref: imgRef,
       src: src,
-      disableAnimation,
       "data-loaded": dataAttr(isImgLoaded),
       className: slots.img({class: classNames?.img}),
       ...mergeProps(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3257

## 📝 Description

Introduced in [a merge conflict](https://github.com/nextui-org/nextui/commit/be29da10978a9569f2845fc04e46d47540a58f0b#diff-98bf46a695c53151ec4baa6c0939f66ed1b04c76ba2026b0441224abca4b6e1e)

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with the `@nextui-org/avatar` package by removing the redundant `disableAnimation` property, ensuring smoother avatar rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->