### PR TITLE
fix(doc): AI bot should not appear inside of the frames

### DIFF
--- a/apps/docs/app/blog/layout.tsx
+++ b/apps/docs/app/blog/layout.tsx
@@ -1,5 +1,7 @@
 import {Image} from "@nextui-org/react";
 
+import {ScriptProviders} from "@/components/scripts/script-providers";
+
 interface DocsLayoutProps {
   children: React.ReactNode;
 }
@@ -22,6 +24,8 @@ export default function DocsLayout({children}: DocsLayoutProps) {
       >
         <Image removeWrapper alt="docs right background" src="/gradients/docs-right.png" />
       </div>
+
+      <ScriptProviders />
     </>
   );
 }

--- a/apps/docs/app/docs/layout.tsx
+++ b/apps/docs/app/docs/layout.tsx
@@ -2,6 +2,7 @@ import {Image} from "@nextui-org/react";
 
 import manifest from "@/config/routes.json";
 import {DocsSidebar} from "@/components/docs/sidebar";
+import {ScriptProviders} from "@/components/scripts/script-providers";
 
 interface DocsLayoutProps {
   children: React.ReactNode;
@@ -30,6 +31,8 @@ export default function DocsLayout({children}: DocsLayoutProps) {
       >
         <Image removeWrapper alt="docs right background" src="/gradients/docs-right.png" />
       </div>
+
+      <ScriptProviders />
     </>
   );
 }

--- a/apps/docs/app/figma/page.tsx
+++ b/apps/docs/app/figma/page.tsx
@@ -2,6 +2,7 @@ import {Image} from "@nextui-org/react";
 
 import {Blockquote} from "@/components/docs/components/blockquote";
 import {FigmaButton} from "@/components/figma-button";
+import {ScriptProviders} from "@/components/scripts/script-providers";
 
 export default function FigmaPage() {
   return (
@@ -43,6 +44,8 @@ export default function FigmaPage() {
       >
         <Image removeWrapper alt="docs right background" src="/gradients/docs-right.png" />
       </div>
+
+      <ScriptProviders />
     </>
   );
 }

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -12,7 +12,6 @@ import {fontSans} from "@/config/fonts";
 import {Navbar} from "@/components/navbar";
 import {Footer} from "@/components/footer";
 import {ProBanner} from "@/components/pro-banner";
-import {ScriptProviders} from "@/components/scripts/script-providers";
 
 export const metadata: Metadata = {
   title: {
@@ -77,7 +76,6 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
           </div>
           <Cmdk />
         </Providers>
-        <ScriptProviders />
       </body>
     </html>
   );


### PR DESCRIPTION


Closes #

## 📝 Description

AI bot should not appear inside of the frames
same: https://github.com/nextui-org/nextui/pull/2783

## ⛳️ Current behavior (updates)

![CleanShot 2024-04-15 at 11 39 20 (1)](https://github.com/nextui-org/nextui/assets/62743644/2cb1c3d9-6527-4b9a-9473-cdf85cd0ab46)

## 🚀 New behavior

https://github.com/nextui-org/nextui/assets/62743644/97774f5a-12ba-4d13-9bf2-0e6e484528cd


## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated `ScriptProviders` component into the blog, docs, and Figma page layouts for enhanced script handling.

- **Refactor**
  - Removed `ScriptProviders` component from the root layout to optimize script management across specific pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->