### PR TITLE
refactor(.github): nextui version description in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,9 +28,9 @@ body:
       description: |
         Please provide the version of NextUI you are using.
         You can find the version number in the package.json file.
-        If you are using global installation, please state the version only. (e.g. 2.4.2)
-        If you are using individual installation, please state the package name as well. (e.g. @nextui-org/button@2.0.34)
-      placeholder: ex. 2.4.2 (global installation) or @nextui-org/button@2.0.34 (individual installation)
+        For global installation, please state the version only. (e.g. 2.4.2)
+        For individual installation, please state the package name as well. (e.g. @nextui-org/button@2.0.34)
+      placeholder: ex. 2.4.2
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,9 @@ body:
       description: |
         Please provide the version of NextUI you are using.
         You can find the version number in the package.json file.
-      placeholder: ex. 2.0.10
+        If you are using global installation, please state the version only. (e.g. 2.4.2)
+        If you are using individual installation, please state the package name as well. (e.g. @nextui-org/button@2.0.34)
+      placeholder: ex. 2.4.2 (global installation) or @nextui-org/button@2.0.34 (individual installation)
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Retrieved from a user.

> As someone who is new to web development and completely unfamiliar with this project, it is unclear what this Bug Report form means by "NextUI Version"... It appears NextUI is just a series of sub-packages and each of them is versioned differently, so there is no one single "version" of NextUI.

## ⛳️ Current behavior (updates)

Sometimes users state an individual package version and it may be confusing with the global package one. For example, if they state 2.2.2. We don't know if it is for `@nextui-org/react` or for other individual packages. This PR is to update the description for better instructions. 

## 🚀 New behavior

<img width="578" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/6c181547-b502-4603-b8a2-13b5d1b94a66">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated bug report template to clarify version details:
    - New placeholder examples for global and individual installations.
    - Instructions added for specifying package names in individual installations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->