### PR TITLE
fix(accordion): variants for nested accordions

### DIFF
--- a/.changeset/nasty-forks-explode.md
+++ b/.changeset/nasty-forks-explode.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/accordion": patch
+"@nextui-org/theme": patch
+---
+
+Fixed variants for nested accordions (#3285)

--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -56,15 +56,8 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
     }
 
     const transitionVariants: Variants = {
-      ...TRANSITION_VARIANTS.collapse,
-      exit: {
-        ...TRANSITION_VARIANTS.collapse.exit,
-        overflowY: "hidden",
-      },
-      enter: {
-        ...TRANSITION_VARIANTS.collapse.enter,
-        overflowY: "unset",
-      },
+      exit: {...TRANSITION_VARIANTS.collapse.exit, overflowY: "hidden"},
+      enter: {...TRANSITION_VARIANTS.collapse.enter, overflowY: "unset"},
     };
 
     return keepContentMounted ? (

--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -1,3 +1,5 @@
+import type {Variants} from "framer-motion";
+
 import {forwardRef} from "@nextui-org/system";
 import {useMemo, ReactNode} from "react";
 import {ChevronIcon} from "@nextui-org/shared-icons";
@@ -53,6 +55,18 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
       return <div {...getContentProps()}>{children}</div>;
     }
 
+    const transitionVariants: Variants = {
+      ...TRANSITION_VARIANTS.collapse,
+      exit: {
+        ...TRANSITION_VARIANTS.collapse.exit,
+        overflowY: "hidden",
+      },
+      enter: {
+        ...TRANSITION_VARIANTS.collapse.enter,
+        overflowY: "unset",
+      },
+    };
+
     return keepContentMounted ? (
       <LazyMotion features={domAnimation}>
         <m.section
@@ -60,8 +74,8 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
           animate={isOpen ? "enter" : "exit"}
           exit="exit"
           initial="exit"
-          style={{overflowY: "hidden", willChange}}
-          variants={TRANSITION_VARIANTS.collapse}
+          style={{willChange}}
+          variants={transitionVariants}
           {...motionProps}
         >
           <div {...getContentProps()}>{children}</div>
@@ -76,8 +90,8 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
               animate="enter"
               exit="exit"
               initial="exit"
-              style={{overflowY: "hidden", willChange}}
-              variants={TRANSITION_VARIANTS.collapse}
+              style={{willChange}}
+              variants={transitionVariants}
               {...motionProps}
             >
               <div {...getContentProps()}>{children}</div>

--- a/packages/components/accordion/src/accordion.tsx
+++ b/packages/components/accordion/src/accordion.tsx
@@ -36,6 +36,7 @@ const AccordionGroup = forwardRef<"div", AccordionProps>((props, ref) => {
         <Fragment key={item.key}>
           <AccordionItem
             item={item}
+            variant={props.variant}
             onFocusChange={handleFocusChanged}
             {...values}
             {...item.props}

--- a/packages/components/accordion/src/use-accordion-item.ts
+++ b/packages/components/accordion/src/use-accordion-item.ts
@@ -1,3 +1,5 @@
+import type {AccordionItemVariantProps} from "@nextui-org/theme";
+
 import {HTMLNextUIProps, PropGetter, useProviderContext} from "@nextui-org/system";
 import {useFocusRing} from "@react-aria/focus";
 import {accordionItem} from "@nextui-org/theme";
@@ -36,6 +38,7 @@ export interface Props<T extends object> extends HTMLNextUIProps<"div"> {
 }
 
 export type UseAccordionItemProps<T extends object = {}> = Props<T> &
+  AccordionItemVariantProps &
   Omit<AccordionItemBaseProps, "onFocusChange">;
 
 export function useAccordionItem<T extends object = {}>(props: UseAccordionItemProps<T>) {
@@ -53,6 +56,7 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
     startContent,
     motionProps,
     focusedKey,
+    variant,
     isCompact = false,
     classNames: classNamesProp = {},
     isDisabled: isDisabledProp = false,
@@ -125,8 +129,9 @@ export function useAccordionItem<T extends object = {}>(props: UseAccordionItemP
         hideIndicator,
         disableAnimation,
         disableIndicatorAnimation,
+        variant,
       }),
-    [isCompact, isDisabled, hideIndicator, disableAnimation, disableIndicatorAnimation],
+    [isCompact, isDisabled, hideIndicator, disableAnimation, disableIndicatorAnimation, variant],
   );
 
   const baseStyles = clsx(classNames?.base, className);

--- a/packages/components/accordion/src/use-accordion.ts
+++ b/packages/components/accordion/src/use-accordion.ts
@@ -215,6 +215,7 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
     return {
       ref: domRef,
       className: classNames,
+      "data-variant": variant,
       "data-orientation": "vertical",
       ...mergeProps(
         accordionProps,

--- a/packages/components/accordion/src/use-accordion.ts
+++ b/packages/components/accordion/src/use-accordion.ts
@@ -215,7 +215,6 @@ export function useAccordion<T extends object>(props: UseAccordionProps<T>) {
     return {
       ref: domRef,
       className: classNames,
-      "data-variant": variant,
       "data-orientation": "vertical",
       ...mergeProps(
         accordionProps,

--- a/packages/core/theme/src/components/accordion.ts
+++ b/packages/core/theme/src/components/accordion.ts
@@ -14,7 +14,7 @@ import {dataFocusVisibleClasses} from "../utils";
  * </div>
  */
 const accordion = tv({
-  base: "px-2 group/base",
+  base: "px-2",
   variants: {
     variant: {
       light: "",
@@ -56,28 +56,7 @@ const accordion = tv({
  */
 const accordionItem = tv({
   slots: {
-    base: [
-      // splitted
-      "group-data-[variant=splitted]/base:px-4",
-      "group-data-[variant=splitted]/base:bg-content1",
-      "group-data-[variant=splitted]/base:shadow-medium",
-      "group-data-[variant=splitted]/base:rounded-medium",
-      // light
-      "group-data-[variant=light]/base:px-0",
-      "group-data-[variant=light]/base:bg-transparent",
-      "group-data-[variant=light]/base:shadow-none",
-      "group-data-[variant=light]/base:rounded-none",
-      // bordered
-      "group-data-[variant=bordered]/base:px-0",
-      "group-data-[variant=bordered]/base:bg-transparent",
-      "group-data-[variant=bordered]/base:shadow-none",
-      "group-data-[variant=bordered]/base:rounded-none",
-      // shadow
-      "group-data-[variant=shadow]/base:px-0",
-      "group-data-[variant=shadow]/base:bg-transparent",
-      "group-data-[variant=shadow]/base:shadow-none",
-      "group-data-[variant=shadow]/base:rounded-none",
-    ],
+    base: "",
     heading: "",
     trigger: [
       "flex py-4 w-full h-full gap-3 outline-none items-center tap-highlight-transparent",
@@ -92,6 +71,11 @@ const accordionItem = tv({
     content: "py-2",
   },
   variants: {
+    variant: {
+      splitted: {
+        base: "px-4 bg-content1 shadow-medium rounded-medium",
+      },
+    },
     isCompact: {
       true: {
         trigger: "py-2",

--- a/packages/core/theme/src/components/accordion.ts
+++ b/packages/core/theme/src/components/accordion.ts
@@ -89,7 +89,7 @@ const accordionItem = tv({
     titleWrapper: "flex-1 flex flex-col text-start",
     title: "text-foreground text-large",
     subtitle: "text-small text-foreground-500 font-normal",
-    content: "p-2",
+    content: "py-2",
   },
   variants: {
     isCompact: {

--- a/packages/core/theme/src/components/accordion.ts
+++ b/packages/core/theme/src/components/accordion.ts
@@ -14,13 +14,13 @@ import {dataFocusVisibleClasses} from "../utils";
  * </div>
  */
 const accordion = tv({
-  base: "px-2",
+  base: "px-2 group/base",
   variants: {
     variant: {
       light: "",
       shadow: "px-4 shadow-medium rounded-medium bg-content1",
       bordered: "px-4 border-medium border-divider rounded-medium",
-      splitted: "group is-splitted flex flex-col gap-2", // the classNames are applied in the accordion-item component
+      splitted: "flex flex-col gap-2",
     },
     fullWidth: {
       true: "w-full",
@@ -57,10 +57,26 @@ const accordion = tv({
 const accordionItem = tv({
   slots: {
     base: [
-      "group-[.is-splitted]:px-4",
-      "group-[.is-splitted]:bg-content1",
-      "group-[.is-splitted]:shadow-medium",
-      "group-[.is-splitted]:rounded-medium",
+      // splitted
+      "group-data-[variant=splitted]/base:px-4",
+      "group-data-[variant=splitted]/base:bg-content1",
+      "group-data-[variant=splitted]/base:shadow-medium",
+      "group-data-[variant=splitted]/base:rounded-medium",
+      // light
+      "group-data-[variant=light]/base:px-0",
+      "group-data-[variant=light]/base:bg-transparent",
+      "group-data-[variant=light]/base:shadow-none",
+      "group-data-[variant=light]/base:rounded-none",
+      // bordered
+      "group-data-[variant=bordered]/base:px-0",
+      "group-data-[variant=bordered]/base:bg-transparent",
+      "group-data-[variant=bordered]/base:shadow-none",
+      "group-data-[variant=bordered]/base:rounded-none",
+      // shadow
+      "group-data-[variant=shadow]/base:px-0",
+      "group-data-[variant=shadow]/base:bg-transparent",
+      "group-data-[variant=shadow]/base:shadow-none",
+      "group-data-[variant=shadow]/base:rounded-none",
     ],
     heading: "",
     trigger: [
@@ -73,7 +89,7 @@ const accordionItem = tv({
     titleWrapper: "flex-1 flex flex-col text-start",
     title: "text-foreground text-large",
     subtitle: "text-small text-foreground-500 font-normal",
-    content: "py-2",
+    content: "p-2",
   },
   variants: {
     isCompact: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3285

## 📝 Description

Based on the current approach, if we have an accordion with `splitted` variant with other variants inside, the styles will be overrode due to the parent `group-*` modifiers .

To keep it simple, we pass variant to accordionItem as well and move the styles there to cover all nested cases.

## ⛳️ Current behavior (updates)

![image](https://github.com/nextui-org/nextui/assets/35857179/5f35ffca-b38c-4393-bdb2-35a3b0fef259)

## 🚀 New behavior

![image](https://github.com/nextui-org/nextui/assets/35857179/362a36a1-c5bd-4e6b-82dc-641ae7bcedfe)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced accordion components with new `variant` property for better customization.

- **Bug Fixes**
  - Fixed issues with nested accordion animations by updating `transitionVariants`.

- **Style**
  - Simplified classNames in accordion and accordion item components for cleaner styling.

- **Refactor**
  - Improved handling of animation effects using `Variants` from "framer-motion".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->