### PR TITLE
fix(system-rsc): extendVariants with defaultVariants

### DIFF
--- a/.changeset/clever-cherries-watch.md
+++ b/.changeset/clever-cherries-watch.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system-rsc": patch
+---
+
+fixed `extendVariants` when having `defaultVariants` (#3009)

--- a/packages/core/system-rsc/src/extend-variants.js
+++ b/packages/core/system-rsc/src/extend-variants.js
@@ -31,14 +31,15 @@ function getClassNamesWithProps({
   hasSlots,
   opts,
 }) {
-  // Do not apply default variants when the props variant is different
+  const keys = [];
+
   if (defaultVariants && typeof defaultVariants === "object") {
     for (const key in defaultVariants) {
       const value = defaultVariants[key];
       const propValue = props?.[key];
 
       if (propValue && propValue !== value) {
-        delete defaultVariants[key];
+        keys.push(key);
       }
     }
   }
@@ -46,7 +47,14 @@ function getClassNamesWithProps({
   const customTv = tv(
     {
       variants,
-      defaultVariants,
+      // Do not apply default variants when the props variant is different
+      defaultVariants: Object.keys(defaultVariants)
+        .filter((k) => !keys.includes(k))
+        .reduce((o, k) => {
+          o[k] = defaultVariants[k];
+
+          return o;
+        }, []),
       compoundVariants,
       ...(hasSlots && {slots}),
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #3009
- Closes #1959

## 📝 Description

The following code was added in this [PR](https://github.com/nextui-org/nextui/pull/1927) last year.

```tsx
if (defaultVariants && typeof defaultVariants === "object") {
  for (const key in defaultVariants) {
    const value = defaultVariants[key];
    const propValue = props?.[key];

    if (propValue && propValue !== value) {
      delete defaultVariants[key];
    }
  }
}
```

However, it will fail in the below case.

```tsx
export const Bar = extendVariants(Button, {
  variants: {
    color: {
      default: "default-shadow bg-red-500",
    },
  },
  defaultVariants: {
    color: "default",
  },
});
```

```tsx
<Bar>Button (red)</Bar>
<Bar color="primary">Button (blue)</Bar>
<Bar>Button (red)</Bar>
```

![image](https://github.com/nextui-org/nextui/assets/35857179/cd1b02b7-b2e1-4f9b-976d-e3975063ee78)

This is because the default color is deleted in above logic when rendering the second `<Bar/>` so the third one would lose the styles. This is also the reason causing the problem reported in above-linked issue.

Therefore, this PR is to convert the same logic without mutation.

## ⛳️ Current behavior (updates)

Clicking Plus 4 times

![image](https://github.com/nextui-org/nextui/assets/35857179/ceb907f3-a59a-4183-9e83-96d6dfae2ecd)

## 🚀 New behavior

Clicking Plus 4 times

![image](https://github.com/nextui-org/nextui/assets/35857179/3896f3a8-f460-4656-a55c-2ac85f542156)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the `extendVariants` behavior to correctly handle `defaultVariants` when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->