### PR TITLE
chore: add accessible name to the icon button

### DIFF
--- a/.changeset/great-avocados-eat.md
+++ b/.changeset/great-avocados-eat.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/chip": patch
+"@nextui-org/input": patch
+---
+
+Add accessible name to the icon button (#2802, #2808)

--- a/apps/docs/content/components/input/password.ts
+++ b/apps/docs/content/components/input/password.ts
@@ -69,7 +69,7 @@ export default function App() {
       variant="bordered"
       placeholder="Enter your password"
       endContent={
-        <button className="focus:outline-none" type="button" onClick={toggleVisibility}>
+        <button className="focus:outline-none" type="button" onClick={toggleVisibility} aria-label="toggle password visibility">
           {isVisible ? (
             <EyeSlashFilledIcon className="text-2xl text-default-400 pointer-events-none" />
           ) : (

--- a/packages/components/chip/src/use-chip.ts
+++ b/packages/components/chip/src/use-chip.ts
@@ -130,6 +130,7 @@ export function useChip(originalProps: UseChipProps) {
       role: "button",
       tabIndex: 0,
       className: slots.closeButton({class: classNames?.closeButton}),
+      "aria-label": "close chip",
       ...mergeProps(closePressProps, closeFocusProps),
     };
   };

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -473,6 +473,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         ...props,
         role: "button",
         tabIndex: 0,
+        "aria-label": "clear input",
         "data-slot": "clear-button",
         "data-focus-visible": dataAttr(isClearButtonFocusVisible),
         className: slots.clearButton({class: clsx(classNames?.clearButton, props?.className)}),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes https://github.com/nextui-org/nextui/issues/2802
- Closes https://github.com/nextui-org/nextui/issues/2808
- Closes https://github.com/nextui-org/nextui/pull/2855

## 📝 Description

Added accessible names to the end icons in Input and Chip components.

## ⛳️ Current behavior (updates)

End icon buttons in Input and Chip components do not have accessible names.

## 🚀 New behavior

Added accessible names to the end icons in Input and Chip components.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accessible names to icon buttons in `@nextui-org/chip` and `@nextui-org/input` components, improving screen reader support.
  - Enhanced password input field by adding an `aria-label` attribute to the visibility toggle button for better accessibility.
  - Introduced `aria-label` attributes for closing chips and clearing input fields, making these actions more accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->