### PR TITLE
fix(radio): ensure radio input correctly references description

### DIFF
--- a/.changeset/dry-foxes-melt.md
+++ b/.changeset/dry-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/radio": patch
+---
+
+Fix ensure radio input correctly references description (#2932)

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -213,6 +213,56 @@ describe("Radio", () => {
 
     expect(radio2).toBeChecked();
   });
+
+  it("should support help text description", function () {
+    const {getByRole} = render(
+      <RadioGroup description="Help text" label="Options">
+        <Radio value="1">Option 1</Radio>
+      </RadioGroup>,
+    );
+
+    const group = getByRole("radiogroup");
+
+    expect(group).toHaveAttribute("aria-describedby");
+
+    const groupDescriptionId = group.getAttribute("aria-describedby");
+    const groupDescriptionElement = document.getElementById(groupDescriptionId as string);
+
+    expect(groupDescriptionElement).toHaveTextContent("Help text");
+  });
+
+  it("should support help text description for the individual radios", function () {
+    const {getByLabelText} = render(
+      <RadioGroup description="Help text" label="Options">
+        <Radio description="Help text for option 1" value="1">
+          Option 1
+        </Radio>
+        <Radio description="Help text for option 2" value="2">
+          Option 2
+        </Radio>
+      </RadioGroup>,
+    );
+
+    const option1 = getByLabelText("Option 1");
+
+    expect(option1).toHaveAttribute("aria-describedby");
+    const option1Description = option1
+      .getAttribute("aria-describedby")
+      ?.split(" ")
+      .map((d) => document.getElementById(d)?.textContent)
+      .join(" ");
+
+    expect(option1Description).toBe("Help text for option 1 Help text");
+
+    const option2 = getByLabelText("Option 2");
+    const option2Description = option2
+      .getAttribute("aria-describedby")
+      ?.split(" ")
+      .map((d) => document.getElementById(d)?.textContent)
+      .join(" ");
+
+    expect(option2Description).toBe("Help text for option 2 Help text");
+  });
 });
 
 describe("validation", () => {

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -214,7 +214,7 @@ describe("Radio", () => {
     expect(radio2).toBeChecked();
   });
 
-  it("should support help text description", function () {
+  it("should support help text description", () => {
     const {getByRole} = render(
       <RadioGroup description="Help text" label="Options">
         <Radio value="1">Option 1</Radio>
@@ -231,7 +231,7 @@ describe("Radio", () => {
     expect(groupDescriptionElement).toHaveTextContent("Help text");
   });
 
-  it("should support help text description for the individual radios", function () {
+  it("should support help text description for the individual radios", () => {
     const {getByLabelText} = render(
       <RadioGroup description="Help text" label="Options">
         <Radio description="Help text for option 1" value="1">

--- a/packages/components/radio/src/radio.tsx
+++ b/packages/components/radio/src/radio.tsx
@@ -9,8 +9,6 @@ const Radio = forwardRef<"input", RadioProps>((props, ref) => {
   const {
     Component,
     children,
-    slots,
-    classNames,
     description,
     getBaseProps,
     getWrapperProps,
@@ -18,6 +16,7 @@ const Radio = forwardRef<"input", RadioProps>((props, ref) => {
     getLabelProps,
     getLabelWrapperProps,
     getControlProps,
+    getDescriptionProps,
   } = useRadio({...props, ref});
 
   return (
@@ -30,9 +29,7 @@ const Radio = forwardRef<"input", RadioProps>((props, ref) => {
       </span>
       <div {...getLabelWrapperProps()}>
         {children && <span {...getLabelProps()}>{children}</span>}
-        {description && (
-          <span className={slots.description({class: classNames?.description})}>{description}</span>
-        )}
+        {description && <span {...getDescriptionProps()}>{description}</span>}
       </div>
     </Component>
   );

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -87,27 +87,33 @@ export function useRadio(props: UseRadioProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const labelId = useId();
+  const descriptionId = useId();
 
   const isRequired = useMemo(() => groupContext.isRequired ?? false, [groupContext.isRequired]);
   const isInvalid = groupContext.isInvalid;
 
   const ariaRadioProps = useMemo(() => {
-    const ariaLabel =
-      otherProps["aria-label"] || typeof children === "string" ? (children as string) : undefined;
     const ariaDescribedBy =
-      otherProps["aria-describedby"] || typeof description === "string"
-        ? (description as string)
-        : undefined;
+      [otherProps["aria-describedby"], descriptionId].filter(Boolean).join(" ") || undefined;
 
     return {
       id,
       isRequired,
       isDisabled: isDisabledProp,
-      "aria-label": ariaLabel,
+      "aria-label": otherProps["aria-label"],
       "aria-labelledby": otherProps["aria-labelledby"] || labelId,
       "aria-describedby": ariaDescribedBy,
     };
-  }, [labelId, id, isDisabledProp, isRequired]);
+  }, [
+    id,
+    isDisabledProp,
+    isRequired,
+    description,
+    otherProps["aria-label"],
+    otherProps["aria-labelledby"],
+    otherProps["aria-describedby"],
+    descriptionId,
+  ]);
 
   const {
     inputProps,
@@ -117,8 +123,7 @@ export function useRadio(props: UseRadioProps) {
   } = useReactAriaRadio(
     {
       value,
-      children,
-      ...groupContext,
+      children: typeof children === "function" ? true : children,
       ...ariaRadioProps,
     },
     groupContext.groupState,
@@ -251,22 +256,30 @@ export function useRadio(props: UseRadioProps) {
     [slots, classNames?.control],
   );
 
+  const getDescriptionProps: PropGetter = useCallback(
+    (props = {}) => ({
+      ...props,
+      id: descriptionId,
+      className: slots.description({class: classNames?.description}),
+    }),
+    [slots, classNames?.description],
+  );
+
   return {
     Component,
     children,
-    slots,
-    classNames,
-    description,
     isSelected,
     isDisabled,
     isInvalid,
     isFocusVisible,
+    description,
     getBaseProps,
     getWrapperProps,
     getInputProps,
     getLabelProps,
     getLabelWrapperProps,
     getControlProps,
+    getDescriptionProps,
   };
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Related: #2932
Not closing the issue as other components might have similar problems.

## 📝 Description

Fixes the radio input to correctly references. its description.

## ⛳️ Current behavior (updates)

Radio input's `aria-describedby` incorrectly uses the description string.

## 🚀 New behavior

Radio input now uses the description element's ID for `aria-describedby`.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->
No.

## 📝 Additional Information

[aria-describedby - Accessibility | MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added support for help text descriptions in radio components, both at the group level and for individual radio options.

- **Bug Fixes**
  - Fixed the issue where the radio input was not correctly referencing the description.
  
- **Refactor**
  - Improved handling of description properties in the Radio component for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->