### PR TITLE
fix(popover): dialog focus behaviour 

### DIFF
--- a/.changeset/plenty-suns-juggle.md
+++ b/.changeset/plenty-suns-juggle.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/autocomplete": patch
+"@nextui-org/popover": patch
+---
+
+add `disableDialogFocus` to free-solo-popover (#3225, #3124, #3203)

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -460,7 +460,9 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       shouldCloseOnInteractOutside: popoverProps?.shouldCloseOnInteractOutside
         ? popoverProps.shouldCloseOnInteractOutside
         : (element: Element) => ariaShouldCloseOnInteractOutside(element, inputWrapperRef, state),
-      skipDialogFocus: true,
+      // when the popover is open, the focus should be on input instead of dialog
+      // therefore, we skip dialog focus here
+      disableDialogFocus: true,
     } as unknown as PopoverProps;
   };
 

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -460,6 +460,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       shouldCloseOnInteractOutside: popoverProps?.shouldCloseOnInteractOutside
         ? popoverProps.shouldCloseOnInteractOutside
         : (element: Element) => ariaShouldCloseOnInteractOutside(element, inputWrapperRef, state),
+      skipDialogFocus: true,
     } as unknown as PopoverProps;
   };
 

--- a/packages/components/popover/src/free-solo-popover.tsx
+++ b/packages/components/popover/src/free-solo-popover.tsx
@@ -24,6 +24,7 @@ export interface FreeSoloPopoverProps extends Omit<UsePopoverProps, "children"> 
     originX?: number;
     originY?: number;
   };
+  skipDialogFocus?: boolean;
 }
 
 type FreeSoloPopoverWrapperProps = {
@@ -87,7 +88,7 @@ const FreeSoloPopoverWrapper = forwardRef<"div", FreeSoloPopoverWrapperProps>(
 FreeSoloPopoverWrapper.displayName = "NextUI.FreeSoloPopoverWrapper";
 
 const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>(
-  ({children, transformOrigin, ...props}, ref) => {
+  ({children, transformOrigin, skipDialogFocus = false, ...props}, ref) => {
     const {
       Component,
       state,
@@ -109,7 +110,7 @@ const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>(
     const dialogRef = React.useRef(null);
     const {dialogProps: ariaDialogProps, titleProps} = useDialog({}, dialogRef);
     const dialogProps = getDialogProps({
-      ref: dialogRef,
+      ...(!skipDialogFocus && {ref: dialogRef}),
       ...ariaDialogProps,
     });
 

--- a/packages/components/popover/src/free-solo-popover.tsx
+++ b/packages/components/popover/src/free-solo-popover.tsx
@@ -24,7 +24,7 @@ export interface FreeSoloPopoverProps extends Omit<UsePopoverProps, "children"> 
     originX?: number;
     originY?: number;
   };
-  skipDialogFocus?: boolean;
+  disableDialogFocus?: boolean;
 }
 
 type FreeSoloPopoverWrapperProps = {
@@ -88,7 +88,7 @@ const FreeSoloPopoverWrapper = forwardRef<"div", FreeSoloPopoverWrapperProps>(
 FreeSoloPopoverWrapper.displayName = "NextUI.FreeSoloPopoverWrapper";
 
 const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>(
-  ({children, transformOrigin, skipDialogFocus = false, ...props}, ref) => {
+  ({children, transformOrigin, disableDialogFocus = false, ...props}, ref) => {
     const {
       Component,
       state,
@@ -110,7 +110,10 @@ const FreeSoloPopover = forwardRef<"div", FreeSoloPopoverProps>(
     const dialogRef = React.useRef(null);
     const {dialogProps: ariaDialogProps, titleProps} = useDialog({}, dialogRef);
     const dialogProps = getDialogProps({
-      ...(!skipDialogFocus && {ref: dialogRef}),
+      // by default, focus is moved into the dialog on mount
+      // we can use `disableDialogFocus` to disable this behaviour
+      // e.g. in autocomplete, the focus should be moved to the input (handled in autocomplete hook) instead of the dialog first
+      ...(!disableDialogFocus && {ref: dialogRef}),
       ...ariaDialogProps,
     });
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes: #3225
- Closes: #3124
- Closes: #3203

## 📝 Description

The focus on autocomplete works only in the following cases:
- production environment
- dev environment without React strictMode

This PR is to avoid autocomplete to focus on dialog before focusing on input so that the focus logic in autocomplete hook also works with React strictMode.

## ⛳️ Current behavior (updates)

- open autocomplete
- focus on dialog (logic from react-aria side)
- focus on input (logic from nextui autocomplete hook)

## 🚀 New behavior

- open autocomplete
- focus on input (logic from nextui autocomplete hook)

Demo (with strictMode: true)

[pr3311-demo.webm](https://github.com/nextui-org/nextui/assets/35857179/6ecf39b4-f441-4835-aabf-c8a6c8a45797)

[pr3311-demo-2.webm](https://github.com/nextui-org/nextui/assets/35857179/fb93040f-7f66-4b42-8bf8-9352cd8c6ea0)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `disableDialogFocus` option to the autocomplete and popover components, allowing users to keep focus on the input when the popover is open.
- **Bug Fixes**
	- Resolved focus-related issues in popover and autocomplete components (#3225, #3124, #3203).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->