### PR TITLE
fix(navbar): shouldHideOnScroll fixed

### DIFF
--- a/.changeset/happy-cameras-whisper.md
+++ b/.changeset/happy-cameras-whisper.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-scroll-position": minor
+---
+
+clearing throttleTimeout when it is supposed to be null in useScrollPosition

--- a/.changeset/happy-cameras-whisper.md
+++ b/.changeset/happy-cameras-whisper.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/use-scroll-position": minor
+"@nextui-org/use-scroll-position": patch
 ---
 
-clearing throttleTimeout when it is supposed to be null in useScrollPosition
+clearing throttleTimeout when it is supposed to be null in useScrollPosition (#3139)

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -61,9 +61,8 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
       if (delay) {
         if (throttleTimeout.current === null) {
           throttleTimeout.current = setTimeout(handler, delay);
-        } else {
-          clearTimeout(throttleTimeout.current);
-          throttleTimeout.current = setTimeout(handler, delay);
+        clearTimeout(throttleTimeout.current);
+        throttleTimeout.current = setTimeout(handler, delay);
         }
       } else {
         handler();

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -61,6 +61,9 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
       if (delay) {
         if (throttleTimeout.current === null) {
           throttleTimeout.current = setTimeout(handler, delay);
+        } else {
+          clearTimeout(throttleTimeout.current);
+          throttleTimeout.current = setTimeout(handler, delay);
         }
       } else {
         handler();

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -61,8 +61,9 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
       if (delay) {
         if (throttleTimeout.current === null) {
           throttleTimeout.current = setTimeout(handler, delay);
-        clearTimeout(throttleTimeout.current);
-        throttleTimeout.current = setTimeout(handler, delay);
+        } else {
+          clearTimeout(throttleTimeout.current);
+          throttleTimeout.current = setTimeout(handler, delay);
         }
       } else {
         handler();

--- a/packages/hooks/use-scroll-position/src/index.ts
+++ b/packages/hooks/use-scroll-position/src/index.ts
@@ -59,12 +59,11 @@ export const useScrollPosition = (props: UseScrollPositionOptions): ScrollValue 
 
     const handleScroll = () => {
       if (delay) {
-        if (throttleTimeout.current === null) {
-          throttleTimeout.current = setTimeout(handler, delay);
-        } else {
+        if (throttleTimeout.current) {
           clearTimeout(throttleTimeout.current);
-          throttleTimeout.current = setTimeout(handler, delay);
         }
+
+        throttleTimeout.current = setTimeout(handler, delay);
       } else {
         handler();
       }


### PR DESCRIPTION
Closes # https://github.com/nextui-org/nextui/issues/3139

## 📝 Description

The `useScrollPosition` hook responsible for reporting new scroll position when scrolled was faulty.

`throttleTimeout.current` not being null is causing `handler()` to not execute at all.

I am clearing the timeout and calling `handler()` after delay in such case.

## ⛳️ Current behavior (updates)

- nav not hiding on scroll

## 🚀 New behavior

- nav hides on scroll

https://github.com/nextui-org/nextui/assets/44525862/eb7af9ed-1790-42f0-b026-2d563ecc4202


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the `useScrollPosition` hook to properly clear the throttle timeout when setting a new timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->