### PR TITLE
docs(pagination): fix typo of missing backtick ("`") in doc

### DIFF
--- a/apps/docs/content/docs/components/pagination.mdx
+++ b/apps/docs/content/docs/components/pagination.mdx
@@ -126,7 +126,7 @@ You can use the `renderItem` property to customize the pagination items.
 - **prev**: The previous button slot.
 - **next**: The next button slot.
 - **item**: The pagination item slot, applied to the middle items.
-- **cursor**: The current page slot. Available only when `disableCursorAnimation` is `false` and `disableAnimation` is `false.
+- **cursor**: The current page slot. Available only when `disableCursorAnimation` is `false` and `disableAnimation` is `false`.
 - **forwardIcon**: The forward icon slot. The one that appears when hovering the ellipsis button.
 - **ellipsis**: The ellipsis slot.
 - **chevronNext**: The chevron next icon slot.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Fix a typo in the pagination documentation where backtick ("`") is missing.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

This is my first pull request, so I kindly ask for your understanding.
I would greatly appreciate it if you could point out any issues. 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in the description of the `cursor` slot in the Pagination documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->