### PR TITLE
fix(image): override default auto height

### DIFF
--- a/.changeset/stale-planes-flash.md
+++ b/.changeset/stale-planes-flash.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/image": patch
+---
+
+override default auto height (#3325)

--- a/packages/components/image/__tests__/image.test.tsx
+++ b/packages/components/image/__tests__/image.test.tsx
@@ -73,4 +73,24 @@ describe("Image", () => {
     expect(wrapper.getByRole("img")).toHaveAttribute("src", src);
     expect(onLoad).toHaveBeenCalled();
   });
+
+  test("should disable aspect ratio if height is set", () => {
+    const wrapper = render(
+      <>
+        <Image height={30} src={src} />
+        <Image height={"40px"} src={src} />
+        <Image height={50} src={src} width={50} />
+        <Image height={"60px"} src={src} width={50} />
+      </>,
+    );
+
+    const images = wrapper.getAllByRole("img");
+
+    expect(images).toHaveLength(4);
+
+    expect(getComputedStyle(images[0]).height).toBe("30px");
+    expect(getComputedStyle(images[1]).height).toBe("40px");
+    expect(getComputedStyle(images[2]).height).toBe("50px");
+    expect(getComputedStyle(images[3]).height).toBe("60px");
+  });
 });

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -96,6 +96,7 @@ export function useImage(originalProps: UseImageProps) {
     srcSet,
     sizes,
     crossOrigin,
+    height,
     ...otherProps
   } = props;
 
@@ -131,6 +132,11 @@ export function useImage(originalProps: UseImageProps) {
     };
   }, [props?.width]);
 
+  const h = useMemo(
+    () => (height ? (typeof height === "number" ? `${height}px` : height) : "auto"),
+    [height],
+  );
+
   const showFallback = (!src || !isImgLoaded) && !!fallbackSrc;
   const showSkeleton = isLoading && !disableSkeleton;
 
@@ -159,6 +165,11 @@ export function useImage(originalProps: UseImageProps) {
       sizes,
       crossOrigin,
       ...otherProps,
+      style: {
+        ...(height && {height: h}),
+        ...props.style,
+        ...otherProps.style,
+      },
     };
   };
 

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -166,6 +166,8 @@ export function useImage(originalProps: UseImageProps) {
       crossOrigin,
       ...otherProps,
       style: {
+        // img has `height: auto` by default
+        // passing the custom height here to override if it is specified
         ...(height && {height: h}),
         ...props.style,
         ...otherProps.style,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3325

## 📝 Description

img has `height: auto` by default. When you pass the height to Image component, the default style will override it since it has higher precedence. This PR is to set the custom height to style if `height` prop is specified.

## ⛳️ Current behavior (updates)

```tsx
<Image src="https://nextui-docs-v2.vercel.app/images/fruit-1.jpeg" width={300} height={300} />
```

The custom height will be discarded. `height: auto` will be used.

<img width="627" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/6f813643-22aa-4be2-9359-69593c870551">

## 🚀 New behavior

```tsx
<Image src="https://nextui-docs-v2.vercel.app/images/fruit-1.jpeg" width={300} height={300} />
```

<img width="626" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/2be80b17-f1ac-4873-b42d-71e7fd0adc5f">

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom image height in the `Image` component.
  
- **Tests**
  - Introduced a new test case to ensure the `Image` component correctly handles the custom `height` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->