### PR TITLE
fix: incorrect year in showMonthAndYearPickers with locale

### DIFF
--- a/.changeset/purple-singers-knock.md
+++ b/.changeset/purple-singers-knock.md
@@ -1,0 +1,8 @@
+---
+"@nextui-org/calendar": patch
+"@nextui-org/date-input": patch
+"@nextui-org/system": patch
+"@nextui-org/shared-utils": patch
+---
+
+Fixed incorrect year in `showMonthAndYearPickers` with different locales

--- a/packages/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/components/calendar/__tests__/calendar.test.tsx
@@ -4,6 +4,7 @@ import {render, act, fireEvent} from "@testing-library/react";
 import {CalendarDate, isWeekend} from "@internationalized/date";
 import {triggerPress, keyCodes} from "@nextui-org/test-utils";
 import {useLocale} from "@react-aria/i18n";
+import {NextUIProvider} from "@nextui-org/system";
 
 import {Calendar as CalendarBase, CalendarProps} from "../src";
 
@@ -15,6 +16,20 @@ const Calendar = React.forwardRef((props: CalendarProps, ref: React.Ref<HTMLDivE
 });
 
 Calendar.displayName = "Calendar";
+
+const CalendarWithLocale = React.forwardRef(
+  (props: CalendarProps & {locale: string}, ref: React.Ref<HTMLDivElement>) => {
+    const {locale, ...otherProps} = props;
+
+    return (
+      <NextUIProvider locale={locale}>
+        <CalendarBase {...otherProps} ref={ref} disableAnimation />
+      </NextUIProvider>
+    );
+  },
+);
+
+CalendarWithLocale.displayName = "CalendarWithLocale";
 
 describe("Calendar", () => {
   beforeAll(() => {
@@ -417,6 +432,26 @@ describe("Calendar", () => {
       }
 
       expect(description).toBe("Selected date unavailable.");
+    });
+
+    it("should display the correct year and month in showMonthAndYearPickers with locale", () => {
+      const {getByRole} = render(
+        <CalendarWithLocale
+          showMonthAndYearPickers
+          defaultValue={new CalendarDate(2024, 6, 26)}
+          locale="th-TH-u-ca-buddhist"
+        />,
+      );
+
+      const header = document.querySelector<HTMLButtonElement>(`button[data-slot="header"]`)!;
+
+      triggerPress(header);
+
+      const month = getByRole("button", {name: "มิถุนายน"});
+      const year = getByRole("button", {name: "พ.ศ. 2567"});
+
+      expect(month).toHaveAttribute("data-value", "6");
+      expect(year).toHaveAttribute("data-value", "2567");
     });
   });
 });

--- a/packages/components/calendar/src/use-calendar-base.ts
+++ b/packages/components/calendar/src/use-calendar-base.ts
@@ -9,7 +9,7 @@ import type {SupportedCalendars} from "@nextui-org/system";
 import type {CalendarState, RangeCalendarState} from "@react-stately/calendar";
 import type {RefObject, ReactNode} from "react";
 
-import {createCalendar, CalendarDate, DateFormatter} from "@internationalized/date";
+import {createCalendar, Calendar, CalendarDate, DateFormatter} from "@internationalized/date";
 import {mapPropsVariants, useProviderContext} from "@nextui-org/system";
 import {useCallback, useMemo} from "react";
 import {calendar} from "@nextui-org/theme";

--- a/packages/components/date-input/src/use-date-input.ts
+++ b/packages/components/date-input/src/use-date-input.ts
@@ -7,15 +7,14 @@ import type {DOMAttributes, GroupDOMAttributes} from "@react-types/shared";
 import type {DateInputGroupProps} from "./date-input-group";
 
 import {useLocale} from "@react-aria/i18n";
-import {CalendarDate} from "@internationalized/date";
+import {createCalendar, CalendarDate, DateFormatter} from "@internationalized/date";
 import {mergeProps} from "@react-aria/utils";
 import {PropGetter, useProviderContext} from "@nextui-org/system";
 import {HTMLNextUIProps, mapPropsVariants} from "@nextui-org/system";
 import {useDOMRef} from "@nextui-org/react-utils";
 import {useDateField as useAriaDateField} from "@react-aria/datepicker";
 import {useDateFieldState} from "@react-stately/datepicker";
-import {createCalendar} from "@internationalized/date";
-import {objectToDeps, clsx, dataAttr} from "@nextui-org/shared-utils";
+import {objectToDeps, clsx, dataAttr, getGregorianYearOffset} from "@nextui-org/shared-utils";
 import {dateInput} from "@nextui-org/theme";
 import {useMemo} from "react";
 
@@ -116,6 +115,15 @@ export function useDateInput<T extends DateValue>(originalProps: UseDateInputPro
 
   const [props, variantProps] = mapPropsVariants(originalProps, dateInput.variantKeys);
 
+  const {locale} = useLocale();
+
+  const calendarProp = createCalendar(new DateFormatter(locale).resolvedOptions().calendar);
+
+  // by default, we are using gregorian calendar with possible years in [1900, 2099]
+  // however, some locales such as `th-TH-u-ca-buddhist` using different calendar making the years out of bound
+  // hence, add the corresponding offset to make sure the year is within the bound
+  const gregorianYearOffset = getGregorianYearOffset(calendarProp.identifier);
+
   const {
     ref,
     as,
@@ -134,8 +142,10 @@ export function useDateInput<T extends DateValue>(originalProps: UseDateInputPro
     descriptionProps: descriptionPropsProp,
     validationBehavior = globalContext?.validationBehavior ?? "aria",
     shouldForceLeadingZeros = true,
-    minValue = globalContext?.defaultDates?.minDate ?? new CalendarDate(1900, 1, 1),
-    maxValue = globalContext?.defaultDates?.maxDate ?? new CalendarDate(2099, 12, 31),
+    minValue = globalContext?.defaultDates?.minDate ??
+      new CalendarDate(calendarProp, 1900 + gregorianYearOffset, 1, 1),
+    maxValue = globalContext?.defaultDates?.maxDate ??
+      new CalendarDate(calendarProp, 2099 + gregorianYearOffset, 12, 31),
     createCalendar: createCalendarProp = globalContext?.createCalendar ?? null,
     isInvalid: isInvalidProp = validationState ? validationState === "invalid" : false,
     errorMessage,
@@ -145,8 +155,6 @@ export function useDateInput<T extends DateValue>(originalProps: UseDateInputPro
   const inputRef = useDOMRef(inputRefProp);
 
   const disableAnimation = originalProps.disableAnimation ?? globalContext?.disableAnimation;
-
-  const {locale} = useLocale();
 
   const state = useDateFieldState({
     ...originalProps,

--- a/packages/core/system/src/provider.tsx
+++ b/packages/core/system/src/provider.tsx
@@ -5,7 +5,6 @@ import {I18nProvider, I18nProviderProps} from "@react-aria/i18n";
 import {RouterProvider} from "@react-aria/utils";
 import {OverlayProvider} from "@react-aria/overlays";
 import {useMemo} from "react";
-import {CalendarDate} from "@internationalized/date";
 import {MotionGlobalConfig} from "framer-motion";
 
 import {ProviderContext} from "./provider-context";
@@ -42,10 +41,9 @@ export const NextUIProvider: React.FC<NextUIProviderProps> = ({
   skipFramerMotionAnimations = disableAnimation,
   validationBehavior = "aria",
   locale = "en-US",
-  defaultDates = {
-    minDate: new CalendarDate(1900, 1, 1),
-    maxDate: new CalendarDate(2099, 12, 31),
-  },
+  // if minDate / maxDate are not specified in `defaultDates`
+  // then they will be set in `use-date-input.ts` or `use-calendar-base.ts`
+  defaultDates,
   createCalendar,
   ...otherProps
 }) => {

--- a/packages/utilities/shared-utils/src/dates.ts
+++ b/packages/utilities/shared-utils/src/dates.ts
@@ -1,0 +1,26 @@
+export function getGregorianYearOffset(identifier: string): number {
+  switch (identifier) {
+    case "buddhist":
+      return 543;
+    case "ethiopic":
+    case "ethioaa":
+      return -8;
+    case "coptic":
+      return -284;
+    case "hebrew":
+      return 3760;
+    case "indian":
+      return -78;
+    case "islamic-civil":
+    case "islamic-tbla":
+    case "islamic-umalqura":
+      return -579;
+    case "persian":
+      return 622;
+    case "roc":
+    case "japanese":
+    case "gregory":
+    default:
+      return 0;
+  }
+}

--- a/packages/utilities/shared-utils/src/index.ts
+++ b/packages/utilities/shared-utils/src/index.ts
@@ -7,3 +7,4 @@ export * from "./functions";
 export * from "./numbers";
 export * from "./console";
 export * from "./types";
+export * from "./dates";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #3272
- Closes #3063
- Closes #3254
- Closes #2842
- Closes #2960

## 📝 Description

Currently we are using gregorian calendar with possible years in $[1900, 2099]$. However, some locales such as `th-TH-u-ca-buddhist` using different calendar making the years out of bound. Hence, add the corresponding offset to make sure the year is within the bound.

## ⛳️ Current behavior (updates)

locale: `th-TH-u-ca-buddhist`

<img width="392" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/87ddeacf-a00d-40b7-8677-dd1c27c67295">

## 🚀 New behavior

locale: `th-TH-u-ca-buddhist`

<img width="342" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/da3364b8-08a8-4154-b4d0-e6091a451509">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `CalendarWithLocale` and `DatePickerWithLocale` components for enhanced localization.

- **Enhancements**
  - Improved date handling with `createCalendar`, `DateFormatter`, and `getGregorianYearOffset` for better calendar management.
  - Updated `minValue` and `maxValue` calculations based on calendar identifiers.

- **Refactor**
  - Adjusted `NextUIProvider` with new initialization for default dates.

- **Chores**
  - Enhanced utility functions in shared utilities for better date management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->