### PR TITLE
fix(table): resolve double fetch issue in useInfiniteScroll hook

### DIFF
--- a/.changeset/fix-infinite-scroll.md
+++ b/.changeset/fix-infinite-scroll.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-infinite-scroll": patch
+---
+
+fix(table): resolve double fetch issue in useInfiniteScroll hook (#3251)

--- a/packages/hooks/use-infinite-scroll/src/index.ts
+++ b/packages/hooks/use-infinite-scroll/src/index.ts
@@ -82,22 +82,22 @@ export function useInfiniteScroll(props: UseInfiniteScrollProps = {}) {
           observerRef.current.disconnect();
         }
       };
-    } else {
-      const debouncedCheckIfNearBottom = debounce(() => {
-        if (
-          scrollContainerNode.scrollHeight - scrollContainerNode.scrollTop <=
-          scrollContainerNode.clientHeight + distance
-        ) {
-          loadMore();
-        }
-      }, 100);
-
-      scrollContainerNode.addEventListener("scroll", debouncedCheckIfNearBottom);
-
-      return () => {
-        scrollContainerNode.removeEventListener("scroll", debouncedCheckIfNearBottom);
-      };
     }
+
+    const debouncedCheckIfNearBottom = debounce(() => {
+      if (
+        scrollContainerNode.scrollHeight - scrollContainerNode.scrollTop <=
+        scrollContainerNode.clientHeight + distance
+      ) {
+        loadMore();
+      }
+    }, 100);
+
+    scrollContainerNode.addEventListener("scroll", debouncedCheckIfNearBottom);
+
+    return () => {
+      scrollContainerNode.removeEventListener("scroll", debouncedCheckIfNearBottom);
+    };
   }, [hasMore, distance, isEnabled, shouldUseLoader, loadMore]);
 
   return [loaderRef, scrollContainerRef] as const;

--- a/packages/hooks/use-infinite-scroll/src/index.ts
+++ b/packages/hooks/use-infinite-scroll/src/index.ts
@@ -41,13 +41,17 @@ export function useInfiniteScroll(props: UseInfiniteScrollProps = {}) {
   const isLoadingRef = useRef(false);
 
   const loadMore = useCallback(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
     if (!isLoadingRef.current && hasMore && onLoadMore) {
       isLoadingRef.current = true;
       onLoadMore();
-      setTimeout(() => {
+      timer = setTimeout(() => {
         isLoadingRef.current = false;
       }, 100); // Debounce time to prevent multiple calls
     }
+
+    return () => clearTimeout(timer);
   }, [hasMore, onLoadMore]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
### Summary
Resolved the issue where the useInfiniteScroll hook was fetching data twice on initial render. This fix ensures that data is fetched only once during initial render and additional data is fetched upon scrolling.

### Issue
- Closes #3251.

### Changes
- Updated useInfiniteScroll hook to prevent double fetching.
- Verified the fix by testing the component and ensuring only one initial fetch.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

I use isLoadingRef to prevent concurrent load calls, implements a debounced loadMore function with useCallback, and simplifies the IntersectionObserver logic.
 The hook now handles both loader-based and scroll-based detection more efficiently, using debounce for scroll events. I also improved cleanup for the IntersectionObserver and better TypeScript typing. These changes collectively make the hook more robust, reducing issues like multiple simultaneous loads and excessive re-renders, while providing a smoother infinite scrolling experience

## ⛳️ Current behavior (updates)

Table useInfiniteScroll hook fetches twice

## 🚀 New behavior

- Updated useInfiniteScroll hook to prevent double fetching.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced infinite scroll functionality with a new `loadMore` callback for improved data loading.
  - Introduced a debounce mechanism to prevent multiple load calls in a short timeframe.
  - Added an IntersectionObserver to optimize content loading when scrolling near the bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->