### PR TITLE
fix(table): custom with class names storybook styles

### DIFF
--- a/packages/components/table/stories/table.stories.tsx
+++ b/packages/components/table/stories/table.stories.tsx
@@ -411,7 +411,12 @@ const CustomCellWithClassnamesTemplate = (args: TableProps) => {
         );
       case "status":
         return (
-          <Chip className="capitalize" color={statusColorMap[user.status]} size="sm" variant="flat">
+          <Chip
+            className="capitalize font-semibold"
+            color={statusColorMap[user.status]}
+            size="sm"
+            variant="flat"
+          >
             {cellValue}
           </Chip>
         );
@@ -1033,22 +1038,13 @@ export const CustomWithClassNames = {
     ...defaultProps,
     classNames: {
       base: ["max-w-3xl", "bg-gradient-to-br", "from-purple-500", "to-indigo-900/90", "shadow-xl"],
-      th: [
-        "bg-transparent",
-        "text-black/70",
-        "dark:text-white/70",
-        "border-b",
-        "border-black/10",
-        "dark:border-white/10",
-      ],
+      th: ["bg-transparent", "text-default-700", "border-b", "border-default"],
       td: [
         "py-4",
         "text-sm",
-        "text-black/90",
-        "dark:text-white/90",
+        "text-default-700",
         "border-b",
-        "border-black/10",
-        "dark:border-white/10",
+        "border-default",
         "group-data-[last=true]:border-b-0",
       ],
     },

--- a/packages/components/table/stories/table.stories.tsx
+++ b/packages/components/table/stories/table.stories.tsx
@@ -394,7 +394,7 @@ const CustomCellWithClassnamesTemplate = (args: TableProps) => {
           <User
             avatarProps={{radius: "lg", src: user.avatar}}
             classNames={{
-              description: "text-white/60",
+              description: "text-default-400",
             }}
             description={user.email}
             name={cellValue}
@@ -406,17 +406,12 @@ const CustomCellWithClassnamesTemplate = (args: TableProps) => {
         return (
           <div className="flex flex-col">
             <p className="text-bold text-sm capitalize">{cellValue}</p>
-            <p className="text-bold text-sm capitalize text-white/60">{user.team}</p>
+            <p className="text-bold text-sm capitalize text-default-400">{user.team}</p>
           </div>
         );
       case "status":
         return (
-          <Chip
-            className="capitalize bg-black/20 font-semibold"
-            color={statusColorMap[user.status]}
-            size="sm"
-            variant="light"
-          >
+          <Chip className="capitalize" color={statusColorMap[user.status]} size="sm" variant="flat">
             {cellValue}
           </Chip>
         );
@@ -424,12 +419,12 @@ const CustomCellWithClassnamesTemplate = (args: TableProps) => {
         return (
           <div className="relative flex items-center gap-2">
             <Tooltip color="foreground" content="Details">
-              <span className="text-lg text-white/70 cursor-pointer active:opacity-50">
+              <span className="text-lg text-default-400 cursor-pointer active:opacity-50">
                 <EyeIcon />
               </span>
             </Tooltip>
             <Tooltip color="foreground" content="Edit user">
-              <span className="text-lg text-white/70 cursor-pointer active:opacity-50">
+              <span className="text-lg text-default-400 cursor-pointer active:opacity-50">
                 <EditIcon />
               </span>
             </Tooltip>
@@ -1038,13 +1033,22 @@ export const CustomWithClassNames = {
     ...defaultProps,
     classNames: {
       base: ["max-w-3xl", "bg-gradient-to-br", "from-purple-500", "to-indigo-900/90", "shadow-xl"],
-      th: ["bg-transparent", "text-white/70", "border-b", "border-white/10"],
+      th: [
+        "bg-transparent",
+        "text-black/70",
+        "dark:text-white/70",
+        "border-b",
+        "border-black/10",
+        "dark:border-white/10",
+      ],
       td: [
         "py-4",
         "text-sm",
-        "text-white/90",
+        "text-black/90",
+        "dark:text-white/90",
         "border-b",
-        "border-white/10",
+        "border-black/10",
+        "dark:border-white/10",
         "group-data-[last=true]:border-b-0",
       ],
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3338 <!-- Github issue # here -->

## 📝 Description

Currently the light mode version of Custom With Class Names Storybook style for tables is bad(text is not visible). This PR modifies the styling for light mode keeping the dark mode styles consistent.

## ⛳️ Current behavior (updates)
Old Light Mode
![Screenshot 2024-06-27 220641](https://github.com/nextui-org/nextui/assets/82326089/61e8ef8b-8109-46b6-b3ee-5ca10a51cae3)

## 🚀 New behavior
New Light Mode
![Screenshot 2024-06-27 220505](https://github.com/nextui-org/nextui/assets/82326089/cd69536a-a724-41f1-b922-fdf9d0642deb)
New Dark Mode
![Screenshot 2024-06-27 220551](https://github.com/nextui-org/nextui/assets/82326089/606e18c9-73b9-4a27-882b-40896d2cc114)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated text colors and background styles in the table component for better readability and consistency.
  - Adjusted Chip component attributes for improved visual appearance.

- **Style**
  - Modified base and header styles for the table component to enhance the overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->