### PR TITLE
fix(calendar): disable button picker in calendar if `isDisabled` is true

### DIFF
--- a/.changeset/friendly-pumas-brush.md
+++ b/.changeset/friendly-pumas-brush.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+disable button picker in calendar if `isDisabled` is true (#3357)

--- a/packages/components/calendar/__tests__/calendar.test.tsx
+++ b/packages/components/calendar/__tests__/calendar.test.tsx
@@ -254,6 +254,16 @@ describe("Calendar", () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it("should not open a month & year picker if isDisabled is true", () => {
+      const {container} = render(
+        <Calendar isDisabled showMonthAndYearPickers value={new CalendarDate(2024, 6, 29)} />,
+      );
+
+      const headerButtonPicker = container.querySelector("[data-slot='header']");
+
+      expect(headerButtonPicker).toHaveAttribute("disabled");
+    });
+
     it("should not select a date on click if isReadOnly", () => {
       let onChange = jest.fn();
       let {getByLabelText, getByText} = render(

--- a/packages/components/calendar/src/use-calendar.ts
+++ b/packages/components/calendar/src/use-calendar.ts
@@ -8,7 +8,7 @@ import {useCalendar as useAriaCalendar} from "@react-aria/calendar";
 import {useCalendarState} from "@react-stately/calendar";
 import {createCalendar} from "@internationalized/date";
 import {clsx} from "@nextui-org/shared-utils";
-import {chain} from "@react-aria/utils";
+import {chain, mergeProps} from "@react-aria/utils";
 
 import {ContextType, useCalendarBase, UseCalendarBaseProps} from "./use-calendar-base";
 import {CalendarBaseProps} from "./calendar-base";
@@ -76,7 +76,7 @@ export function useCalendar<T extends DateValue>({
   const baseStyles = clsx(classNames?.base, className);
 
   const buttonPickerProps: ButtonProps = {
-    ...buttonPickerPropsProp,
+    ...mergeProps(buttonPickerPropsProp, {isDisabled: originalProps.isDisabled}),
     onPress: chain(buttonPickerPropsProp?.onPress, () => setIsHeaderExpanded(!isHeaderExpanded)),
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3357

## 📝 Description

passing `isDisabled` to `buttonPickerProps`

## ⛳️ Current behavior (updates)

<img width="311" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/282337e2-4e64-443c-ade8-8a7649ea0b52">

<img width="346" alt="image" src="https://github.com/nextui-org/nextui/assets/35857179/ca192eec-0f2b-4785-8904-4c7495e1c623">

## 🚀 New behavior

![image](https://github.com/nextui-org/nextui/assets/35857179/af4e52a0-2bd3-4349-b276-2e2c6474e826)

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled the button picker in the calendar when `isDisabled` is set to true, resolving issue #3357.

- **Tests**
  - Added a test to ensure the month & year picker does not open when `isDisabled` is true.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->