### PR TITLE
fix: remove autoCapitalize to prevent Firefox warning

### DIFF
--- a/.changeset/chatty-pianos-run.md
+++ b/.changeset/chatty-pianos-run.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-input": patch
+---
+
+Removed autoCapitalize to prevent warnings (#3297)

--- a/packages/components/date-input/src/date-input-segment.tsx
+++ b/packages/components/date-input/src/date-input-segment.tsx
@@ -25,6 +25,11 @@ export const DateInputSegment: React.FC<DateInputSegmentProps> = ({
 
   let {segmentProps} = useDateSegment(segment, state, ref);
 
+  // @ts-expect-error autoCapitalize is not a valid prop
+  // Removing autoCapitalize as it causes bugs in Firefox.
+  // See: https://github.com/adobe/react-spectrum/issues/5599
+  delete segmentProps.autoCapitalize;
+
   return (
     <div
       {...mergeProps(segmentProps, otherProps)}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3297 

## 📝 Description

This bug occurs because [react-aria sets `autoCapitalize: 'off'`](https://github.com/adobe/react-spectrum/issues/5599) on each segment of the DateInput , but in Firefox, it defaults to 'none'. This discrepancy between server side rendering and client-side rendering  results in a warning. In Safari and Chrome, it remains 'off', so no warning is displayed. Since the DateInput has [`input-mode=numeric`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode#numeric), which already shows a numeric keyboard, the [`autoCapitalize`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) setting is unnecessary.

## ⛳️ Current behavior (updates)

A warning is displayed when rendering a component with DateInput in Firefox.

<img width="1625" alt="autoCapitalize-off" src="https://github.com/nextui-org/nextui/assets/76232929/62d6163a-0ce8-4b9a-b35b-181847ef8f78">

## 🚀 New behavior

No warning is displayed.
<img width="1491" alt="autoCapitalize-undefined" src="https://github.com/nextui-org/nextui/assets/76232929/536e00be-4de8-4452-a553-f080da921dac">

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed `autoCapitalize` property from the `DateInputSegment` component to resolve compatibility issues in Firefox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->