### PR TITLE
fix(date-range-picker): input field clear error

### DIFF
--- a/apps/docs/content/components/date-range-picker/presets.ts
+++ b/apps/docs/content/components/date-range-picker/presets.ts
@@ -88,7 +88,7 @@ export default function App() {
           </ButtonGroup>
         }
         calendarProps={{
-          focusedValue: value.start,
+          focusedValue: value?.start,
           onFocusChange: (val) => setValue({...value, start: val}),
           nextButtonProps: {
             variant: "bordered",

--- a/packages/components/date-picker/stories/date-range-picker.stories.tsx
+++ b/packages/components/date-picker/stories/date-range-picker.stories.tsx
@@ -349,7 +349,7 @@ const PresetsTemplate = (args: DateRangePickerProps) => {
           </ButtonGroup>
         }
         calendarProps={{
-          focusedValue: value.start,
+          focusedValue: value?.start,
           onFocusChange: (val) => setValue({...value, start: val}),
           nextButtonProps: {
             variant: "bordered",


### PR DESCRIPTION
Closes #3388 

## 📝 Description
When you clear any fields inside the input of `DateRangePicker` you get the following errors.

**Storybook**

![image](https://github.com/nextui-org/nextui/assets/8769408/26da1da1-1859-4c8d-b8fd-c37ffae23028)

**Docs**

![image](https://github.com/nextui-org/nextui/assets/8769408/35e3bfb9-f3eb-45e7-85d7-8bf7651beb81)

![image](https://github.com/nextui-org/nextui/assets/8769408/a3e883e7-581f-4e25-94c5-8d3dd06a323f)

## ⛳️ Current behavior (updates)
Errors as shown above

## 🚀 New behavior
No errors

## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information
If the PR gets accepted please use my GitHub email-id (shrinidhiupadhyaya1195@gmail.com) instead of my other email-id for the Co-authored-by: message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `date-range-picker` to handle potential `null` or `undefined` values for `start` property, ensuring more robust performance and fewer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->