### PR TITLE
docs(frameworks): update highlighted line numbers in Frameworks examples

### DIFF
--- a/apps/docs/content/docs/frameworks/astro.mdx
+++ b/apps/docs/content/docs/frameworks/astro.mdx
@@ -62,7 +62,7 @@ the following code to your `tailwind.config.cjs` file:
 **Note**: If you are using pnpm and monorepo architecture, please make sure you are pointing to the ROOT `node_modules`
 </Blockquote>
 
-```js {9,14-15}
+```js {2,9,14-15}
 // tailwind.config.cjs
 const { nextui } = require("@nextui-org/react");
 

--- a/apps/docs/content/docs/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs.mdx
@@ -99,7 +99,7 @@ Filtered results for: Enter something to filter
 
 You still need to add the provider to your app manually (we are working on automating this step).
 
-```jsx {7,9}
+```jsx {3,7,9}
 // app/providers.tsx
 
 import {NextUIProvider} from '@nextui-org/react'
@@ -115,7 +115,7 @@ export function Providers({children}: { children: React.ReactNode }) {
 
 <Spacer y={4} />
 
-```jsx {7,9,11}
+```jsx {3,7,9,11}
 // app/layout.tsx
 
 import {Providers} from "./providers";
@@ -174,7 +174,7 @@ the following code to your `tailwind.config.js` file:
 **Note**: If you are using pnpm and monorepo architecture, please make sure you are pointing to the ROOT `node_modules`
 </Blockquote>
 
-```js {9,14-15}
+```js {2,9,14-15}
 // tailwind.config.js
 import {nextui} from "@nextui-org/react";
 
@@ -199,7 +199,7 @@ export default config;
 
 Go to your `app/providers.tsx` or `app/providers.jsx` (create it if it doesn't exist) and wrap the Component with the `NextUIProvider`:
 
-```jsx {8,10}
+```jsx {4,8,10}
 // app/providers.tsx
 'use client'
 
@@ -218,7 +218,7 @@ export function Providers({children}: { children: React.ReactNode }) {
 
 Now, Go to your `root` layout page and wrap it with the `Providers`:
 
-```jsx {6,8,10}
+```jsx {2,6,8,10,12}
 // app/layout.tsx
 import {Providers} from "./providers";
 
@@ -244,7 +244,7 @@ of them by adding the `dark`/`light` class to the `html` tag. See the [theme doc
 Now you can import any NextUI component directly in your Server Components without needing to use
 the `use client;` directive:
 
-```jsx {2}
+```jsx {2,7}
 // app/page.tsx
 import {Button} from '@nextui-org/button'; 
 
@@ -338,7 +338,7 @@ Filtered results for: Enter something to filter
 
 You still need to add the provider to your app manually (we are working on automating this step).
 
-```jsx {7,9}
+```jsx {3,7,9}
 // app/providers.tsx
 
 import {NextUIProvider} from '@nextui-org/react'
@@ -354,7 +354,7 @@ export function Providers({children}: { children: React.ReactNode }) {
 
 <Spacer y={4} />
 
-```jsx {7,9,11}
+```jsx {3,7,9,11,13}
 // app/layout.tsx
 
 import {Providers} from "./providers";
@@ -413,7 +413,7 @@ the following code to your `tailwind.config.js` file:
 **Note**: If you are using pnpm and monorepo architecture, please make sure you are pointing to the ROOT `node_modules`
 </Blockquote>
 
-```js {9,14-15}
+```js {2,9,14-15}
 // tailwind.config.js
 import {nextui} from "@nextui-org/react";
 
@@ -438,7 +438,7 @@ export default config;
 
 Go to pages`/_app.js` or `pages/_app.tsx` (create it if it doesn't exist) and wrap the Component with the `NextUIProvider`:
 
-```jsx {6,8}
+```jsx {2,6,8}
 // pages/_app.js
 import {NextUIProvider} from '@nextui-org/react'
 
@@ -457,7 +457,7 @@ export default MyApp;
 
 Now you can import any NextUI component wherever you want:
 
-```jsx {1}
+```jsx {1,6}
 import {Button} from '@nextui-org/react'
 
 export default function Page() {

--- a/apps/docs/content/docs/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs.mdx
@@ -218,7 +218,7 @@ export function Providers({children}: { children: React.ReactNode }) {
 
 Now, Go to your `root` layout page and wrap it with the `Providers`:
 
-```jsx {2,6,8,10,12}
+```jsx {2,6,8,10}
 // app/layout.tsx
 import {Providers} from "./providers";
 

--- a/apps/docs/content/docs/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/frameworks/nextjs.mdx
@@ -354,7 +354,7 @@ export function Providers({children}: { children: React.ReactNode }) {
 
 <Spacer y={4} />
 
-```jsx {3,7,9,11,13}
+```jsx {3,7,9,11}
 // app/layout.tsx
 
 import {Providers} from "./providers";

--- a/apps/docs/content/docs/frameworks/remix.mdx
+++ b/apps/docs/content/docs/frameworks/remix.mdx
@@ -56,7 +56,7 @@ the following code to your `tailwind.config.js` file:
 **Note**: If you are using pnpm and monorepo architecture, please make sure you are pointing to the ROOT `node_modules`
 </Blockquote>
 
-```ts {10,15-16}
+```ts {2,10,15-16}
 // tailwind.config.ts
 const { nextui } = require("@nextui-org/react");
 

--- a/apps/docs/content/docs/frameworks/vite.mdx
+++ b/apps/docs/content/docs/frameworks/vite.mdx
@@ -57,7 +57,7 @@ the following code to your `tailwind.config.js` file:
 **Note**: If you are using pnpm and monorepo architecture, please make sure you are pointing to the ROOT `node_modules`
 </Blockquote>
 
-```js {8,13-14}
+```js {2,8,13-14}
 // tailwind.config.js
 const { nextui } = require("@nextui-org/react");
 
@@ -81,7 +81,7 @@ After installing NextUI, you need to set up the `NextUIProvider` at the `root` o
 
 Go to the src directory and inside `main.jsx` or `main.tsx`, wrap `NextUIProvider` around App:
 
-```jsx
+```jsx {4,10,12}
 // main.tsx or main.jsx
 import React from 'react'
 import ReactDOM from 'react-dom/client'


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

No associated issue

## 📝 Description

> Added some highlight configurations for the line numbers that need to be modified in the configuration.

## ⛳️ Current behavior (updates)

> Some highlighted line numbers in the document are not set completely.

## 🚀 New behavior

> All relevant line numbers are highlighted.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

> No
## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Adjusted line numbers in code snippets within Astro, Next.js, Remix, and Vite documentation for improved clarity and compatibility with pnpm and monorepo architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->