### PR TITLE
fix(image): optional height

### DIFF
--- a/.changeset/cool-pugs-lay.md
+++ b/.changeset/cool-pugs-lay.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/image": patch
+---
+
+fixed missing required `height` property issue

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -167,7 +167,7 @@ export function useImage(originalProps: UseImageProps) {
       style: {
         // img has `height: auto` by default
         // passing the custom height here to override if it is specified
-        ...(props?.height && {height: h}),
+        ...(otherProps?.height && {height: h}),
         ...props.style,
         ...otherProps.style,
       },

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -96,7 +96,6 @@ export function useImage(originalProps: UseImageProps) {
     srcSet,
     sizes,
     crossOrigin,
-    height,
     ...otherProps
   } = props;
 
@@ -122,20 +121,20 @@ export function useImage(originalProps: UseImageProps) {
 
   const domRef = useDOMRef(ref);
 
-  const {w} = useMemo(() => {
+  const {w, h} = useMemo(() => {
     return {
       w: props.width
         ? typeof props.width === "number"
           ? `${props.width}px`
           : props.width
         : "fit-content",
+      h: props.height
+        ? typeof props.height === "number"
+          ? `${props.height}px`
+          : props.height
+        : "auto",
     };
-  }, [props?.width]);
-
-  const h = useMemo(
-    () => (height ? (typeof height === "number" ? `${height}px` : height) : "auto"),
-    [height],
-  );
+  }, [props?.width, props?.height]);
 
   const showFallback = (!src || !isImgLoaded) && !!fallbackSrc;
   const showSkeleton = isLoading && !disableSkeleton;
@@ -168,7 +167,7 @@ export function useImage(originalProps: UseImageProps) {
       style: {
         // img has `height: auto` by default
         // passing the custom height here to override if it is specified
-        ...(height && {height: h}),
+        ...(props?.height && {height: h}),
         ...props.style,
         ...otherProps.style,
       },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

introduced by https://github.com/nextui-org/nextui/pull/3327. `height` should be optional. also refactored a bit.

## ⛳️ Current behavior (updates)

![image](https://github.com/nextui-org/nextui/assets/35857179/efd83049-8afa-463e-8507-60021866e896)

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the way image height and width are calculated and applied to enhance consistency and accuracy in rendering images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->