### PR TITLE
fix(docs): incorrect image height in documentation

### DIFF
--- a/apps/docs/components/marketing/hero/floating-components.tsx
+++ b/apps/docs/components/marketing/hero/floating-components.tsx
@@ -67,7 +67,7 @@ export const FloatingComponents: React.FC<{}> = () => {
             alt="Professional camera"
             as={NextImage}
             className="object-cover -translate-y-12 h-[100%]"
-            height={120}
+            height={180}
             src="/images/card-example-6.webp"
             width={120}
           />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Previously NextUI Image component doesn't take height input, so it still looked ok when the height was incorrect.

## ⛳️ Current behavior (updates)

![image](https://github.com/nextui-org/nextui/assets/35857179/638f28d7-a0a1-4b90-afa7-45267422edca)

## 🚀 New behavior

![image](https://github.com/nextui-org/nextui/assets/35857179/fe738920-9fb4-4cbf-bc48-373bcd30fa3f)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
