### PR TITLE
docs(table): supplement string typing in table row key 

### DIFF
--- a/apps/docs/content/components/popover/usage.ts
+++ b/apps/docs/content/components/popover/usage.ts
@@ -2,7 +2,7 @@ const App = `import {Popover, PopoverTrigger, PopoverContent, Button} from "@nex
 
 export default function App() {
   return (
-    <Popover placement="right">
+    <Popover placement="top">
       <PopoverTrigger>
         <Button>Open Popover</Button>
       </PopoverTrigger>

--- a/apps/docs/content/components/popover/usage.ts
+++ b/apps/docs/content/components/popover/usage.ts
@@ -2,7 +2,7 @@ const App = `import {Popover, PopoverTrigger, PopoverContent, Button} from "@nex
 
 export default function App() {
   return (
-    <Popover placement="top">
+    <Popover placement="right">
       <PopoverTrigger>
         <Button>Open Popover</Button>
       </PopoverTrigger>

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings)
 
 This format makes it clear and easy to follow.
 ### Multiple Row Selection

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, [Refer Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information,Refer [Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -149,8 +149,11 @@ provide a default set of selected rows.
 
 <CodeDemo title="Single Row Selection" files={tableContent.singleSelection} />
 
-> **Note**: The value of the selected keys must match the key prop of the row.
+> **Note**:
+> - The value of the selected keys must match the `key` prop of the row.
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
 
+This format makes it clear and easy to follow.
 ### Multiple Row Selection
 
 You can also select multiple rows by using the `selectionMode="multiple"` prop. Use `defaultSelectedKeys` to

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,9 +151,8 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
 
-This format makes it clear and easy to follow.
 ### Multiple Row Selection
 
 You can also select multiple rows by using the `selectionMode="multiple"` prop. Use `defaultSelectedKeys` to

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, Refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys are treated as strings to avoid type mismatch issues. For more information, refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948).
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, [Refer Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information,Refer [Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, Refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3238

## 📝 Description

 Added the note to prevent possible bugs due to react key
```bash
React keys are automatically converted to strings. When using the Table component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues.
```
## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

<img width="651" alt="Screenshot 2024-07-10 at 5 56 14 PM" src="https://github.com/nextui-org/nextui/assets/147910430/3522b330-ba7a-4b62-aea8-37d4d220ff77">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
 A very simple Docs Change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new event handlers for date picker component to improve focus and change events.
  - Updated popover placement from "right" to "top" for better usability.

- **Documentation**
  - Enhanced notes on key prop matching and React key conversion for the Table component to improve developer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->