### PR TITLE
fix(use-image): cached image flashing

### DIFF
--- a/.changeset/pink-beans-sit.md
+++ b/.changeset/pink-beans-sit.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/use-image": patch
+"@nextui-org/test-utils": patch
+---
+
+fix cached image flashing due to use-image always returning pending initially. The fix was to check if the image is loaded instantly through HTMLImageElement.complete attribute and use that to initialize the state.

--- a/packages/hooks/use-image/__tests__/use-image.test.tsx
+++ b/packages/hooks/use-image/__tests__/use-image.test.tsx
@@ -1,0 +1,44 @@
+import {renderHook} from "@testing-library/react-hooks";
+import {mocks} from "@nextui-org/test-utils";
+
+import {useImage} from "../src";
+
+describe("use-image hook", () => {
+  let mockImage: {restore: any; simulate: (value: "loaded" | "error") => void};
+
+  beforeEach(() => {
+    mockImage = mocks.image();
+  });
+  afterEach(() => {
+    mockImage.restore();
+  });
+
+  it("can handle missing src", () => {
+    const rendered = renderHook(() => useImage({}));
+
+    expect(rendered.result.current).toEqual("pending");
+  });
+
+  it("can handle loading image", async () => {
+    const rendered = renderHook(() => useImage({src: "/test.png"}));
+
+    expect(rendered.result.current).toEqual("loading");
+    mockImage.simulate("loaded");
+    await rendered.waitForValueToChange(() => rendered.result.current === "loaded");
+  });
+
+  it("can handle error image", async () => {
+    mockImage.simulate("error");
+    const rendered = renderHook(() => useImage({src: "/test.png"}));
+
+    expect(rendered.result.current).toEqual("loading");
+    await rendered.waitForValueToChange(() => rendered.result.current === "failed");
+  });
+
+  it("can handle cached image", async () => {
+    mockImage.simulate("loaded");
+    const rendered = renderHook(() => useImage({src: "/test.png"}));
+
+    expect(rendered.result.current).toEqual("loaded");
+  });
+});

--- a/packages/hooks/use-image/package.json
+++ b/packages/hooks/use-image/package.json
@@ -41,7 +41,8 @@
   },
   "devDependencies": {
     "clean-package": "2.2.0",
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "@nextui-org/test-utils": "workspace:*"
   },
   "clean-package": "../../../clean-package.config.json",
   "tsup": {

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -1,9 +1,9 @@
 /**
  * Part of this code is taken from @chakra-ui/react package ❤️
  */
-import type {ImgHTMLAttributes, SyntheticEvent} from "react";
+import type {ImgHTMLAttributes, MutableRefObject, SyntheticEvent} from "react";
 
-import {useCallback, useEffect, useRef, useState} from "react";
+import {useEffect, useRef, useState} from "react";
 import {useSafeLayoutEffect} from "@nextui-org/use-safe-layout-effect";
 
 type NativeImageProps = ImgHTMLAttributes<HTMLImageElement>;
@@ -66,40 +66,37 @@ type ImageEvent = SyntheticEvent<HTMLImageElement, Event>;
 export function useImage(props: UseImageProps = {}) {
   const {loading, src, srcSet, onLoad, onError, crossOrigin, sizes, ignoreFallback} = props;
 
-  const [status, setStatus] = useState<Status>("pending");
+  const imageRef = useRef<HTMLImageElement | null>();
+  const firstMount = useRef<boolean>(true);
+  const [status, setStatus] = useState<Status>(() => setImageAndGetInitialStatus(props, imageRef));
+
+  useSafeLayoutEffect(() => {
+    if (firstMount.current) {
+      firstMount.current = false;
+
+      return;
+    }
+
+    setStatus(setImageAndGetInitialStatus(props, imageRef));
+
+    return () => {
+      flush();
+    };
+  }, [src, crossOrigin, srcSet, sizes, loading]);
 
   useEffect(() => {
-    setStatus(src ? "loading" : "pending");
-  }, [src]);
-
-  const imageRef = useRef<HTMLImageElement | null>();
-
-  const load = useCallback(() => {
-    if (!src) return;
-
-    flush();
-
-    const img = new Image();
-
-    img.src = src;
-    if (crossOrigin) img.crossOrigin = crossOrigin;
-    if (srcSet) img.srcset = srcSet;
-    if (sizes) img.sizes = sizes;
-    if (loading) img.loading = loading;
-
-    img.onload = (event) => {
+    if (!imageRef.current) return;
+    imageRef.current.onload = (event) => {
       flush();
       setStatus("loaded");
       onLoad?.(event as unknown as ImageEvent);
     };
-    img.onerror = (error) => {
+    imageRef.current.onerror = (error) => {
       flush();
       setStatus("failed");
       onError?.(error as any);
     };
-
-    imageRef.current = img;
-  }, [src, crossOrigin, srcSet, sizes, onLoad, onError, loading]);
+  }, [imageRef.current]);
 
   const flush = () => {
     if (imageRef.current) {
@@ -109,27 +106,36 @@ export function useImage(props: UseImageProps = {}) {
     }
   };
 
-  useSafeLayoutEffect(() => {
-    /**
-     * If user opts out of the fallback/placeholder
-     * logic, let's bail out.
-     */
-    if (ignoreFallback) return undefined;
-
-    if (status === "loading") {
-      load();
-    }
-
-    return () => {
-      flush();
-    };
-  }, [status, load, ignoreFallback]);
-
   /**
    * If user opts out of the fallback/placeholder
    * logic, let's just return 'loaded'
    */
   return ignoreFallback ? "loaded" : status;
+}
+
+function setImageAndGetInitialStatus(
+  props: UseImageProps,
+  imageRef: MutableRefObject<HTMLImageElement | null | undefined>,
+): Status {
+  const {loading, src, srcSet, crossOrigin, sizes, ignoreFallback} = props;
+
+  if (!src) return "pending";
+  if (ignoreFallback) return "loaded";
+
+  const img = new Image();
+
+  img.src = src;
+  if (crossOrigin) img.crossOrigin = crossOrigin;
+  if (srcSet) img.srcset = srcSet;
+  if (sizes) img.sizes = sizes;
+  if (loading) img.loading = loading;
+
+  imageRef.current = img;
+  if (img.complete && img.naturalWidth) {
+    return "loaded";
+  }
+
+  return "loading";
 }
 
 export const shouldShowFallbackImage = (status: Status, fallbackStrategy: FallbackStrategy) =>

--- a/packages/utilities/test-utils/src/mocks/image.ts
+++ b/packages/utilities/test-utils/src/mocks/image.ts
@@ -14,6 +14,10 @@ export function mockImage() {
     onerror: VoidFunction = () => {};
     src = "";
     alt = "";
+    naturalWidth = 100;
+    get complete() {
+      return status === "loaded";
+    }
     hasAttribute(name: string) {
       return name in this;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3417,6 +3417,9 @@ importers:
         specifier: workspace:*
         version: link:../use-safe-layout-effect
     devDependencies:
+      '@nextui-org/test-utils':
+        specifier: workspace:*
+        version: link:../../utilities/test-utils
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
@@ -5979,6 +5982,10 @@ packages:
     peerDependencies:
       '@effect-ts/otel-node': '*'
     peerDependenciesMeta:
+      '@effect-ts/core':
+        optional: true
+      '@effect-ts/otel':
+        optional: true
       '@effect-ts/otel-node':
         optional: true
     dependencies:
@@ -7384,6 +7391,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -7392,6 +7400,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -7400,6 +7409,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -7408,6 +7418,7 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -7500,6 +7511,7 @@ packages:
     engines: {node: '>= 12'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7509,6 +7521,7 @@ packages:
     engines: {node: '>= 12'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -7518,6 +7531,7 @@ packages:
     engines: {node: '>= 12'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7527,6 +7541,7 @@ packages:
     engines: {node: '>= 12'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -8650,6 +8665,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -8659,6 +8675,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -8668,6 +8685,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -8677,6 +8695,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -8686,6 +8705,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -11611,6 +11631,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -11619,6 +11640,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -11627,6 +11649,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -11635,6 +11658,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -20032,6 +20056,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -20041,6 +20066,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -20050,6 +20076,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -20059,6 +20086,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -22450,6 +22478,9 @@ packages:
     resolution: {integrity: sha512-W+gxAq7aQ9dJIg/XLKGcRT0cvnStFAQHPaI0pvD0U2l6IVLueUAm3nwN7lkY62zZNmlvNx6jNtE4wlbS+CyqSg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
+    peerDependenciesMeta:
+      '@parcel/core':
+        optional: true
     dependencies:
       '@parcel/config-default': 2.12.0(@parcel/core@2.12.0)(typescript@4.9.5)
       '@parcel/core': 2.12.0


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3437  <!-- Github issue # here -->

## 📝 Description

As mentioned in #3437, avatars may flicker even if its already cached. The fix was to check the image loading status immediately after creating the image to see if it's instantly loaded (when the image is cached), and use it to initialize the state. This will affect Avatar, AvatarGroup, and Image components.

Also added test for use-image too since it doesn't exist before.

| Before | After |
|--------|--------|
| ![nextui-flashing-before](https://github.com/nextui-org/nextui/assets/1536976/601a54ea-d562-477e-9165-db1b8419bd70) | ![nextui-flashing-after](https://github.com/nextui-org/nextui/assets/1536976/f7b5ab13-fd67-4671-9d1d-26e051bb518d) |

## ⛳️ Current behavior (updates)

Image flickers due to use-image initializes with `pending` and only updated the status in `useLayoutEffect`.

## 🚀 New behavior

Initialize image loading status with loaded if possible.

## 💣 Is this a breaking change (Yes/No):  No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved issue where cached images were flashing due to improper initialization of the image's loaded state.

- **Tests**
	- Added comprehensive tests for the `useImage` hook covering scenarios like missing source, loading, errors, and cached images.

- **Chores**
	- Updated `use-image` package devDependencies to include `@nextui-org/test-utils`.

- **Refactor**
	- Refined image loading logic in the `useImage` function to improve the image initialization and status determination process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->