### PR TITLE
fix(card): removed the default z-10 of card header

### DIFF
--- a/.changeset/grumpy-days-refuse.md
+++ b/.changeset/grumpy-days-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+removed the default z-10 of card header(#3198)

--- a/packages/core/theme/src/components/card.ts
+++ b/packages/core/theme/src/components/card.ts
@@ -35,7 +35,6 @@ const card = tv({
     header: [
       "flex",
       "p-3",
-      "z-10",
       "w-full",
       "justify-start",
       "items-center",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3198

## 📝 Description

## Removed the `z-10` prop of card header

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
 