### PR TITLE
fix(input): fixed the value prop error to pass string on type number

### DIFF
--- a/.changeset/wild-suits-enjoy.md
+++ b/.changeset/wild-suits-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Updated the input to accept value prop as number on type number

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -137,7 +137,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const innerWrapperRef = useDOMRef<HTMLDivElement>(innerWrapperRefProp);
 
   const [inputValue, setInputValue] = useControlledState<string | undefined>(
-    props.value?.toString() ?? undefined,
+    props.value?.toString(),
     props.defaultValue?.toString() ?? "",
     handleValueChange,
   );

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -19,6 +19,9 @@ import {useMemo, Ref, useCallback, useState} from "react";
 import {chain, mergeProps} from "@react-aria/utils";
 import {useTextField} from "@react-aria/textfield";
 
+// definfing the type of value
+type Value = string | number | undefined;
+
 export interface Props<T extends HTMLInputElement | HTMLTextAreaElement = HTMLInputElement>
   extends Omit<HTMLNextUIProps<"input">, keyof InputVariantProps> {
   /**
@@ -118,7 +121,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   } = props;
 
   const handleValueChange = useCallback(
-    (value: string | number | undefined) => {
+    (value: Value) => {
       onValueChange(value ?? "");
     },
     [onValueChange],
@@ -136,7 +139,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const inputWrapperRef = useDOMRef<HTMLDivElement>(wrapperRef);
   const innerWrapperRef = useDOMRef<HTMLDivElement>(innerWrapperRefProp);
 
-  const [inputValue, setInputValue] = useControlledState<string | undefined>(
+  const [inputValue, setInputValue] = useControlledState<Value>(
     props.value?.toString(),
     props.defaultValue?.toString() ?? "",
     handleValueChange,
@@ -180,7 +183,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       ...originalProps,
       validationBehavior,
       autoCapitalize: originalProps.autoCapitalize as AutoCapitalize,
-      value: inputValue,
+      value: inputValue?.toString(),
       "aria-label": safeAriaLabel(
         originalProps["aria-label"],
         originalProps.label,

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -80,7 +80,7 @@ export interface Props<T extends HTMLInputElement | HTMLTextAreaElement = HTMLIn
   /**
    * React aria onChange event.
    */
-  onValueChange?: (value: string) => void;
+  onValueChange?: (value: string | number) => void;
 }
 
 type AutoCapitalize = AriaTextFieldOptions<"input">["autoCapitalize"];
@@ -118,7 +118,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   } = props;
 
   const handleValueChange = useCallback(
-    (value: string | undefined) => {
+    (value: string | number | undefined) => {
       onValueChange(value ?? "");
     },
     [onValueChange],
@@ -137,8 +137,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const innerWrapperRef = useDOMRef<HTMLDivElement>(innerWrapperRefProp);
 
   const [inputValue, setInputValue] = useControlledState<string | undefined>(
-    props.value,
-    props.defaultValue ?? "",
+    props.value?.toString() ?? undefined,
+    props.defaultValue?.toString() ?? "",
     handleValueChange,
   );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3448 

## 📝 Description

Updated the value prop to type of string  or number
and 
onValueChange to accept both string and number values

## ⛳️ Current behavior (updates)

<img width="443" alt="Screenshot 2024-07-12 at 12 35 47 AM" src="https://github.com/user-attachments/assets/5a396de9-2bb3-49fc-a284-c2216cb376f9">
<img width="410" alt="Screenshot 2024-07-12 at 12 35 57 AM" src="https://github.com/user-attachments/assets/8e1fec7c-9b0e-44a5-ab14-67ee6a780c62">


## 🚀 New behavior - No Error on paasing number values

<img width="414" alt="Screenshot 2024-07-12 at 12 33 28 AM" src="https://github.com/user-attachments/assets/7065fad1-1912-4c31-859d-598543c60509">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced input component to accept numerical values for the `number` type.

- **Improvements**
  - Updated `onValueChange` to handle both string and number values, providing more flexibility in input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->