### PR TITLE
fix(docs): update docs for autocomplete to show correct type on `classNames` prop

### DIFF
--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -4,6 +4,7 @@ description: "An autocomplete combines a text input with a listbox, allowing use
 ---
 
 import {autocompleteContent} from "@/content/components/autocomplete";
+import { Button, Popover, PopoverContent, PopoverTrigger } from '@nextui-org/react';
 
 # Autocomplete
 
@@ -84,7 +85,7 @@ the end of the label and the autocomplete will be required.
 
 ### Read Only
 
-If you pass the `isReadOnly` property to the Autocomplete, the Listbox will open to display 
+If you pass the `isReadOnly` property to the Autocomplete, the Listbox will open to display
 all available options, but users won't be able to select any of the listed options.
 
 <CodeDemo title="Read Only" highlightedLines="8" files={autocompleteContent.readOnly} />
@@ -459,7 +460,7 @@ properties to customize the popover, listbox and input components.
 | disableClearable            | `boolean`                                                                                                                             | Whether the clear button should be hidden. (**Deprecated**) Use `isClearable` instead.                                                                        | `false`                  |
 | disableAnimation            | `boolean`                                                                                                                             | Whether the Autocomplete should be animated.                                                                                                                  | `true`                   |
 | disableSelectorIconRotation | `boolean`                                                                                                                             | Whether the select should disable the rotation of the selector icon.                                                                                          | `false`                  |
-| classNames                  | `Record<"base"｜ "listboxWrapper"｜ "listbox"｜ "popoverContent" ｜ "endContentWrapper"｜ "clearButton" ｜ "selectorButton", string>` | Allows to set custom class names for the Autocomplete slots.                                                                                                  | -                        |
+| classNames                  | <Popover><PopoverTrigger><Button>Check</Button></PopoverTrigger><PopoverContent className="w-full"><code className="w-[95%]">{`Partial<Record<"base"｜ "listboxWrapper"｜ "listbox"｜ "popoverContent" ｜ "endContentWrapper"｜ "clearButton" ｜ "selectorButton", string>>`}</code></PopoverContent></Popover> | Allows to set custom class names for the Autocomplete slots.                                                                                                  | -                        |
 
 ### Autocomplete Events
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes [#3216](https://github.com/nextui-org/nextui/issues/3216)

## 📝 Description

Components that `classNames` props had the wrong type specified on their documentation page. This fixes for all those components.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information
There are a lot of files but all have similar kind of change. Changed `Record<UnionType, string>` to `Partial<Record<UnionType, string>>` for each component `classNames` type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the Autocomplete component with new interactive elements, including a dropdown popover and a trigger button for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->