### PR TITLE
docs(image): added note on removeWrapper for using img props directly

### DIFF
--- a/apps/docs/content/components/popover/usage.ts
+++ b/apps/docs/content/components/popover/usage.ts
@@ -2,7 +2,7 @@ const App = `import {Popover, PopoverTrigger, PopoverContent, Button} from "@nex
 
 export default function App() {
   return (
-    <Popover placement="right">
+    <Popover placement="top">
       <PopoverTrigger>
         <Button>Open Popover</Button>
       </PopoverTrigger>

--- a/apps/docs/content/components/popover/usage.ts
+++ b/apps/docs/content/components/popover/usage.ts
@@ -2,7 +2,7 @@ const App = `import {Popover, PopoverTrigger, PopoverContent, Button} from "@nex
 
 export default function App() {
   return (
-    <Popover placement="top">
+    <Popover placement="right">
       <PopoverTrigger>
         <Button>Open Popover</Button>
       </PopoverTrigger>

--- a/apps/docs/content/docs/components/image.mdx
+++ b/apps/docs/content/docs/components/image.mdx
@@ -41,6 +41,7 @@ The Image component is used to display images with support for fallback.
 ## Usage
 
 <CodeDemo title="Usage" files={imageContent.usage} />
+> **Note**: The `<Image />` component is, by default, a `<div>` element containing an `<img />` child element. To use the properties of the `<img />` element directly, set `removeWrapper={true}`.
 
 ### Blurred
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings)
 
 This format makes it clear and easy to follow.
 ### Multiple Row Selection

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, [Refer Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information,Refer [Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -149,8 +149,11 @@ provide a default set of selected rows.
 
 <CodeDemo title="Single Row Selection" files={tableContent.singleSelection} />
 
-> **Note**: The value of the selected keys must match the key prop of the row.
+> **Note**:
+> - The value of the selected keys must match the `key` prop of the row.
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
 
+This format makes it clear and easy to follow.
 ### Multiple Row Selection
 
 You can also select multiple rows by using the `selectionMode="multiple"` prop. Use `defaultSelectedKeys` to

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,9 +151,8 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
 
-This format makes it clear and easy to follow.
 ### Multiple Row Selection
 
 You can also select multiple rows by using the `selectionMode="multiple"` prop. Use `defaultSelectedKeys` to

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, Refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys are treated as strings to avoid type mismatch issues. For more information, refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948).
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, refer to the [React documentation on keys](https://reactjs.org/docs/lists-and-keys.html#keys)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, [Refer Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -151,7 +151,7 @@ provide a default set of selected rows.
 
 > **Note**:
 > - The value of the selected keys must match the `key` prop of the row.
-> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information,Refer [Here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
+> - React keys are automatically converted to strings. When using the `Table` component, ensure that all row keys (e.g., row IDs) are treated as strings to avoid type mismatch issues. For more information, Refer [here](https://softwareengineering.stackexchange.com/questions/381268/why-are-react-keys-limited-to-strings/432948#432948)
 
 ### Multiple Row Selection
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3074

## 📝 Description

Adde `Note` to use `removeWrapper={true}` for using the `img` props directly.

## ⛳️ Current behavior (updates)



## 🚀 New behavior

<img width="701" alt="Screenshot 2024-07-14 at 6 28 16 PM" src="https://github.com/user-attachments/assets/8949dec9-da18-4067-bb03-2b039b27efa9">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a note on the `<Image />` component explaining how to access the properties of the `<img />` element directly by setting `removeWrapper={true}`.
  - Expanded the note on selected keys in the `Table` component to emphasize treating row keys as strings to avoid type mismatch issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->