### PR TITLE
fix(tooltip): Tooltip shouldBlockScroll doesn't work

### DIFF
--- a/.changeset/modern-pianos-destroy.md
+++ b/.changeset/modern-pianos-destroy.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/tooltip": major
+"@nextui-org/tooltip": patch
 ---
 
 Fix where scrolling was enabled when tooltip was open (#3474)

--- a/.changeset/modern-pianos-destroy.md
+++ b/.changeset/modern-pianos-destroy.md
@@ -2,4 +2,4 @@
 "@nextui-org/tooltip": major
 ---
 
-Fix bug #3474 where scrolling was enabled when tooltip was open
+Fix where scrolling was enabled when tooltip was open (#3474)

--- a/.changeset/modern-pianos-destroy.md
+++ b/.changeset/modern-pianos-destroy.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tooltip": major
+---
+
+Fix bug #3474 where scrolling was enabled when tooltip was open

--- a/packages/components/popover/src/popover-content.tsx
+++ b/packages/components/popover/src/popover-content.tsx
@@ -2,11 +2,10 @@ import type {AriaDialogProps} from "@react-aria/dialog";
 import type {HTMLMotionProps} from "framer-motion";
 
 import {DOMAttributes, ReactNode, useMemo, useRef} from "react";
-import {forwardRef} from "@nextui-org/system";
+import {forwardRef, HTMLNextUIProps} from "@nextui-org/system";
 import {DismissButton} from "@react-aria/overlays";
 import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
 import {m, domAnimation, LazyMotion} from "framer-motion";
-import {HTMLNextUIProps} from "@nextui-org/system";
 import {RemoveScroll} from "react-remove-scroll";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {useDialog} from "@react-aria/dialog";

--- a/packages/components/tooltip/package.json
+++ b/packages/components/tooltip/package.json
@@ -34,17 +34,17 @@
     "postpack": "clean-package restore"
   },
   "peerDependencies": {
-    "react": ">=18",
-    "react-dom": ">=18",
-    "framer-motion": ">=10.17.0",
+    "@nextui-org/system": ">=2.0.0",
     "@nextui-org/theme": ">=2.1.0",
-    "@nextui-org/system": ">=2.0.0"
+    "framer-motion": ">=10.17.0",
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "dependencies": {
-    "@nextui-org/shared-utils": "workspace:*",
-    "@nextui-org/react-utils": "workspace:*",
     "@nextui-org/aria-utils": "workspace:*",
     "@nextui-org/framer-utils": "workspace:*",
+    "@nextui-org/react-utils": "workspace:*",
+    "@nextui-org/shared-utils": "workspace:*",
     "@nextui-org/use-safe-layout-effect": "workspace:*",
     "@react-aria/interactions": "3.21.3",
     "@react-aria/overlays": "3.22.1",
@@ -52,7 +52,8 @@
     "@react-aria/utils": "3.24.1",
     "@react-stately/tooltip": "3.4.9",
     "@react-types/overlays": "3.8.7",
-    "@react-types/tooltip": "3.4.9"
+    "@react-types/tooltip": "3.4.9",
+    "react-remove-scroll": "^2.5.6"
   },
   "devDependencies": {
     "@nextui-org/button": "workspace:*",

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -6,6 +6,7 @@ import {warn} from "@nextui-org/shared-utils";
 import {Children, cloneElement, isValidElement} from "react";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {mergeProps} from "@react-aria/utils";
+import {RemoveScroll} from "react-remove-scroll";
 
 import {UseTooltipProps, useTooltip} from "./use-tooltip";
 
@@ -53,7 +54,7 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
     warn("Tooltip must have only one child node. Please, check your code.");
   }
 
-  const {ref: tooltipRef, id, style, ...otherTooltipProps} = getTooltipProps();
+  const {ref: tooltipRef, id, style, shouldBlockScroll, ...otherTooltipProps} = getTooltipProps();
 
   const animatedContent = (
     <div ref={tooltipRef} id={id} style={style}>
@@ -75,7 +76,7 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
   );
 
   return (
-    <>
+    <RemoveScroll enabled={shouldBlockScroll && isOpen} removeScrollBar={false}>
       {trigger}
       {disableAnimation && isOpen ? (
         <OverlayContainer portalContainer={portalContainer}>
@@ -90,7 +91,7 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
           ) : null}
         </AnimatePresence>
       )}
-    </>
+    </RemoveScroll>
   );
 });
 

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -4,7 +4,7 @@ import type {OverlayTriggerProps} from "@react-types/overlays";
 import type {HTMLMotionProps} from "framer-motion";
 import type {OverlayOptions} from "@nextui-org/aria-utils";
 
-import {ReactNode, Ref, useId, useImperativeHandle} from "react";
+import {ReactNode, Ref, useId, useImperativeHandle, useMemo, useRef, useCallback} from "react";
 import {useTooltipTriggerState} from "@react-stately/tooltip";
 import {mergeProps} from "@react-aria/utils";
 import {useTooltip as useReactAriaTooltip, useTooltipTrigger} from "@react-aria/tooltip";
@@ -17,9 +17,7 @@ import {
 } from "@nextui-org/system";
 import {popover} from "@nextui-org/theme";
 import {clsx, dataAttr, objectToDeps} from "@nextui-org/shared-utils";
-import {ReactRef, mergeRefs} from "@nextui-org/react-utils";
-import {createDOMRef} from "@nextui-org/react-utils";
-import {useMemo, useRef, useCallback} from "react";
+import {ReactRef, mergeRefs, createDOMRef} from "@nextui-org/react-utils";
 import {toReactAriaPlacement, getArrowPlacement} from "@nextui-org/aria-utils";
 import {useSafeLayoutEffect} from "@nextui-org/use-safe-layout-effect";
 
@@ -82,6 +80,10 @@ interface Props extends Omit<HTMLNextUIProps, "content"> {
    * ```
    */
   classNames?: SlotsToClasses<"base" | "arrow" | "content">;
+  /**
+   * shouldBlockScroll to stop scrolling when tooltip is open.
+   */
+  shouldBlockScroll?: boolean;
 }
 
 export type UseTooltipProps = Props &
@@ -123,6 +125,7 @@ export function useTooltip(originalProps: UseTooltipProps) {
     onClose,
     motionProps,
     classNames,
+    shouldBlockScroll = false,
     ...otherProps
   } = props;
 
@@ -247,6 +250,7 @@ export function useTooltip(originalProps: UseTooltipProps) {
       style: mergeProps(positionProps.style, otherProps.style, props.style),
       className: slots.base({class: classNames?.base}),
       id: tooltipId,
+      shouldBlockScroll,
     }),
     [
       slots,
@@ -261,6 +265,7 @@ export function useTooltip(originalProps: UseTooltipProps) {
       positionProps,
       props,
       tooltipId,
+      shouldBlockScroll,
     ],
   );
 

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -82,6 +82,7 @@ interface Props extends Omit<HTMLNextUIProps, "content"> {
   classNames?: SlotsToClasses<"base" | "arrow" | "content">;
   /**
    * shouldBlockScroll to stop scrolling when tooltip is open.
+   *  @default true
    */
   shouldBlockScroll?: boolean;
 }
@@ -125,7 +126,7 @@ export function useTooltip(originalProps: UseTooltipProps) {
     onClose,
     motionProps,
     classNames,
-    shouldBlockScroll = false,
+    shouldBlockScroll = true,
     ...otherProps
   } = props;
 

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -82,7 +82,7 @@ interface Props extends Omit<HTMLNextUIProps, "content"> {
   classNames?: SlotsToClasses<"base" | "arrow" | "content">;
   /**
    * shouldBlockScroll to stop scrolling when tooltip is open.
-   *  @default true
+   * @default true
    */
   shouldBlockScroll?: boolean;
 }

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -38,6 +38,11 @@ export default {
         type: "boolean",
       },
     },
+    shouldBlockScroll: {
+      control: {
+        type: "boolean",
+      },
+    },
     placement: {
       control: {
         type: "select",
@@ -283,6 +288,13 @@ export const WithArrow = {
   },
 };
 
+export const DisbaleScrollbar = {
+  args: {
+    ...defaultProps,
+    shouldBlockScroll: false,
+  },
+};
+
 export const OpenChange = {
   render: OpenChangeTemplate,
 
@@ -380,6 +392,7 @@ export const AlwaysOpen = {
     ...defaultProps,
     isOpen: true,
     showArrow: true,
+    shouldBlockScroll: true,
     content: (
       <div className="px-1 py-2">
         <div className="text-sm font-bold">Custom Content</div>

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -38,11 +38,6 @@ export default {
         type: "boolean",
       },
     },
-    shouldBlockScroll: {
-      control: {
-        type: "boolean",
-      },
-    },
     placement: {
       control: {
         type: "select",
@@ -285,13 +280,6 @@ export const WithArrow = {
   args: {
     ...defaultProps,
     showArrow: true,
-  },
-};
-
-export const DisableScrollbar = {
-  args: {
-    ...defaultProps,
-    shouldBlockScroll: true,
   },
 };
 

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -392,7 +392,6 @@ export const AlwaysOpen = {
     ...defaultProps,
     isOpen: true,
     showArrow: true,
-    shouldBlockScroll: true,
     content: (
       <div className="px-1 py-2">
         <div className="text-sm font-bold">Custom Content</div>

--- a/packages/components/tooltip/stories/tooltip.stories.tsx
+++ b/packages/components/tooltip/stories/tooltip.stories.tsx
@@ -288,10 +288,10 @@ export const WithArrow = {
   },
 };
 
-export const DisbaleScrollbar = {
+export const DisableScrollbar = {
   args: {
     ...defaultProps,
-    shouldBlockScroll: false,
+    shouldBlockScroll: true,
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 4.0.2(eslint@7.32.0)(webpack@5.91.0)
       eslint-plugin-import:
         specifier: ^2.26.0
-        version: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+        version: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       eslint-plugin-jest:
         specifier: ^24.3.6
         version: 24.7.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@7.32.0)(typescript@4.9.5)
@@ -2772,6 +2772,9 @@ importers:
       '@react-types/tooltip':
         specifier: 3.4.9
         version: 3.4.9(react@18.2.0)
+      react-remove-scroll:
+        specifier: ^2.5.6
+        version: 2.5.9(@types/react@18.2.8)(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -16030,7 +16033,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       object.assign: 4.1.5
       object.entries: 1.1.8
     dev: true
@@ -16063,7 +16066,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.29.1)(eslint@7.32.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
       eslint-plugin-react: 7.34.1(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
@@ -16086,7 +16089,7 @@ packages:
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@7.32.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
       eslint-plugin-react: 7.34.1(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
@@ -16135,7 +16138,7 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-flowtype: 5.10.0(eslint@7.32.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       eslint-plugin-jest: 24.7.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@7.32.0)(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@7.32.0)
       eslint-plugin-react: 7.34.1(eslint@7.32.0)
@@ -16176,7 +16179,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 7.32.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.8
@@ -16196,7 +16199,7 @@ packages:
       enhanced-resolve: 5.16.0
       eslint: 7.32.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -16307,7 +16310,7 @@ packages:
       string-natural-compare: 3.0.1
     dev: true
 
-  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0):
+  /eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@7.32.0):
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
     engines: {node: '>=4'}
     peerDependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3474

## 📝 Description

> This pull request addresses a bug (#3474) where scrolling was occurring when tooltip was open. The issue was causing unintended scrolling behavior that disrupted user experience.

## ⛳️ Current behavior (updates)

> When a tooltip is open, users are able to scroll the page. This unintended scrolling can cause the tooltip to move out of view or create confusion for users.

## 🚀 New behavior

> When a tooltip is open, the page scrolling is disabled. The tooltip remains in a fixed position relative to its target, ensuring it stays visible and does not move out of view.

## 💣 Is this a breaking change (Yes/No):

Yes, as the tooltip when open it will stop scrolling.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `shouldBlockScroll` option to tooltips to control scrolling behavior, preventing accidental scrolling when the tooltip is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->