### PR TITLE
fix(use-input): sync the inputValue with domRef.current.value when hovering the input

### DIFF
--- a/.changeset/angry-icons-jump.md
+++ b/.changeset/angry-icons-jump.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+sync the inputValue with domRef.current.value when hovering the input

--- a/.changeset/angry-icons-jump.md
+++ b/.changeset/angry-icons-jump.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-sync the inputValue with domRef.current.value when hovering the input (#3024, #3436)
+sync the inputValue with domRef.current.value when hovering or tabbing the input (#3024, #3436)

--- a/.changeset/angry-icons-jump.md
+++ b/.changeset/angry-icons-jump.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-sync the inputValue with domRef.current.value when hovering the input
+sync the inputValue with domRef.current.value when hovering the input (#3024, #3436)

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -186,7 +186,8 @@ describe("Input", () => {
 
     const {container} = render(<Input ref={ref} value="value" />);
     const inputBase = container.querySelector("[data-slot='base']");
-    const input = inputBase && inputBase.querySelector("input");
+    const input = inputBase?.querySelector("input");
+
     const user = userEvent.setup();
 
     expect(inputBase).not.toBeNull();

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -180,6 +180,23 @@ describe("Input", () => {
 
     expect(inputs[1]).toBeVisible();
   });
+
+  it("should sync ref.current.value with input's value after hovering over the input", async () => {
+    const ref = React.createRef<HTMLInputElement>();
+
+    const {container} = render(<Input ref={ref} value="value" />);
+    const inputBase = container.querySelector("[data-slot='base']");
+    const input = inputBase && inputBase.querySelector("input");
+    const user = userEvent.setup();
+
+    if (!input) throw new Error("input is null");
+    if (!ref.current) throw new Error("ref is null");
+
+    ref.current.value = "new value";
+    await user.hover(inputBase);
+
+    expect(input).toHaveValue("new value");
+  });
 });
 
 describe("Input with React Hook Form", () => {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -15,7 +15,7 @@ describe("Input", () => {
   it("ref should be forwarded", () => {
     const ref = React.createRef<HTMLInputElement>();
 
-    render(<Input ref={ref} label="test should clear the valueinput" />);
+    render(<Input ref={ref} label="test input" />);
     expect(ref.current).not.toBeNull();
   });
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -206,6 +206,30 @@ describe("Input", () => {
   });
 });
 
+it("should sync ref.current.value with input's value after hovering the input", async () => {
+  const user = userEvent.setup();
+  const ref = React.createRef<HTMLInputElement>();
+
+  const {container} = render(<Input ref={ref} value="value" />);
+
+  expect(ref.current).not.toBeNull();
+
+  const inputBase = container.querySelector("[data-slot='base']");
+
+  expect(inputBase).not.toBeNull();
+
+  const input = container.querySelector("input");
+
+  expect(input).not.toBeNull();
+
+  ref.current!.value = "new value";
+
+  await act(async () => {
+    await user.hover(inputBase!);
+  });
+  expect(input).toHaveValue("new value");
+});
+
 describe("Input with React Hook Form", () => {
   let input1: HTMLInputElement;
   let input2: HTMLInputElement;

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -15,7 +15,7 @@ describe("Input", () => {
   it("ref should be forwarded", () => {
     const ref = React.createRef<HTMLInputElement>();
 
-    render(<Input ref={ref} label="test input" />);
+    render(<Input ref={ref} label="test should clear the valueinput" />);
     expect(ref.current).not.toBeNull();
   });
 
@@ -181,7 +181,7 @@ describe("Input", () => {
     expect(inputs[1]).toBeVisible();
   });
 
-  it("should sync ref.current.value with input's value after hovering over the input", async () => {
+  it("should sync ref.current.value with input's value after clicking the input", async () => {
     const ref = React.createRef<HTMLInputElement>();
 
     const {container} = render(<Input ref={ref} value="value" />);
@@ -195,8 +195,7 @@ describe("Input", () => {
     expect(ref.current).not.toBeNull();
 
     ref.current!.value = "new value";
-    await user.hover(inputBase!);
-
+    await user.click(inputBase!);
     expect(input).toHaveValue("new value");
   });
 });

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -189,11 +189,12 @@ describe("Input", () => {
     const input = inputBase && inputBase.querySelector("input");
     const user = userEvent.setup();
 
-    if (!input) throw new Error("input is null");
-    if (!ref.current) throw new Error("ref is null");
+    expect(inputBase).not.toBeNull();
+    expect(input).not.toBeNull();
+    expect(ref.current).not.toBeNull();
 
-    ref.current.value = "new value";
-    await user.hover(inputBase);
+    ref.current!.value = "new value";
+    await user.hover(inputBase!);
 
     expect(input).toHaveValue("new value");
   });

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {render, renderHook, fireEvent} from "@testing-library/react";
+import {render, renderHook, fireEvent, act} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {useForm} from "react-hook-form";
 
@@ -182,20 +182,26 @@ describe("Input", () => {
   });
 
   it("should sync ref.current.value with input's value after clicking the input", async () => {
+    const user = userEvent.setup();
     const ref = React.createRef<HTMLInputElement>();
 
     const {container} = render(<Input ref={ref} value="value" />);
-    const inputBase = container.querySelector("[data-slot='base']");
-    const input = inputBase?.querySelector("input");
 
-    const user = userEvent.setup();
-
-    expect(inputBase).not.toBeNull();
-    expect(input).not.toBeNull();
     expect(ref.current).not.toBeNull();
 
+    const inputBase = container.querySelector("[data-slot='base']");
+
+    expect(inputBase).not.toBeNull();
+
+    const input = container.querySelector("input");
+
+    expect(input).not.toBeNull();
+
     ref.current!.value = "new value";
-    await user.click(inputBase!);
+
+    await act(async () => {
+      await user.click(inputBase!);
+    });
     expect(input).toHaveValue("new value");
   });
 });

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -158,6 +158,10 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     domRef.current?.focus();
   }, [setInputValue, onClear]);
 
+  const syncRefValueToInputValue = () => {
+    setInputValue(domRef.current?.value);
+  };
+
   // if we use `react-hook-form`, it will set the input value using the ref in register
   // i.e. setting ref.current.value to something which is uncontrolled
   // hence, sync the state with `ref.current.value`
@@ -207,10 +211,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
 
   const {isHovered, hoverProps} = useHover({
     isDisabled: !!originalProps?.isDisabled,
-    onHoverStart: () => {
-      if (!domRef.current) return;
-      setInputValue(domRef.current.value);
-    },
+    onHoverStart: syncRefValueToInputValue,
   });
 
   const {focusProps: clearFocusProps, isFocusVisible: isClearButtonFocusVisible} = useFocusRing();
@@ -222,6 +223,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const {pressProps: clearPressProps} = usePress({
     isDisabled: !!originalProps?.isDisabled,
     onPress: handleClear,
+    onPressStart: syncRefValueToInputValue,
   });
 
   const isInvalid = validationState === "invalid" || originalProps.isInvalid || isAriaInvalid;

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -205,7 +205,13 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     isTextInput: true,
   });
 
-  const {isHovered, hoverProps} = useHover({isDisabled: !!originalProps?.isDisabled});
+  const {isHovered, hoverProps} = useHover({
+    isDisabled: !!originalProps?.isDisabled,
+    onHoverStart: () => {
+      if (!domRef.current) return;
+      setInputValue(domRef.current.value);
+    },
+  });
 
   const {focusProps: clearFocusProps, isFocusVisible: isClearButtonFocusVisible} = useFocusRing();
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3024
Closes #3436

## 📝 Description

> Add a brief description

### Problem
1. setting the input's value via its ref 
2. (but not updated `inputValue`)
3. hovering the input
4. `isHovered` is updated, so re-render occurs.
5. `<Input/>` uses the `inputValue` that is not updated to new value.


### Solve
when hover start, `setInputValues(domRef.current.value)`


## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying


https://github.com/user-attachments/assets/312b2d96-def4-44f3-af57-48d7f63416e4



## 🚀 New behavior

> Please describe the behavior or changes this PR adds


https://github.com/user-attachments/assets/bb7ed45e-3c78-4fb4-84d8-f4d5516750cd




## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a hover functionality that sets the input value when hovering starts.

- **Tests**
	- Added test cases to ensure input value syncs correctly when hovering and clicking on the input element in the `Input` component when used with React Hook Form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->