### PR TITLE
fix(listbox): card shadow clipping when inside listbox item

### DIFF
--- a/.changeset/bright-avocados-yell.md
+++ b/.changeset/bright-avocados-yell.md
@@ -1,5 +1,0 @@
----
-"@nextui-org/theme": patch
----
-
-fixed the shadow clipping of card inside listbox or menubox item (#3480)

--- a/.changeset/bright-avocados-yell.md
+++ b/.changeset/bright-avocados-yell.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the shadow clipping of card inside listbox or menubox item (#3480)

--- a/.changeset/five-teachers-refuse.md
+++ b/.changeset/five-teachers-refuse.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-fixed the shadow clipping of card inside listbox or menubox item
+fixed the shadow clipping of card inside listbox or menubox item (#3480)

--- a/.changeset/five-teachers-refuse.md
+++ b/.changeset/five-teachers-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the shadow clipping of card inside listbox or menubox item

--- a/packages/core/theme/src/components/menu.ts
+++ b/packages/core/theme/src/components/menu.ts
@@ -71,7 +71,7 @@ const menuItem = tv({
       "data-[focus-visible=true]:dark:ring-offset-background-content1",
     ],
     wrapper: "w-full flex flex-col items-start justify-center",
-    title: "flex-1 text-small font-normal truncate",
+    title: "flex-1 text-small font-normal overflow-visible",
     description: ["w-full", "text-tiny", "text-foreground-500", "group-hover:text-current"],
     selectedIcon: ["text-inherit", "w-3", "h-3", "flex-shrink-0"],
     shortcut: [

--- a/packages/core/theme/src/components/menu.ts
+++ b/packages/core/theme/src/components/menu.ts
@@ -71,7 +71,7 @@ const menuItem = tv({
       "data-[focus-visible=true]:dark:ring-offset-background-content1",
     ],
     wrapper: "w-full flex flex-col items-start justify-center",
-    title: "flex-1 text-small font-normal overflow-visible",
+    title: "flex-1 text-small font-normal",
     description: ["w-full", "text-tiny", "text-foreground-500", "group-hover:text-current"],
     selectedIcon: ["text-inherit", "w-3", "h-3", "flex-shrink-0"],
     shortcut: [


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3480

## 📝 Description

Fixed the clipping of card shadow, when present inside listbox-item or menubox-item

## ⛳️ Current behavior (updates)

<img width="551" alt="Screenshot 2024-07-17 at 3 01 56 AM" src="https://github.com/user-attachments/assets/e4d0783f-d2a6-47c0-99c4-bdb2b72e6997">

## 🚀 New behavior

<img width="631" alt="Screenshot 2024-07-17 at 3 02 36 AM" src="https://github.com/user-attachments/assets/f7dbc11b-cd91-4e35-a530-efffb22a2477">


## 💣 Is this a breaking change (Yes/No): No



## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with shadow clipping for cards inside listbox or menubox items.
  - Improved text overflow behavior in menu items by adjusting the style attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->