### PR TITLE
fix(docs): remove body position which cause popover/tooltip wrong

### DIFF
--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -15,7 +15,6 @@ html {
 
 body {
   min-height: 100vh;
-  position: relative;
 }
 /* Experimental */
 /* body::after { 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #3461
- Closes #2778 

## 📝 Description

`apps/docs/app/layout.tsx` 

The child element of the body have been added `position: relative`

<img width="785" alt="image" src="https://github.com/user-attachments/assets/031f29a7-0688-479f-9ab4-664097f032f6">

![CleanShot 2024-07-17 at 09 56 42](https://github.com/user-attachments/assets/a2f1746e-7674-4077-bc40-e40fad01c7d4)


> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
