### PR TITLE
fix(table): sortable header slow color change during theme change

### DIFF
--- a/.changeset/thirty-jars-love.md
+++ b/.changeset/thirty-jars-love.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the slow color change of sortable table header during theme change(#3488)

--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -74,7 +74,6 @@ const table = tv({
       "rtl:last:rounded-l-lg",
       "rtl:last:rounded-r-[unset]",
       "outline-none",
-      "data-[sortable=true]:transition-colors",
       "data-[sortable=true]:cursor-pointer",
       "data-[hover=true]:text-foreground-400",
       ...dataFocusVisibleClasses,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3488
## 📝 Description

 removed the `transition-colors` css to fix the slow color change of sortable table header during theme change

## ⛳️ Current behavior (updates)

https://github.com/user-attachments/assets/05a02744-1721-44c7-900e-7b9eb2ed5caa

## 🚀 New behavior

https://github.com/user-attachments/assets/3e38ed09-9c9f-4b72-9808-30b55fb5b5b4

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
