### PR TITLE
fix(modal): double scrollbar in inside scrollbehaviour

### DIFF
--- a/.changeset/seven-onions-explain.md
+++ b/.changeset/seven-onions-explain.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the issue of double scrollbar in modal with inside scrollbehaviour

--- a/.changeset/seven-onions-explain.md
+++ b/.changeset/seven-onions-explain.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-fixed the issue of double scrollbar in modal with inside scrollbehaviour
+fixed the issue of double scrollbar in modal with inside `scrollBehavior` (#3942)

--- a/packages/core/theme/src/components/modal.ts
+++ b/packages/core/theme/src/components/modal.ts
@@ -157,7 +157,7 @@ const modal = tv({
         base: "overflow-y-hidden",
       },
       inside: {
-        base: "max-h-[calc(100%_-_7.5rem)]",
+        base: "max-h-[calc(100%_-_8rem)]",
         body: "overflow-y-auto",
       },
       outside: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3492

## 📝 Description

 Reduced the modal height to avoid 2nd scrollbar from `100%_-_7.5rem` to  `100%_-_8rem`

## ⛳️ Current behavior (updates)

<img width="1440" alt="Screenshot 2024-07-18 at 2 52 49 AM" src="https://github.com/user-attachments/assets/a3f7ee7e-9b6f-4971-8460-58da4fe73773">

## 🚀 New behavior

<img width="1227" alt="Screenshot 2024-07-18 at 2 51 56 AM" src="https://github.com/user-attachments/assets/6c6d4720-606a-4871-aa60-61e8c7f6b270">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Addressed the issue of a double scrollbar appearing in modals with inside scroll behavior.
  - Adjusted modal component styling to improve vertical space management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->