### PR TITLE
fix(theme): button scaling when disableAnimation is true

### DIFF
--- a/.changeset/empty-countries-count.md
+++ b/.changeset/empty-countries-count.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Fixed button scaling when `disableAnimation` is `true` (#3489)

--- a/packages/core/theme/src/components/button.ts
+++ b/packages/core/theme/src/components/button.ts
@@ -85,7 +85,7 @@ const button = tv({
       false: "[&>svg]:max-w-[theme(spacing.8)]",
     },
     disableAnimation: {
-      true: "!transition-none",
+      true: "!transition-none data-[pressed=true]:scale-100",
       false: "transition-transform-colors-opacity motion-reduce:transition-none",
     },
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3489

## 📝 Description

`data-[pressed=true]:scale-[0.97]` was moved from `disableAnimation` false case to global base in [here](https://github.com/nextui-org/nextui/pull/2929/files#diff-ae075221d59003e0b1c8add05fbb594132e2df8bd2d6b987f48aec5188166486L89). With such change, `data-[pressed=true]:scale-[0.97]` will be also applied to the true case now.

## ⛳️ Current behavior (updates)

there is scaling on press when `disableAnimation` is `true`

[pr3499-before.webm](https://github.com/user-attachments/assets/31cac2d4-b047-4200-b6a4-22a731aa73b3)

## 🚀 New behavior

there is no scaling on press when `disableAnimation` is `true`

[pr3499-after.webm](https://github.com/user-attachments/assets/11779b02-9380-424c-a9d6-9d493385d114)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
