### PR TITLE
build(script): fixing Clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "format:write": "prettier --write packages/**/**/src --cache",
     "turbo:clean": "turbo clean && rimraf ./node_modules/.cache/turbo",
     "turbo:graph": "pnpm build --graph=dependency-graph.png",
-    "clean": "pnpm turbo:clean && pnpm clean:jest && pnpm clean:node-modules && pnpm clean:lock && pnpm install --hoist",
+    "clean": "pnpm turbo:clean && pnpm clean:jest && pnpm clean:lock && pnpm clean:node-modules && pnpm install --hoist",
     "clean:node-modules": "rimraf ./apps/**/node_modules && rimraf ./packages/**/**/node_modules && rimraf ./node_modules",
     "clean:changelogs": "rimraf ./packages/**/**/CHANGELOG.md",
     "clean:lock": "rimraf ./pnpm-lock.yaml",


### PR DESCRIPTION
running clean lock before clean node modules.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description
Cleaning node modules before cleaning the lock files fails since the rimraf cmd is deleted from node_modules.
This prevents the furture execution of the script to install the npm dependencies back.

> Add a brief description

## ⛳️ Current behavior (updates)
Clean script failing.
> Please describe the current behavior that you are modifying

## 🚀 New behavior
Clean scipt succed if we remove the node modules after the lock files.
> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
