### PR TITLE
fix(system-rsc): defaultVariants null case in extendVariants

### DIFF
--- a/.changeset/sharp-bobcats-happen.md
+++ b/.changeset/sharp-bobcats-happen.md
@@ -2,4 +2,4 @@
 "@nextui-org/system-rsc": patch
 ---
 
-handled defaultVariants null case in extendVariants
+handled defaultVariants null case in extendVariants (#3502)

--- a/.changeset/sharp-bobcats-happen.md
+++ b/.changeset/sharp-bobcats-happen.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system-rsc": patch
+---
+
+handled defaultVariants null case in extendVariants

--- a/packages/core/system-rsc/src/extend-variants.js
+++ b/packages/core/system-rsc/src/extend-variants.js
@@ -47,14 +47,17 @@ function getClassNamesWithProps({
   const customTv = tv(
     {
       variants,
-      // Do not apply default variants when the props variant is different
-      defaultVariants: Object.keys(defaultVariants)
-        .filter((k) => !keys.includes(k))
-        .reduce((o, k) => {
-          o[k] = defaultVariants[k];
+      defaultVariants:
+        defaultVariants && typeof defaultVariants === "object"
+          ? // Do not apply default variants when the props variant is different
+            Object.keys(defaultVariants)
+              .filter((k) => !keys.includes(k))
+              .reduce((o, k) => {
+                o[k] = defaultVariants[k];
 
-          return o;
-        }, []),
+                return o;
+              }, [])
+          : defaultVariants,
       compoundVariants,
       ...(hasSlots && {slots}),
     },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3502

## 📝 Description

handled defaultVariants null case in defaultVariants

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of default variants in the system to prevent application of incorrect default styles when the provided variant is different.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->