### PR TITLE
fix(docs): typo in date picker page

### DIFF
--- a/apps/docs/content/docs/components/date-picker.mdx
+++ b/apps/docs/content/docs/components/date-picker.mdx
@@ -277,7 +277,7 @@ import {I18nProvider} from "@react-aria/i18n";
 `DatePicker` has the following attributes on the `base` element:
 
 - **data-slot**:
-  All slots have this prop. which slot the element represents(e.g. `canlendar`).
+  All slots have this prop. which slot the element represents(e.g. `calendar`).
 - **data-open**:
   Indicates if the calendar popover is open.
 - **data-invalid**:


### PR DESCRIPTION
`canlendar` → `calendar`

## 📝 Description

Updating a typo 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the `DatePicker` component documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->