### PR TITLE
fix(navbar):  over height when style h-full

### DIFF
--- a/.changeset/brown-days-applaud.md
+++ b/.changeset/brown-days-applaud.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the navbar height when `h-full`(#1694)

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -52,7 +52,7 @@ const navbar = tv({
       "flex",
       "z-40",
       "w-full",
-      "h-auto",
+      "max-h-[var(--navbar-height)]",
       "items-center",
       "justify-center",
       "data-[menu-open=true]:border-none",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1694

## 📝 Description

Fixed the complete screen  covering by navbar when `h-full` styled. 

## Current Behaviour
<img width="740" alt="before-1" src="https://github.com/user-attachments/assets/1a96d4b5-86ec-4c23-90d3-e506a6eee9b9">
<img width="776" alt="before-2" src="https://github.com/user-attachments/assets/88e16158-98a0-434a-89c3-e1da0a510624">


## 🚀 New behavior

<img width="750" alt="after" src="https://github.com/user-attachments/assets/57ebea7a-bfcb-452a-8afa-e8139b8bf550">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with the navbar height when using the `h-full` class, enhancing layout consistency.
  
- **Improvements**
	- Adjusted navbar height properties for better responsiveness using CSS variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->