### PR TITLE
fix(navbar ): height overflow when h-full

### DIFF
--- a/.changeset/brown-days-applaud.md
+++ b/.changeset/brown-days-applaud.md
@@ -1,5 +1,0 @@
----
-"@nextui-org/theme": patch
----
-
-fixed the navbar height when `h-full`(#1694)

--- a/.changeset/brown-days-applaud.md
+++ b/.changeset/brown-days-applaud.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the navbar height when `h-full`(#1694)

--- a/.changeset/funny-mayflies-return.md
+++ b/.changeset/funny-mayflies-return.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-fixed the over-covering navbar height when h-full
+fixed the over-covering navbar height when h-full ([#1694](https://github.com/nextui-org/nextui/issues/1694))

--- a/.changeset/funny-mayflies-return.md
+++ b/.changeset/funny-mayflies-return.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fixed the over-covering navbar height when h-full

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -52,7 +52,7 @@ const navbar = tv({
       "flex",
       "z-40",
       "w-full",
-      "h-[var(--navbar-height)]",
+      "max-h-[var(--navbar-height)]",
       "items-center",
       "justify-center",
       "data-[menu-open=true]:border-none",

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -52,7 +52,7 @@ const navbar = tv({
       "flex",
       "z-40",
       "w-full",
-      "max-h-[var(--navbar-height)]",
+      "h-[var(--navbar-height)]",
       "items-center",
       "justify-center",
       "data-[menu-open=true]:border-none",

--- a/packages/core/theme/src/components/navbar.ts
+++ b/packages/core/theme/src/components/navbar.ts
@@ -52,7 +52,7 @@ const navbar = tv({
       "flex",
       "z-40",
       "w-full",
-      "h-auto",
+      "max-h-[var(--navbar-height)]",
       "items-center",
       "justify-center",
       "data-[menu-open=true]:border-none",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #1694

## 📝 Description

Fixed the overflow of navbar height over main content 

## ⛳️ Current behavior (updates)

<img width="640" alt="before-1" src="https://github.com/user-attachments/assets/b794951e-956a-4df6-bb0b-a6792fce7a75">
<img width="676" alt="before-2" src="https://github.com/user-attachments/assets/d8c74578-f3d9-4998-8e0c-47f2f4a93674">


## 🚀 New behavior

<img width="650" alt="after" src="https://github.com/user-attachments/assets/a2eba7bb-a815-4a85-b2d4-42dd86cdbb29">


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the navbar height, preventing it from taking up excessive vertical space in full-height scenarios. 
	- Improved layout stability and usability for components using the updated theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->