### PR TITLE
fix(select): prevent select from closing instantly when clicking on label of select

### DIFF
--- a/.changeset/clean-dryers-notice.md
+++ b/.changeset/clean-dryers-notice.md
@@ -2,4 +2,4 @@
 "@nextui-org/select": patch
 ---
 
-Fix toggle issue while clicking on label of select component unexpectedly open and close the model instantly.The removal of code block containing group-data-[filled=true]:pointer-events-auto prevent from any unwanted user interactions and resolve the flickering issue.
+Fixed toggle issue while clicking on label of select component unexpectedly open and close the model instantly. The removal of code block containing `group-data-[filled=true]:pointer-events-auto` prevent from any unwanted user interactions and resolve the flickering issue (#3558)

--- a/.changeset/clean-dryers-notice.md
+++ b/.changeset/clean-dryers-notice.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Fix toggle issue while clicking on label of select component unexpectedly open and close the model instantly.The removal of code block containing group-data-[filled=true]:pointer-events-auto prevent from any unwanted user interactions and resolve the flickering issue.

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -469,9 +469,6 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
       }),
       ...labelProps,
       ...props,
-      onClick: (e: React.MouseEvent<HTMLLabelElement>) => {
-        e.preventDefault();
-      },
     }),
     [slots, classNames?.label, labelProps],
   );

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -469,6 +469,9 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
       }),
       ...labelProps,
       ...props,
+      onClick: (e: React.MouseEvent<HTMLLabelElement>) => {
+        e.preventDefault();
+      },
     }),
     [slots, classNames?.label, labelProps],
   );

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -535,13 +535,6 @@ const select = tv({
         trigger: "h-16 min-h-16 py-2.5 gap-0",
       },
     },
-    //  labelPlacement=[inside, outside]
-    {
-      labelPlacement: ["inside", "outside"],
-      class: {
-        label: ["group-data-[filled=false]:pointer-events-auto"],
-      },
-    },
     {
       labelPlacement: "outside",
       isMultiline: false,

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -539,7 +539,7 @@ const select = tv({
     {
       labelPlacement: ["inside", "outside"],
       class: {
-        label: ["group-data-[filled=true]:pointer-events-auto"],
+        label: ["group-data-[filled=false]:pointer-events-auto"],
       },
     },
     {


### PR DESCRIPTION
Closes #3558
Closes #3683

📝 Description

Fixed select component unexpectedly close while click on label of select component

⛳️ Current behavior (updates)

Below recording shows the current behavior of component.

https://github.com/user-attachments/assets/7bc1411b-e456-41d3-92d7-1032ca0c6e45


🚀 New behavior

Below recording shows the fix behavior of component

https://github.com/user-attachments/assets/73bb0136-5905-4536-8fb0-d40a2f84bb92


💣 Is this a breaking change (Yes/No):No

📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved user interaction by preventing default actions on label clicks within the select component.
	- Simplified interaction model for the select component by adjusting class assignments based on its filled state.

- **Bug Fixes**
	- Resolved a toggle issue in the select component that caused unexpected behavior when clicking on the label, enhancing the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->