### PR TITLE
refactor(deps): remove react copy from react-rsc-utils bundle

### DIFF
--- a/.changeset/tall-balloons-sleep.md
+++ b/.changeset/tall-balloons-sleep.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/react-rsc-utils": patch
+---
+
+added react to peerDependencies to remove react copy from react-rsc-utils bundle (#3531)

--- a/packages/utilities/react-rsc-utils/package.json
+++ b/packages/utilities/react-rsc-utils/package.json
@@ -37,8 +37,12 @@
     "prepack": "clean-package",
     "postpack": "clean-package restore"
   },
+  "peerDependencies": {
+    "react": ">=18"
+  },
   "devDependencies": {
-    "clean-package": "2.2.0"
+    "clean-package": "2.2.0",
+    "react": "^18.0.0"
   },
   "clean-package": "../../../clean-package.config.json",
   "tsup": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3710,6 +3710,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
 
   packages/utilities/react-utils:
     dependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3531

## 📝 Description

`react-rsc-utils` currently bundles a copy of React, increasing the size of the bundle and making NextUI incompatible with Preact

## ⛳️ Current behavior (updates)

<img width="342" alt="image" src="https://github.com/user-attachments/assets/7df892f1-5fa5-4a99-9079-b0058b1f50d8">

## 🚀 New behavior

<img width="321" alt="image" src="https://github.com/user-attachments/assets/eaf5cb03-f6f4-4706-b9cd-ff18917db585">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated compatibility requirements for the `react-rsc-utils` package to support React version 18 or higher.
  
- **Chores**
	- Enhanced dependency management to prevent bundling multiple instances of React, ensuring better application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->