### PR TITLE
fix(navbar): allow height prop to accept number type and fix broken menu

### DIFF
--- a/.changeset/healthy-clouds-refuse.md
+++ b/.changeset/healthy-clouds-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/navbar": patch
+---
+
+Fix navbar menu breaking when a numerical height value is provided. The height value is now converted to pixels if it is a number.

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -50,7 +50,7 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
         data-open={dataAttr(isMenuOpen)}
         style={{
           // @ts-expect-error
-          "--navbar-height": height,
+          "--navbar-height": typeof height === "number" ? `${height}px` : height,
         }}
         {...otherProps}
       >
@@ -72,7 +72,7 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
               initial="exit"
               style={{
                 // @ts-expect-error
-                "--navbar-height": height,
+                "--navbar-height": typeof height === "number" ? `${height}px` : height,
                 ...style,
               }}
               variants={menuVariants}

--- a/packages/components/navbar/src/use-navbar.ts
+++ b/packages/components/navbar/src/use-navbar.ts
@@ -198,7 +198,7 @@ export function useNavbar(originalProps: UseNavbarProps) {
     ref: domRef,
     className: slots.base({class: clsx(baseStyles, props?.className)}),
     style: {
-      "--navbar-height": height,
+      "--navbar-height": typeof height === "number" ? `${height}px` : height,
       ...otherProps?.style,
       ...props?.style,
     },


### PR DESCRIPTION
## 📝 Description

> Navbar menu breaks when passing a custom height of type number. This PR fixes the issue by converting the height to pixels if it is a number.

## ⛳️ Current behavior (updates)

> Fixed the mentioned error. Now, we can pass custom height as either a number or a string without breaking the navbar menu.

## 🚀 New behavior

> The height parameter can be provided as a number, which will be automatically converted to pixels, or as a string. This ensures the navbar menu remains intact regardless of the input type.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No additional information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `height` property in the navbar component to prevent layout issues when specifying a numerical height value.

- **New Features**
	- Enhanced robustness of the `--navbar-height` CSS variable assignment by ensuring it always receives a valid pixel format for numerical values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->