### PR TITLE
fix(utilities): gregorian year offset for persian

### DIFF
--- a/.changeset/wild-apples-cheer.md
+++ b/.changeset/wild-apples-cheer.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/shared-utils": patch
+---
+
+fixed gregorian year offset for persian (#3602)

--- a/packages/utilities/shared-utils/src/dates.ts
+++ b/packages/utilities/shared-utils/src/dates.ts
@@ -16,7 +16,7 @@ export function getGregorianYearOffset(identifier: string): number {
     case "islamic-umalqura":
       return -579;
     case "persian":
-      return 622;
+      return -600;
     case "roc":
     case "japanese":
     case "gregory":


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3602

## 📝 Description

correct the gregorian year offset for persian suggested by Ehsan256

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the handling of date conversions for the Persian calendar, improving accuracy in date-related functionalities. 
	- Resolved a previously reported issue (#3602) related to the Gregorian year offset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->