### PR TITLE
fix(hooks): ensure exposed functions wrap by `useCallback`

### DIFF
--- a/.changeset/selfish-spies-visit.md
+++ b/.changeset/selfish-spies-visit.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/use-clipboard": patch
+"@nextui-org/use-real-shape": patch
+"@nextui-org/use-ref-state": patch
+---
+
+ensure exposed functions wrap by `useCallback`

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import {useCallback, useState} from "react";
 
 export interface UseClipboardProps {
   /**
@@ -18,34 +18,40 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
   const [copied, setCopied] = useState(false);
   const [copyTimeout, setCopyTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
 
-  const onClearTimeout = () => {
+  const onClearTimeout = useCallback(() => {
     if (copyTimeout) {
       clearTimeout(copyTimeout);
     }
-  };
+  }, [copyTimeout]);
 
-  const handleCopyResult = (value: boolean) => {
-    onClearTimeout();
-    setCopyTimeout(setTimeout(() => setCopied(false), timeout));
-    setCopied(value);
-  };
+  const handleCopyResult = useCallback(
+    (value: boolean) => {
+      onClearTimeout();
+      setCopyTimeout(setTimeout(() => setCopied(false), timeout));
+      setCopied(value);
+    },
+    [onClearTimeout, timeout],
+  );
 
-  const copy = (valueToCopy: any) => {
-    if ("clipboard" in navigator) {
-      navigator.clipboard
-        .writeText(valueToCopy)
-        .then(() => handleCopyResult(true))
-        .catch((err) => setError(err));
-    } else {
-      setError(new Error("useClipboard: navigator.clipboard is not supported"));
-    }
-  };
+  const copy = useCallback(
+    (valueToCopy: any) => {
+      if ("clipboard" in navigator) {
+        navigator.clipboard
+          .writeText(valueToCopy)
+          .then(() => handleCopyResult(true))
+          .catch((err) => setError(err));
+      } else {
+        setError(new Error("useClipboard: navigator.clipboard is not supported"));
+      }
+    },
+    [handleCopyResult],
+  );
 
-  const reset = () => {
+  const reset = useCallback(() => {
     setCopied(false);
     setError(null);
     onClearTimeout();
-  };
+  }, [onClearTimeout]);
 
   return {copy, reset, error, copied};
 }

--- a/packages/hooks/use-real-shape/src/index.ts
+++ b/packages/hooks/use-real-shape/src/index.ts
@@ -14,7 +14,7 @@ export function useRealShape<T extends HTMLElement>(ref: RefObject<T | null>) {
     const {width, height} = getRealShape(ref.current);
 
     setState({width, height});
-  }, [ref]);
+  }, []);
 
   useEffect(() => updateShape(), [updateShape]);
 

--- a/packages/hooks/use-real-shape/src/index.ts
+++ b/packages/hooks/use-real-shape/src/index.ts
@@ -1,4 +1,4 @@
-import {RefObject, useState, useEffect} from "react";
+import {RefObject, useCallback, useState, useEffect} from "react";
 import {ShapeType, getRealShape} from "@nextui-org/react-utils";
 
 export type ShapeResult = [ShapeType, () => void];
@@ -8,15 +8,15 @@ export function useRealShape<T extends HTMLElement>(ref: RefObject<T | null>) {
     width: 0,
     height: 0,
   });
-  const updateShape = () => {
+  const updateShape = useCallback(() => {
     if (!ref?.current) return;
 
     const {width, height} = getRealShape(ref.current);
 
     setState({width, height});
-  };
+  }, [ref]);
 
-  useEffect(() => updateShape(), [ref.current]);
+  useEffect(() => updateShape(), [updateShape]);
 
   return [shape, updateShape] as ShapeResult;
 }

--- a/packages/hooks/use-ref-state/src/index.ts
+++ b/packages/hooks/use-ref-state/src/index.ts
@@ -1,4 +1,12 @@
-import {Dispatch, MutableRefObject, SetStateAction, useEffect, useRef, useState} from "react";
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 export type CurrentStateType<S> = [S, Dispatch<SetStateAction<S>>, MutableRefObject<S>];
 
@@ -15,12 +23,12 @@ export function useRefState<S>(initialState: S | (() => S)) {
     ref.current = state;
   }, [state]);
 
-  const setValue = (val: SetStateAction<S>) => {
+  const setValue = useCallback((val: SetStateAction<S>) => {
     const result = typeof val === "function" ? (val as (prevState: S) => S)(ref.current) : val;
 
     ref.current = result;
     setState(result);
-  };
+  }, []);
 
   return [state, setValue, ref] as CurrentStateType<S>;
 }


### PR DESCRIPTION
Closes #

## 📝 Description

In this commit, I made improvements to our custom React hooks by wrapping the exposed functions with `useCallback`. This change aims to enhance performance.

## ⛳️ Current behavior (updates)

N/A.

## 🚀 New behavior

N/A.

## 💣 Is this a breaking change

No.

## 📝 Additional Information

By wrapping functions with `useCallback`, we ensure that these functions are not recreated on every component re-render unless their dependencies change. This optimization can significantly reduce unnecessary renders and improve the application's performance, especially when these functions are passed as props to child components.

By ensuring that the functions returned by our hooks are memoized, we provide a more consistent behavior, aligning with React's best practices. This consistency is particularly beneficial when dealing with complex state management or event handlers in components.

With functions wrapped in `useCallback`, developers can more easily reason about when and why a component might re-render, improving code maintainability and debugging ease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced performance of the application by optimizing hooks for clipboard handling, shape updates, and state management.
	- Improved efficiency in React components by memoizing critical functions, reducing unnecessary re-renders.
  
- **Bug Fixes**
	- Resolved issues related to function identity in props, ensuring stable behavior across component renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->