### PR TITLE
fixed a typo in override styles doc

### DIFF
--- a/apps/docs/content/docs/customization/override-styles.mdx
+++ b/apps/docs/content/docs/customization/override-styles.mdx
@@ -177,7 +177,7 @@ With the corresponding CSS module:
 
 ### CSS-in-JS
 
-If you are a CSS-in-JS library such as [styled-components](https://styled-components.com/) or [emotion](https://emotion.sh/), you can use the following
+If you are using a CSS-in-JS library such as [styled-components](https://styled-components.com/) or [emotion](https://emotion.sh/), you can use the following
 example to override the styles of a component:
 
 


### PR DESCRIPTION
Fixed a typo or maybe missing word inside the override-styles.mdx file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity in documentation by rephrasing a section related to CSS-in-JS libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->