### PR TITLE
fix(input): prevent clearable when input is readonly

### DIFF
--- a/.changeset/soft-wombats-wash.md
+++ b/.changeset/soft-wombats-wash.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-Fix issue where clear button is disabled when input is read-only.
+disable clear button when input is read-only

--- a/.changeset/soft-wombats-wash.md
+++ b/.changeset/soft-wombats-wash.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-Fix issue where clear button is shown when input is read-only
+Fix issue where clear button is disabled when input is read-only.

--- a/.changeset/soft-wombats-wash.md
+++ b/.changeset/soft-wombats-wash.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+Fix issue where clear button is shown when input is read-only

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -180,6 +180,26 @@ describe("Input", () => {
 
     expect(inputs[1]).toBeVisible();
   });
+
+  it("should not show clear button when isReadOnly is true", () => {
+    const {queryByRole} = render(
+      <Input isClearable isReadOnly defaultValue='This is "isReadOnly"' label="test input" />,
+    );
+
+    const clearButton = queryByRole("button");
+
+    expect(clearButton).toBeNull();
+  });
+
+  it("should show clear button when isReadOnly is false", () => {
+    const {getByRole} = render(
+      <Input isClearable defaultValue='This is "isReadOnly"' label="test input" />,
+    );
+
+    const clearButton = getByRole("button");
+
+    expect(clearButton).not.toBeNull();
+  });
 });
 
 describe("Input with React Hook Form", () => {

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -181,24 +181,31 @@ describe("Input", () => {
     expect(inputs[1]).toBeVisible();
   });
 
-  it("should not show clear button when isReadOnly is true", () => {
-    const {queryByRole} = render(
-      <Input isClearable isReadOnly defaultValue='This is "isReadOnly"' label="test input" />,
-    );
+  it("should disable clear button when isReadOnly is true", async () => {
+    const onClear = jest.fn();
 
-    const clearButton = queryByRole("button");
+    const ref = React.createRef<HTMLInputElement>();
 
-    expect(clearButton).toBeNull();
-  });
-
-  it("should show clear button when isReadOnly is false", () => {
     const {getByRole} = render(
-      <Input isClearable defaultValue='This is "isReadOnly"' label="test input" />,
+      <Input
+        ref={ref}
+        isClearable
+        isReadOnly
+        defaultValue="readOnly test for clear button"
+        label="test input"
+        onClear={onClear}
+      />,
     );
 
     const clearButton = getByRole("button");
 
     expect(clearButton).not.toBeNull();
+
+    const user = userEvent.setup();
+
+    await user.click(clearButton);
+
+    expect(onClear).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -214,7 +214,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   });
 
   const {pressProps: clearPressProps} = usePress({
-    isDisabled: !!originalProps?.isDisabled,
+    isDisabled: !!originalProps?.isDisabled || !!originalProps?.isReadOnly,
     onPress: handleClear,
   });
 
@@ -245,7 +245,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     typeof props.errorMessage === "function"
       ? props.errorMessage({isInvalid, validationErrors, validationDetails})
       : props.errorMessage || validationErrors?.join(" ");
-  const isClearable = !originalProps.isReadOnly && (!!onClear || originalProps.isClearable);
+  const isClearable = !!onClear || originalProps.isClearable;
   const hasElements = !!label || !!description || !!errorMessage;
   const hasPlaceholder = !!props.placeholder;
   const hasLabel = !!label;

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -245,7 +245,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     typeof props.errorMessage === "function"
       ? props.errorMessage({isInvalid, validationErrors, validationDetails})
       : props.errorMessage || validationErrors?.join(" ");
-  const isClearable = !!onClear || originalProps.isClearable;
+  const isClearable = !originalProps.isReadOnly && (!!onClear || originalProps.isClearable);
   const hasElements = !!label || !!description || !!errorMessage;
   const hasPlaceholder = !!props.placeholder;
   const hasLabel = !!label;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->


## 📝 Description

This PR addresses the issue where the clear button (`isClearable`) should not be displayed when the input field is read-only (`isReadOnly`). The `useInput` hook has been modified to automatically set `isClearable` to `false` when `isReadOnly` is `true`.

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/e68fefc0-01a2-4092-88f5-5fd013bed660)

Currently, the clear button can still be shown even if the input field is read-only. This is not the desired behavior because users should not be able to clear a read-only input field.

## 🚀 New behavior

With this PR, when the input field is set to read-only (`isReadOnly`), the clear button (`isClearable`) will automatically be hidden, ensuring that read-only fields cannot be cleared by the user.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

The `useInput` hook has been updated to check the `isReadOnly` property and conditionally set the `isClearable` property. This change ensures consistency and improves the user experience by preventing unintended actions on read-only fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit



- **New Features**
	- Improved usability of the input component by ensuring the clear button is disabled when the input is read-only.
  
- **Bug Fixes**
	- Resolved an issue where the clear button was incorrectly enabled on read-only input fields.

- **Tests**
	- Added new test cases to validate the behavior of the clear button when the input is in read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->