### PR TITLE
fix(calendar): arrows changing order when html has dir="rtl"

### DIFF
--- a/.changeset/sixty-games-wait.md
+++ b/.changeset/sixty-games-wait.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+fix arrow keys order when html has dir="rtl"

--- a/packages/components/calendar/src/calendar-base.tsx
+++ b/packages/components/calendar/src/calendar-base.tsx
@@ -5,7 +5,6 @@ import type {HTMLAttributes, ReactNode, RefObject} from "react";
 
 import {Fragment} from "react";
 import {useState} from "react";
-import {useLocale} from "@react-aria/i18n";
 import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {Button} from "@nextui-org/button";
 import {chain, mergeProps} from "@react-aria/utils";
@@ -55,8 +54,6 @@ export function CalendarBase(props: CalendarBaseProps) {
 
   const [direction, setDirection] = useState<number>(0);
 
-  const {direction: rtlDirection} = useLocale();
-
   const currentMonth = state.visibleRange.start;
 
   const headers: React.ReactNode[] = [];
@@ -72,7 +69,7 @@ export function CalendarBase(props: CalendarBaseProps) {
             {...prevButtonProps}
             onPress={chain(prevButtonProps.onPress, () => setDirection(-1))}
           >
-            {rtlDirection === "rtl" ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+            <ChevronLeftIcon />
           </Button>
         )}
         <CalendarHeader
@@ -86,7 +83,7 @@ export function CalendarBase(props: CalendarBaseProps) {
             {...nextButtonProps}
             onPress={chain(nextButtonProps.onPress, () => setDirection(1))}
           >
-            {rtlDirection === "rtl" ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+            <ChevronRightIcon />
           </Button>
         )}
       </Fragment>,

--- a/packages/core/theme/src/components/calendar.ts
+++ b/packages/core/theme/src/components/calendar.ts
@@ -10,10 +10,10 @@ const calendar = tv({
       "rounded-large overflow-x-auto bg-default-50 dark:bg-background",
       "w-[calc(var(--visible-months)_*_var(--calendar-width))]",
     ],
-    prevButton: [],
-    nextButton: [],
+    prevButton: ["order-1"],
+    nextButton: ["order-3"],
     headerWrapper: [
-      "px-4 py-2 flex items-center justify-between gap-2 bg-content1 overflow-hidden",
+      "px-4 py-2 flex items-center justify-between gap-2 bg-content1 overflow-hidden rtl:flex-row-reverse",
       "[&_.chevron-icon]:flex-none",
       // month/year picker wrapper
       "after:content-['']",
@@ -21,7 +21,7 @@ const calendar = tv({
       "after:w-full after:h-0",
       "after:absolute after:top-0 after:left-0",
     ],
-    header: "flex w-full items-center justify-center gap-2 z-10",
+    header: "flex w-full items-center justify-center gap-2 z-10 order-2",
     title: "text-default-500 text-small font-medium",
     content: "w-[calc(var(--visible-months)_*_var(--calendar-width))]",
     gridWrapper: "flex max-w-full overflow-hidden pb-2 h-auto relative",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3641 #3642 

## 📝 Description


## ⛳️ Current behavior (updates)

As described in #3641,  currently, if the html has `dir attribute equal to `rtl`, the arrow keys look incorrect.`

## 🚀 New behavior

Added  `order` to `prevButton`, `nextButton` and `header` . Added `rtl:flex-row-reverse` to `headerWrapper`.
The prev button should always be a left arrow and the next button should always be a right arrow, hence removed condition that changed arrow type based on locale direction.

#### Calendar with `dir="rtl"`
![image](https://github.com/user-attachments/assets/85b97084-b141-472e-a653-fd359e7a1b53)

#### Date Picker with `dir="rtl"`
![image](https://github.com/user-attachments/assets/3ea2bd85-4db8-418f-98f2-5464094d22df)



## 💣 Is this a breaking change (Yes/No):

No. 

