### PR TITLE
fix(#3640) : `errorFallbackSrc` and `loadingFallbackSrc` props  to image component

### DIFF
--- a/.changeset/small-gifts-learn.md
+++ b/.changeset/small-gifts-learn.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/image": minor
+---
+
+Added `errorFallbackSrc` and `loadingFallbackSrc` to display different fallbacks for loading and error states.

--- a/apps/docs/content/components/image/fallback.ts
+++ b/apps/docs/content/components/image/fallback.ts
@@ -7,6 +7,8 @@ export default function App() {
       height={200}
       src="https://app.requestly.io/delay/1000/https://nextui-docs-v2.vercel.app/images/fruit-4.jpeg"
       fallbackSrc="https://via.placeholder.com/300x200"
+      errorFallbackSrc="https://via.placeholder.com/250x300"
+      loadingFallbackSrc="https://via.placeholder.com/300x300"
       alt="NextUI Image with fallback"
     />
   );

--- a/apps/docs/content/docs/components/image.mdx
+++ b/apps/docs/content/docs/components/image.mdx
@@ -68,10 +68,18 @@ Image component has a built-in `skeleton` animation to indicate the image is loa
 You can use the `fallbackSrc` prop to display a fallback image when:
 
 - The `fallbackSrc` prop is provided.
-- The image provided in `src` is still loading.
-- The image provided in `src` fails to load.
-- The image provided in `src` is not found.
+  - The image provided in `src` is still loading and `loadingFallbackSrc` is not provided.
+  - The image provided in `src` fails to load.
+  - The image provided in `src` is not found.
 
+ Image provided in `fallbackSrc` is used as fallback during second and third case only 
+ if `errorFallbackSrc` is not provided
+
+- `errorFallbackSrc` prop is used to display a fallback image when:
+  - The image provided in `src` fails to load or there is some error or `src` is not found
+
+- `loadingFallbackSrc` prop is used to display a fallback image when:
+  - The image provided in `src` is still loading
 <CodeDemo displayMode="visible" title="Image with fallback" files={imageContent.fallback} />
 
 ### With Next.js Image
@@ -107,6 +115,8 @@ you can use it with NextUI `Image` component as well.
 | shadow          | `none` \| `sm` \| `md` \| `lg`                                       | The image shadow.                                                                                                                                                                                           | `none`  |
 | loading         | `eager` \| `lazy`                                                    | A loading strategy to use for the image.                                                                                                                                                                    | -       |
 | fallbackSrc     | `string`                                                             | The fallback image source.                                                                                                                                                                                  | -       |
+| errorFallbackSrc| `string`                                                             | Fallback to display when image fails to load due to some error                                                                                                                                              | -
+| loadingFallbackSrc | `string`                                                          | Fallback to display when image is still loading                                                                                                                                                             | -
 | isBlurred       | `boolean`                                                            | Whether the image should have a duplicated blurred image at the background.                                                                                                                                 | `false` |
 | isZoomed        | `boolean`                                                            | Whether the image should be zoomed when hovered.                                                                                                                                                            | `false` |
 | removeWrapper   | `boolean`                                                            | Whether to remove the wrapper element. This will cause the image to be rendered as a direct child of the parent element. If you set this prop as `true` neither the skeleton nor the zoom effect will work. | `false` |

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -1,6 +1,6 @@
 import type {ImageVariantProps, SlotsToClasses, ImageSlots} from "@nextui-org/theme";
 
-import React, {ImgHTMLAttributes, useCallback} from "react";
+import {ImgHTMLAttributes, useCallback} from "react";
 import {
   HTMLNextUIProps,
   mapPropsVariants,

--- a/packages/components/image/stories/image.stories.tsx
+++ b/packages/components/image/stories/image.stories.tsx
@@ -132,6 +132,8 @@ export const Fallback = {
     radius: "lg",
     src: "https://app.requestly.io/delay/3000/https://images.unsplash.com/photo-1539571696357-5a69c17a67c6",
     fallbackSrc: "/images/placeholder_300x450.png",
+    errorFallbackSrc: "/images/placeholder_450x500.png",
+    loadingFallbackSrc: "/images/placeholder_500x550.png",
   },
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3640 <!-- Github issue # here -->

## 📝 Description
## ⛳️ Current behavior (updates)
Fallback displays same fallback image for error and loading state


## 🚀 New behavior
`errorFallbackSrc` and `loadingFallbackSrc` props are added to display different fallbacks for both states.

## 💣 Is this a breaking change (Yes/No):
I don't know


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `errorFallbackSrc` and `loadingFallbackSrc` properties for improved image handling during loading and error states.
	- Enhanced user experience by displaying relevant placeholder images instead of broken icons during loading errors.
  
- **Documentation**
	- Updated documentation to reflect the new properties and provide clearer usage instructions for the `Image` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->