### PR TITLE
fix(select): nullify quick clicks on select

### DIFF
--- a/.changeset/chilled-jeans-laugh.md
+++ b/.changeset/chilled-jeans-laugh.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-aria-multiselect": patch
+---
+
+Multiple quick clicks on select trigger was not waiting for animation to complete and starts to process the actions by subsequent clicks to open/close the popover. The PR makes the fix which blocks the actions triggered by the click until a threshold time of 500ms.


### PR DESCRIPTION
Closes #3619

#### 📝 Description

> Multiple quick clicks on select trigger was not waiting for animation to complete and starts to process the actions by subsequent clicks to open/close the popover. 
> The PR makes the fix which blocks the actions triggered by the click until a specific threshold time.

#### ⛳️ Current behavior (updates)
> As shown in the video below, on multiple quick click, the subsequent clicks action is triggered which closes/opens the pop-over without waiting for the animation to get completed.

https://github.com/user-attachments/assets/ab3af3dd-e189-49f7-90fc-456675c8b410

#### 🚀 New behavior

> PR adds an a delay of **threshold** only after which the click will trigger action. 

https://github.com/user-attachments/assets/9f15ea7d-1dbb-4a59-8b5e-db29ff207040

#### 💣 Is this a breaking change (Yes/No): No

#### 📝 Questions to the reviewers:
* The threshold selected is based on trial and error as I was unable to get the information about timing in which the framer motion animation will get over. Current threshold works good but is there an better way in thresholding here?
* The code makes changes in `use-multiselect`, by modifying the `triggerProps` returned. Alternative of this could be making the change in `use-select` by modifying `onPressStart` there. But the current way is implemented in order to support re-usability. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Resolved an issue with the multi-select component that caused unintended actions during rapid clicks, enhancing user experience.
  
- **New Features**
	- Introduced a functionality to manage press event timing, preventing rapid consecutive triggers for improved interaction with the multi-select component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->