### PR TITLE
fix(modal): modal position when keyboard appears

### DIFF
--- a/.changeset/seven-apricots-happen.md
+++ b/.changeset/seven-apricots-happen.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/modal": patch
+"@nextui-org/theme": patch
+---
+
+adjust modal position when keyboard appears (#2837)

--- a/packages/components/modal/src/modal-content.tsx
+++ b/packages/components/modal/src/modal-content.tsx
@@ -8,7 +8,7 @@ import {TRANSITION_VARIANTS} from "@nextui-org/framer-utils";
 import {CloseIcon} from "@nextui-org/shared-icons";
 import {domAnimation, LazyMotion, m} from "framer-motion";
 import {useDialog} from "@react-aria/dialog";
-import {chain, mergeProps} from "@react-aria/utils";
+import {chain, mergeProps, useViewportSize} from "@react-aria/utils";
 import {HTMLNextUIProps} from "@nextui-org/system";
 import {KeyboardEvent} from "react";
 
@@ -41,6 +41,8 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
   } = useModalContext();
 
   const Component = as || DialogComponent || "div";
+
+  const viewport = useViewportSize();
 
   const {dialogProps} = useDialog(
     {
@@ -97,8 +99,18 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
     );
   }, [backdrop, disableAnimation, getBackdropProps]);
 
+  // set the height dynamically to avoid keyboard covering the bottom modal
+  const viewportStyle = {
+    "--visual-viewport-height": viewport.height + "px",
+  };
+
   const contents = disableAnimation ? (
-    <div className={slots.wrapper({class: classNames?.wrapper})} data-slot="wrapper">
+    <div
+      className={slots.wrapper({class: classNames?.wrapper})}
+      data-slot="wrapper"
+      // @ts-ignore
+      style={viewportStyle}
+    >
       {content}
     </div>
   ) : (
@@ -111,6 +123,8 @@ const ModalContent = forwardRef<"div", ModalContentProps, KeysToOmit>((props, _)
         initial="exit"
         variants={scaleInOut}
         {...motionProps}
+        // @ts-ignore
+        style={viewportStyle}
       >
         {content}
       </m.div>

--- a/packages/core/theme/src/components/modal.ts
+++ b/packages/core/theme/src/components/modal.ts
@@ -32,6 +32,7 @@ const modal = tv({
       "z-50",
       "overflow-x-auto",
       "justify-center",
+      "h-[--visual-viewport-height]",
     ],
     base: [
       "flex",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes: #2837
- Closes: #2838
- Closes: #3241

## 📝 Description

If there is input in modal where the position is bottom, when the keyboard is open, it covers the input which results in bad UX.

## ⛳️ Current behavior (updates)

<img src="https://github.com/user-attachments/assets/c1a56dd4-8c3b-4832-974f-e9c6423e0747" height="400"/>

## 🚀 New behavior

<img src="https://github.com/user-attachments/assets/9c0b9576-3df2-4f6d-b13c-eb40247fc2a6" height="400"/>

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
