### PR TITLE
fix(menu)/dropdown menu selection

### DIFF
--- a/.changeset/silly-cooks-divide.md
+++ b/.changeset/silly-cooks-divide.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/menu": patch
+---
+
+The condition for data-selectable now includes isHovered along with isSelectable.This ensures that the item can be selected when it is hovered over, addressing the issue where the selection stays in the same place when the cursor moves out of the menu.This change should help fix the dropdown selection functionality on mobile devices and improve the user experience.

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -69,6 +69,7 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
 
   const isDisabled = state.disabledKeys.has(key) || originalProps.isDisabled;
   const isSelectable = state.selectionManager.selectionMode !== "none";
+
   const isMobile = useIsMobile();
 
   const {isFocusVisible, focusProps} = useFocusRing({
@@ -139,9 +140,9 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
     "data-selected": dataAttr(isSelected),
     "data-pressed": dataAttr(isPressed),
     "data-focus-visible": dataAttr(isFocusVisible),
-
     className: slots.base({class: clsx(baseStyles, props.className)}),
   });
+
   const getLabelProps: PropGetter = (props = {}) => ({
     ...mergeProps(labelProps, props),
     className: slots.title({class: classNames?.title}),

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -69,7 +69,6 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
 
   const isDisabled = state.disabledKeys.has(key) || originalProps.isDisabled;
   const isSelectable = state.selectionManager.selectionMode !== "none";
-
   const isMobile = useIsMobile();
 
   const {isFocusVisible, focusProps} = useFocusRing({
@@ -106,6 +105,7 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
   );
 
   let itemProps = menuItemProps;
+  let isFocusActive = isHovered && (isFocused || isFocusVisible);
 
   const slots = useMemo(
     () =>
@@ -133,13 +133,13 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
       itemProps,
       props,
     ),
-    "data-focus": dataAttr(isFocused),
+    "data-focus": dataAttr(isFocusActive),
     "data-selectable": dataAttr(isPressed ? isSelectable : false),
     "data-hover": dataAttr(isMobile ? isHovered || isPressed : isHovered),
     "data-disabled": dataAttr(isDisabled),
     "data-selected": dataAttr(isSelected),
     "data-pressed": dataAttr(isPressed),
-    "data-focus-visible": dataAttr(isFocusVisible),
+    "data-focus-visible": dataAttr(isFocusActive),
     className: slots.base({class: clsx(baseStyles, props.className)}),
   });
 

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -105,7 +105,6 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
   );
 
   let itemProps = menuItemProps;
-  let isFocusActive = isHovered && (isFocused || isFocusVisible);
 
   const slots = useMemo(
     () =>
@@ -133,16 +132,16 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
       itemProps,
       props,
     ),
-    "data-focus": dataAttr(isFocusActive),
-    "data-selectable": dataAttr(isPressed ? isSelectable : false),
+    "data-focus": dataAttr(isFocused),
+    "data-selectable": dataAttr(isHovered && isSelectable),
     "data-hover": dataAttr(isMobile ? isHovered || isPressed : isHovered),
     "data-disabled": dataAttr(isDisabled),
     "data-selected": dataAttr(isSelected),
     "data-pressed": dataAttr(isPressed),
-    "data-focus-visible": dataAttr(isFocusActive),
+    "data-focus-visible": dataAttr(isFocusVisible),
+
     className: slots.base({class: clsx(baseStyles, props.className)}),
   });
-
   const getLabelProps: PropGetter = (props = {}) => ({
     ...mergeProps(labelProps, props),
     className: slots.title({class: classNames?.title}),

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -134,7 +134,7 @@ export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>
       props,
     ),
     "data-focus": dataAttr(isFocused),
-    "data-selectable": dataAttr(isSelectable),
+    "data-selectable": dataAttr(isPressed ? isSelectable : false),
     "data-hover": dataAttr(isMobile ? isHovered || isPressed : isHovered),
     "data-disabled": dataAttr(isDisabled),
     "data-selected": dataAttr(isSelected),


### PR DESCRIPTION
Closes #1560 

📝 Description

This PR addresses the issue where the dropdown selection functionality is not working on mobile devices as well as in web.

⛳️ Current behavior (updates)

As you can see the figure below the bug is the selection stay at the same place when cursor move out of the menu.

https://github.com/user-attachments/assets/b63a04a3-db0c-4f19-8f5f-517cc2f44e52


🚀 New behavior

As Video below the bug get solved by applying some condition in code

https://github.com/user-attachments/assets/6d17eb8d-37ec-47dd-8d95-0d8e311b8daf


💣 Is this a breaking change (Yes/No):No


📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced focus and selection management for menu items, improving user interaction and visual feedback.
	- Improved interactivity by refining conditions for item selection based on hover state.

- **Bug Fixes**
	- Resolved issues with item selection, ensuring items can be selected when hovered over, particularly enhancing dropdown functionality on mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->