### PR TITLE
chore(input): rollback PR3533

### DIFF
--- a/.changeset/long-ducks-do.md
+++ b/.changeset/long-ducks-do.md
@@ -1,5 +1,0 @@
----
-"@nextui-org/input": patch
----
-
-syncs changes to ref value to internal (state) value (#3024, #3436)

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -126,26 +126,6 @@ describe("Input", () => {
     expect(ref.current?.value)?.toBe(value);
   });
 
-  it("setting ref should sync the internal value", () => {
-    const ref = React.createRef<HTMLInputElement>();
-
-    const {container} = render(<Input ref={ref} type="text" />);
-
-    if (!ref.current) {
-      throw new Error("ref is null");
-    }
-
-    ref.current!.value = "value";
-
-    const input = container.querySelector("input")!;
-
-    input.focus();
-
-    const internalValue = input.value;
-
-    expect(ref.current?.value)?.toBe(internalValue);
-  });
-
   it("should clear the value and onClear is triggered", async () => {
     const onClear = jest.fn();
 

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -15,7 +15,7 @@ import {useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {useFocusWithin, useHover, usePress} from "@react-aria/interactions";
 import {clsx, dataAttr, isEmpty, objectToDeps, safeAriaLabel, warn} from "@nextui-org/shared-utils";
 import {useControlledState} from "@react-stately/utils";
-import {useMemo, Ref, useCallback, useState, useImperativeHandle, useRef} from "react";
+import {useMemo, Ref, useCallback, useState} from "react";
 import {chain, mergeProps} from "@react-aria/utils";
 import {useTextField} from "@react-aria/textfield";
 
@@ -131,40 +131,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const disableAnimation =
     originalProps.disableAnimation ?? globalContext?.disableAnimation ?? false;
 
-  const domRef = useRef<T>(null);
-
-  let proxy: T | undefined = undefined;
-
-  useImperativeHandle(
-    ref,
-    () => {
-      if (proxy === undefined) {
-        proxy = new Proxy(domRef.current!, {
-          get(target, prop) {
-            const value = target[prop];
-
-            if (value instanceof Function) {
-              return value.bind(target);
-            }
-
-            return value;
-          },
-          set(target, prop, value) {
-            target[prop] = value;
-
-            if (prop === "value") {
-              setInputValue(value);
-            }
-
-            return true;
-          },
-        });
-      }
-
-      return proxy;
-    },
-    [domRef.current],
-  );
+  const domRef = useDOMRef<T>(ref);
 
   const baseDomRef = useDOMRef<HTMLDivElement>(baseRef);
   const inputWrapperRef = useDOMRef<HTMLDivElement>(wrapperRef);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3712

## 📝 Description

PR3533 broke autocomplete. rollback at this moment. cc @AnthonyPaulO

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed a test case from the `Input` component's test suite, simplifying the testing process.

- **Refactor**
	- Simplified the `useInput` hook by removing the proxy logic and directly utilizing `useDOMRef`, enhancing performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->