### PR TITLE
fix(autocomplete): highlight item in `AutocompleteSection` during keyboard navigation

### DIFF
--- a/.changeset/popular-baboons-pull.md
+++ b/.changeset/popular-baboons-pull.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/listbox": patch
+---
+
+Fix item highlighting in `AutocompleteSection` during keyboard navigation (#3713)

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -109,13 +109,9 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     itemProps = removeEvents(itemProps);
   }
 
-  const isHighlighted = useMemo(() => {
-    if (shouldHighlightOnFocus && isFocused) {
-      return true;
-    }
-
-    return isMobile ? isHovered || isPressed : isHovered;
-  }, [isHovered, isPressed, isFocused, isMobile, shouldHighlightOnFocus]);
+  const isHighlighted =
+    (shouldHighlightOnFocus && isFocused) ||
+    (isMobile ? isHovered || isPressed : isHovered || (isFocused && !isFocusVisible));
 
   const getItemProps: PropGetter = (props = {}) => ({
     ref: domRef,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3713

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

https://github.com/user-attachments/assets/880732a6-f937-4058-ab31-65fee6c098d0

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved keyboard navigation for item highlighting in the AutocompleteSection, enhancing accessibility and usability.
  
- **Bug Fixes**
	- Resolved issues with item highlighting during keyboard navigation, ensuring a smoother interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->