### PR TITLE
fix(docs): remove unwanted generic from PaginationItemRenderProps

### DIFF
--- a/apps/docs/content/components/pagination/custom-items.ts
+++ b/apps/docs/content/components/pagination/custom-items.ts
@@ -59,7 +59,7 @@ export default function App() {
     onPrevious,
     setPage,
     className,
-  }: PaginationItemRenderProps<HTMLButtonElement>) => {
+  }: PaginationItemRenderProps) => {
     if (value === PaginationItemType.NEXT) {
       return (
         <button key={key} className={cn(className, "bg-default-200/50 min-w-8 w-8 h-8")} onClick={onNext}>


### PR DESCRIPTION
In the documentation on the custom item the type PaginationItemRenderProps is represented with a generic but in the implementation it doesn't receive a generic type.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> In the documentation on the custom item the type PaginationItemRenderProps is represented with a generic but in the implementation it doesn't receive a generic type.

## ⛳️ Current behavior (updates)

> The documentation example it show the type receiving a generic

## 🚀 New behavior

> The type implementation doesn't receive a generic and now in the documentation is doing that

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the type signature for pagination component, enhancing flexibility without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->