### PR TITLE
fix(table): Add an isKeyboardNavigationDisabled prop to disable the navigation

### DIFF
--- a/.changeset/fluffy-icons-refuse.md
+++ b/.changeset/fluffy-icons-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/table": patch
+---
+
+Currently, whenever any arrow-key keypress is triggered it navigates the focus to other cell/row. This creates an issue when the table cell contains a component which requires this keys for specific purpose (eg. if a table cell contains input component, it might need arrow keys for editing. But it is not possible because whenever the keypress triggers navigation). The PR adds an `isKeyboardNavigationDisabled` prop to disable the navigation.

--- a/apps/docs/content/docs/components/table.mdx
+++ b/apps/docs/content/docs/components/table.mdx
@@ -457,7 +457,7 @@ You can customize the `Table` component by passing custom Tailwind CSS classes t
 | disableAnimation              | `boolean`                                                                                                                                                     | Whether to disable the table and checkbox animations.                                                        | `false`     |
 | checkboxesProps               | [CheckboxProps](/docs/components/checkbox/#checkbox-props)                                                                                                    | Props to be passed to the checkboxes.                                                                        | -           |
 | classNames                    | `Record<"base" ｜ "table" ｜ "thead" ｜ "tbody" ｜ "tfoot" ｜ "emptyWrapper" ｜ "loadingWrapper" ｜ "wrapper" ｜ "tr" ｜ "th" ｜ "td" ｜ "sortIcon", string>` | Allows to set custom class names for the dropdown item slots.                                                | -           |
-
+| isKeyboardNavigationDisabled  | `boolean`                                                                                                                                                     | Whether to disable keyboard navigations or not.                                                              | `false`     |
 ### Table Events
 
 | Attribute         | Type                                  | Description                                                         |

--- a/packages/components/table/__tests__/table.test.tsx
+++ b/packages/components/table/__tests__/table.test.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
-import {act, render} from "@testing-library/react";
+import {act, render, fireEvent} from "@testing-library/react";
 import userEvent, {UserEvent} from "@testing-library/user-event";
 
+
 import {Table, TableHeader, TableCell, TableColumn, TableBody, TableRow} from "../src";
+import {keyCodes} from "../../../utilities/test-utils/src";
 
 const columns = [
   {name: "Foo", key: "foo"},
@@ -99,6 +101,42 @@ describe("Table", () => {
     // should have 2 "role=gridcell" - react-aria sets the first one as "rowheader"
     expect(wrapper.getAllByRole("rowheader")).toHaveLength(1);
     expect(wrapper.getAllByRole("gridcell")).toHaveLength(2);
+  });
+
+  it("should disable key navigations when isKeyboardNavigationDisabled is enabled", async () => {
+    const wrapper = render(
+      <Table isKeyboardNavigationDisabled={true} selectionMode="single">
+        <TableHeader>
+          <TableColumn>Foo</TableColumn>
+          <TableColumn>Bar</TableColumn>
+          <TableColumn>Baz</TableColumn>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Foo 1</TableCell>
+            <TableCell>Bar 1</TableCell>
+            <TableCell>Baz 1</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Foo 2</TableCell>
+            <TableCell>Bar 2</TableCell>
+            <TableCell>Baz 2</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+
+    const row1 = wrapper.getAllByRole("row")[1];
+
+    // selecting the row1
+    await act(async () => {
+      await userEvent.click(row1);
+    });
+    expect(row1).toHaveFocus();
+
+    // triggering the arrow down on row1 should not shift the focus to row2
+    fireEvent.keyDown(row1, {key: "ArrowDown", keyCode: keyCodes.ArrowDown});
+    expect(row1).toHaveFocus();
   });
 
   it("should render dynamic table", () => {

--- a/packages/components/table/src/use-table.ts
+++ b/packages/components/table/src/use-table.ts
@@ -91,6 +91,11 @@ interface Props<T> extends HTMLNextUIProps<"table"> {
    */
   disableAnimation?: boolean;
   /**
+   * Whether to disable the keyboard navigation functionality.
+   * @default false
+   */
+  isKeyboardNavigationDisabled?: boolean;
+  /**
    * Props to be passed to the checkboxes.
    */
   checkboxesProps?: CheckboxProps;
@@ -158,6 +163,7 @@ export function useTable<T extends object>(originalProps: UseTableProps<T>) {
     classNames,
     removeWrapper = false,
     disableAnimation = globalContext?.disableAnimation ?? false,
+    isKeyboardNavigationDisabled = false,
     selectionMode = "none",
     topContentPlacement = "inside",
     bottomContentPlacement = "inside",
@@ -184,6 +190,10 @@ export function useTable<T extends object>(originalProps: UseTableProps<T>) {
     children,
     showSelectionCheckboxes,
   });
+
+  if (isKeyboardNavigationDisabled && !state.isKeyboardNavigationDisabled) {
+    state.setKeyboardNavigationDisabled(true);
+  }
 
   const {collection} = state;
 


### PR DESCRIPTION
Closes #3681 

#### 📝 Description

> PR adds isKeyboardNavigationDisabled prop to disable navigation on keypress

#### ⛳️ Current behavior (updates)

* Currently, whenever any arrow-key keypress is triggered it navigates the focus to other cell/row.
* This maybe an issue when the table cell contains a component which requires this keys for specific purpose.
* Example for above scenario could be: table cell contains input component, it might need arrow keys for editing. But it is not possible because whenever the keypress triggers navigation

https://github.com/user-attachments/assets/61ae353d-cdca-4cbf-b12d-1146da371704

#### 🚀 New behavior

* The PR adds an `isKeyboardNavigationDisabled` prop to disable the navigation through keyboard.

https://github.com/user-attachments/assets/c05c084a-8caf-4959-aee8-102818220a0a

#### 💣 Is this a breaking change (Yes/No): No

#### Additional info
* updated the docs
<img width="750" alt="Screenshot 2024-09-10 at 4 34 44 PM" src="https://github.com/user-attachments/assets/16910213-2188-4abe-8763-da56e0ff2021">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `isKeyboardNavigationDisabled` prop for the Table component, allowing users to disable keyboard navigation when interacting with components that require arrow key inputs.
  
- **Documentation**
  - Enhanced Table component documentation with details about the new `isKeyboardNavigationDisabled` prop, updated props and events tables, and added usage examples for improved clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->