### PR TITLE
fix(theme): update flat variant text colors to be accessible

### DIFF
--- a/.changeset/tough-mangos-deliver.md
+++ b/.changeset/tough-mangos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": minor
+---
+
+Updates the text colors for the flat variant in the theme so that elements using this variant are accessible

--- a/.changeset/tough-mangos-deliver.md
+++ b/.changeset/tough-mangos-deliver.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/theme": minor
+"@nextui-org/theme": patch
 ---
 
-Updates the text colors for the flat variant in the theme so that elements using this variant are accessible
+Updates the text colors for the flat variant in the theme so that elements using this variant are accessible (#3738)

--- a/packages/core/theme/src/utils/variants.ts
+++ b/packages/core/theme/src/utils/variants.ts
@@ -29,12 +29,12 @@ const bordered = {
 };
 
 const flat = {
-  default: "bg-default/40 text-default-foreground",
-  primary: "bg-primary/20 text-primary",
-  secondary: "bg-secondary/20 text-secondary",
-  success: "bg-success/20 text-success-600 dark:text-success",
-  warning: "bg-warning/20 text-warning-600 dark:text-warning",
-  danger: "bg-danger/20 text-danger dark:text-danger-500",
+  default: "bg-default/40 text-default-700",
+  primary: "bg-primary/20 text-primary-700",
+  secondary: "bg-secondary/20 text-secondary-700",
+  success: "bg-success/20 text-success-800 dark:text-success",
+  warning: "bg-warning/20 text-warning-800 dark:text-warning",
+  danger: "bg-danger/20 text-danger-800 dark:text-danger-500",
   foreground: "bg-foreground/10 text-foreground",
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR updates the text colors in the nextui theme's `flat` variant to ensure that the text color contrast is at an accessible level for the respective background color.

This fixes the open issue [here](https://github.com/nextui-org/nextui/issues/3050)

## ⛳️ Current behavior (updates)

Text colors on the flat variant (i.e. in `Button`, `Chip`) do not pass contrast accessibility on their backgrounds

## 🚀 New behavior

- Updates text colors in the `flat` variant following ways to pass accessibility:

- `default`: `text-default-foreground` -> `text-default-700`
- `primary`: `text-primary` -> `text-primary-700`
- `secondary`: `text-secondary` -> `text-secondary-700`
- `success`: `text-success-600` -> `text-success-800`
- `warning`: `text-warning` -> `text-warning-800`
- `danger`: `text-danger` -> `text-danger-800`


## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated text colors for the flat theme variant to enhance accessibility and readability.
  
- **Bug Fixes**
	- Improved visual contrast for text elements to ensure better perception against backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->