### PR TITLE
refactor(docs): example of blurred card

### DIFF
--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -73,9 +73,11 @@ You can use other NextUI components inside the card to compose a more complex ca
 
 ### Blurred Card
 
-You can pass the `isBlurred` prop to the card to blur the card.
+You can pass the `isBlurred` prop to the card to blur the card. Card gets blurred properties based on its ancestor element.
 
 <CodeDemo isGradientBox title="Blurred Card" files={cardContent.blurred} />
+
+**Note**: While trying out the above example, it is required to provide the necessary background to any ancestor element of the Card component to obtain the `blur` effect as seen in the preview.
 
 ### Primary Action
 

--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -75,9 +75,17 @@ You can use other NextUI components inside the card to compose a more complex ca
 
 You can pass the `isBlurred` prop to the card to blur the card. Card gets blurred properties based on its ancestor element.
 
-<CodeDemo isGradientBox title="Blurred Card" files={cardContent.blurred} />
+> **Note**: To achieve the blur effect as seen in the preview, you need to provide a suitable background to an ancestor element of the Card component. The following example adds a gradient background to a parent div, allowing the Card's blur effect to be visible.
 
-**Note**: While trying out the above example, it is required to provide the necessary background(eg. adding `bg-gradient-to-tr from-[#FFB457] to-[#FF705B]` classes) to any ancestor element of the Card component to obtain the `blur` effect as seen in the preview.
+```jsx
+<div className="bg-gradient-to-tr from-[#FFB457] to-[#FF705B]">
+  <Card isBlurred>
+    {/* Card content */}
+  </Card>
+</div>
+```
+
+<CodeDemo isGradientBox title="Blurred Card" files={cardContent.blurred} />
 
 ### Primary Action
 

--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -77,7 +77,7 @@ You can pass the `isBlurred` prop to the card to blur the card. Card gets blurre
 
 <CodeDemo isGradientBox title="Blurred Card" files={cardContent.blurred} />
 
-**Note**: While trying out the above example, it is required to provide the necessary background to any ancestor element of the Card component to obtain the `blur` effect as seen in the preview.
+**Note**: While trying out the above example, it is required to provide the necessary background(eg. adding `bg-gradient-to-tr from-[#FFB457] to-[#FF705B]` classes) to any ancestor element of the Card component to obtain the `blur` effect as seen in the preview.
 
 ### Primary Action
 

--- a/apps/docs/content/docs/components/card.mdx
+++ b/apps/docs/content/docs/components/card.mdx
@@ -75,15 +75,7 @@ You can use other NextUI components inside the card to compose a more complex ca
 
 You can pass the `isBlurred` prop to the card to blur the card. Card gets blurred properties based on its ancestor element.
 
-> **Note**: To achieve the blur effect as seen in the preview, you need to provide a suitable background to an ancestor element of the Card component. The following example adds a gradient background to a parent div, allowing the Card's blur effect to be visible.
-
-```jsx
-<div className="bg-gradient-to-tr from-[#FFB457] to-[#FF705B]">
-  <Card isBlurred>
-    {/* Card content */}
-  </Card>
-</div>
-```
+> **Note**: To achieve the blur effect as seen in the preview, you need to provide a suitable background (e.g., `bg-gradient-to-tr from-[#FFB457] to-[#FF705B]`) to an ancestor element of the Card component allowing the Card's blur effect to be visible.
 
 <CodeDemo isGradientBox title="Blurred Card" files={cardContent.blurred} />
 


### PR DESCRIPTION
Closes #3717 

#### 📝 Description

> Adds info for adding gradient for re-creating the code example.

#### ⛳️ Current behavior (updates)

> Currently the blurred card example gets the gradient from the codeDemo but user when trying out the component need to add the background to the parent/ansestor element.

<img width="729" alt="Screenshot 2024-09-15 at 11 37 30 PM" src="https://github.com/user-attachments/assets/125725df-08d8-47ec-8bb8-bdb55bbadeea">

#### 🚀 New behavior

> Adds info for the user/reader in the docs.

<img width="729" alt="Screenshot 2024-09-15 at 11 38 59 PM" src="https://github.com/user-attachments/assets/bbe45e1f-885e-4c36-a8f6-23c2a4140586">

#### 💣 Is this a breaking change (Yes/No): No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the visual presentation of the card component with a new gradient background.

- **Documentation**
	- Updated documentation to clarify the interaction of the `isBlurred` prop with the parent component's properties, emphasizing the need for a suitable background to observe the blur effect. An example demonstrating the use of a gradient background has been included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->