### PR TITLE
fix(docs): set shouldBlockScroll to false

### DIFF
--- a/apps/docs/components/marketing/hero/floating-components.tsx
+++ b/apps/docs/components/marketing/hero/floating-components.tsx
@@ -110,6 +110,7 @@ export const FloatingComponents: React.FC<{}> = () => {
             content="Developers love Next.js"
             isOpen={!isTablet}
             placement="top"
+            shouldBlockScroll={false}
             style={{
               zIndex: 39,
             }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

currently canary doc landing page is not scrollable because of opened tooltip

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new prop `shouldBlockScroll` to the FloatingComponents, allowing the underlying page to remain scrollable when the floating component is displayed, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->