### PR TITLE
fix(dropdown): _a2.find is not a function

### DIFF
--- a/.changeset/serious-panthers-beg.md
+++ b/.changeset/serious-panthers-beg.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/dropdown": patch
+---
+
+fixed \_a2.find is not a function (#3761)

--- a/.changeset/serious-panthers-beg.md
+++ b/.changeset/serious-panthers-beg.md
@@ -1,5 +1,6 @@
 ---
 "@nextui-org/dropdown": patch
+"@nextui-org/use-aria-menu": patch
 ---
 
-fixed \_a2.find is not a function (#3761)
+fixed `_a2.find` is not a function (#3761)

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -796,7 +796,7 @@ describe("Keyboard interactions", () => {
     logSpy.mockRestore();
   });
 
-  it("should respect closeOnSelect setting of DropdownItem", async () => {
+  it("should respect closeOnSelect setting of DropdownItem (static)", async () => {
     const onOpenChange = jest.fn();
     const wrapper = render(
       <Dropdown onOpenChange={onOpenChange}>
@@ -808,6 +808,53 @@ describe("Keyboard interactions", () => {
             New file
           </DropdownItem>
           <DropdownItem key="copy">Copy link</DropdownItem>
+        </DropdownMenu>
+      </Dropdown>,
+    );
+
+    let triggerButton = wrapper.getByTestId("trigger-test");
+
+    act(() => {
+      triggerButton.click();
+    });
+    expect(onOpenChange).toBeCalledTimes(1);
+
+    let menuItems = wrapper.getAllByRole("menuitem");
+
+    await act(async () => {
+      await userEvent.click(menuItems[0]);
+      expect(onOpenChange).toBeCalledTimes(1);
+    });
+
+    await act(async () => {
+      await userEvent.click(menuItems[1]);
+      expect(onOpenChange).toBeCalledTimes(2);
+    });
+  });
+
+  it("should respect closeOnSelect setting of DropdownItem (dynamic)", async () => {
+    const onOpenChange = jest.fn();
+    const items = [
+      {
+        key: "new",
+        label: "New file",
+      },
+      {
+        key: "copy",
+        label: "Copy link",
+      },
+    ];
+    const wrapper = render(
+      <Dropdown onOpenChange={onOpenChange}>
+        <DropdownTrigger>
+          <Button data-testid="trigger-test">Trigger</Button>
+        </DropdownTrigger>
+        <DropdownMenu aria-label="Actions" items={items}>
+          {(item) => (
+            <DropdownItem key={item.key} closeOnSelect={item.key !== "new"}>
+              {item.label}
+            </DropdownItem>
+          )}
         </DropdownMenu>
       </Dropdown>,
     );

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -42,6 +42,37 @@ interface Props extends HTMLNextUIProps<"div"> {
 
 export type UseDropdownProps = Props & Omit<PopoverProps, "children" | "color" | "variant">;
 
+const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined, key: string) => {
+  if (props) {
+    const mergedChildren = Array.isArray(props.children)
+      ? props.children
+      : [...(props?.items || [])];
+
+    if (mergedChildren && mergedChildren.length) {
+      const item = (mergedChildren.find((item) => {
+        if ("key" in item && item.key === key) {
+          return item;
+        }
+      }) || {}) as {props: MenuProps};
+
+      return item;
+    }
+  }
+};
+
+const getCloseOnSelect = <T extends object>(
+  props: Partial<MenuProps<T>> | undefined,
+  key: string,
+) => {
+  const item = getMenuItem(props, key);
+
+  if (item && item.props && "closeOnSelect" in item.props) {
+    return item.props.closeOnSelect;
+  }
+
+  return props?.closeOnSelect;
+};
+
 export function useDropdown(props: UseDropdownProps) {
   const globalContext = useProviderContext();
 
@@ -153,15 +184,9 @@ export function useDropdown(props: UseDropdownProps) {
       closeOnSelect,
       ...mergeProps(props, {
         onAction: (key: any) => {
-          // @ts-ignore
-          const item = props?.children?.find((item) => item.key === key);
+          const closeOnSelect = getCloseOnSelect(props, key);
 
-          if (item?.props?.closeOnSelect === false) {
-            onMenuAction(false);
-
-            return;
-          }
-          onMenuAction(props?.closeOnSelect);
+          onMenuAction(closeOnSelect);
         },
         onClose: state.close,
       }),

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -13,6 +13,7 @@ import {ariaShouldCloseOnInteractOutside} from "@nextui-org/aria-utils";
 import {useMemo, useRef} from "react";
 import {mergeProps} from "@react-aria/utils";
 import {MenuProps} from "@nextui-org/menu";
+import {CollectionElement} from "@react-types/shared";
 
 interface Props extends HTMLNextUIProps<"div"> {
   /**
@@ -49,8 +50,8 @@ const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined,
       : [...(props?.items || [])];
 
     if (mergedChildren && mergedChildren.length) {
-      const item = (mergedChildren.find((item) => {
-        if ("key" in item && item.key === key) {
+      const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
+        if (item.key === key) {
           return item;
         }
       }) || {}) as {props: MenuProps};

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -44,20 +44,23 @@ interface Props extends HTMLNextUIProps<"div"> {
 export type UseDropdownProps = Props & Omit<PopoverProps, "children" | "color" | "variant">;
 
 const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined, key: string) => {
-  if (!props) {
-    return null;
-  }
-  const mergedChildren = Array.isArray(props.children) ? props.children : [...(props?.items || [])];
+  if (props) {
+    const mergedChildren = Array.isArray(props.children)
+      ? props.children
+      : [...(props?.items || [])];
 
-  if (mergedChildren && mergedChildren.length) {
-    const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
-      if (item.key === key) {
-        return item;
-      }
-    }) || {}) as {props: MenuProps};
+    if (mergedChildren && mergedChildren.length) {
+      const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
+        if (item.key === key) {
+          return item;
+        }
+      }) || {}) as {props: MenuProps};
 
-    return item;
+      return item;
+    }
   }
+
+  return null;
 };
 
 const getCloseOnSelect = <T extends object>(

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -183,8 +183,8 @@ export function useDropdown(props: UseDropdownProps) {
       menuProps,
       closeOnSelect,
       ...mergeProps(props, {
-        onAction: (key: any) => {
-          const closeOnSelect = getCloseOnSelect(props, key);
+        onAction: (key: any, item?: any) => {
+          const closeOnSelect = item ? item.props?.closeOnSelect : getCloseOnSelect(props, key);
 
           onMenuAction(closeOnSelect);
         },

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -63,11 +63,12 @@ const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined,
 const getCloseOnSelect = <T extends object>(
   props: Partial<MenuProps<T>> | undefined,
   key: string,
+  item?: any,
 ) => {
-  const item = getMenuItem(props, key);
+  const mergedItem = item || getMenuItem(props, key);
 
-  if (item && item.props && "closeOnSelect" in item.props) {
-    return item.props.closeOnSelect;
+  if (mergedItem && mergedItem.props && "closeOnSelect" in mergedItem.props) {
+    return mergedItem.props.closeOnSelect;
   }
 
   return props?.closeOnSelect;
@@ -184,7 +185,7 @@ export function useDropdown(props: UseDropdownProps) {
       closeOnSelect,
       ...mergeProps(props, {
         onAction: (key: any, item?: any) => {
-          const closeOnSelect = item ? item.props?.closeOnSelect : getCloseOnSelect(props, key);
+          const closeOnSelect = getCloseOnSelect(props, key, item);
 
           onMenuAction(closeOnSelect);
         },

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -44,20 +44,19 @@ interface Props extends HTMLNextUIProps<"div"> {
 export type UseDropdownProps = Props & Omit<PopoverProps, "children" | "color" | "variant">;
 
 const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined, key: string) => {
-  if (props) {
-    const mergedChildren = Array.isArray(props.children)
-      ? props.children
-      : [...(props?.items || [])];
+  if (!props) {
+    return null;
+  }
+  const mergedChildren = Array.isArray(props.children) ? props.children : [...(props?.items || [])];
 
-    if (mergedChildren && mergedChildren.length) {
-      const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
-        if (item.key === key) {
-          return item;
-        }
-      }) || {}) as {props: MenuProps};
+  if (mergedChildren && mergedChildren.length) {
+    const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
+      if (item.key === key) {
+        return item;
+      }
+    }) || {}) as {props: MenuProps};
 
-      return item;
-    }
+    return item;
   }
 };
 

--- a/packages/hooks/use-aria-menu/src/use-menu-item.ts
+++ b/packages/hooks/use-aria-menu/src/use-menu-item.ts
@@ -94,7 +94,7 @@ export interface AriaMenuItemProps
    * Handler that is called when the user activates the item.
    * @deprecated - pass to the menu instead.
    */
-  onAction?: (key: Key) => void;
+  onAction?: (key: Key, item: any) => void;
 
   /**
    * The native button click event handler
@@ -167,11 +167,11 @@ export function useMenuItem<T>(
 
     if (props.onAction) {
       // @ts-ignore
-      props.onAction(key);
+      props.onAction(key, item);
       // @ts-ignore
     } else if (data.onAction) {
       // @ts-ignore
-      data.onAction(key);
+      data.onAction(key, item);
     }
 
     if (e.target instanceof HTMLAnchorElement) {

--- a/packages/hooks/use-aria-menu/src/use-menu.ts
+++ b/packages/hooks/use-aria-menu/src/use-menu.ts
@@ -24,7 +24,7 @@ export interface AriaMenuOptions<T> extends Omit<AriaMenuProps<T>, "children">, 
 
 interface MenuData {
   onClose?: () => void;
-  onAction?: (key: Key) => void;
+  onAction?: (key: Key, item: any) => void;
 }
 
 export const menuData = new WeakMap<TreeState<unknown>, MenuData>();


### PR DESCRIPTION
…Item (dynamic)"

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3761

## 📝 Description

> Add a brief description

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with dropdown and menu components that caused errors during operation.
  
- **New Features**
	- Introduced utility functions to enhance dropdown functionality.
	- Improved handling of the `closeOnSelect` property for dropdown items.

- **Tests**
	- Enhanced testing for the `Dropdown` component to ensure correct behavior based on item selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->