### PR TITLE
fix(theme): fullWidth in input and select

### DIFF
--- a/.changeset/fast-horses-explode.md
+++ b/.changeset/fast-horses-explode.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-The PR changes the styling to fix the fullWidth variant in input and select component. (#3745)
+fix the fullWidth variant in input and select component. (#3745)

--- a/.changeset/fast-horses-explode.md
+++ b/.changeset/fast-horses-explode.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-The PR changes the styling to fix the fullWidth variant in input and select component.
+The PR changes the styling to fix the fullWidth variant in input and select component. (#3745)

--- a/.changeset/fast-horses-explode.md
+++ b/.changeset/fast-horses-explode.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+The PR changes the styling to fix the fullWidth variant in input and select component.

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -185,6 +185,7 @@ const input = tv({
       true: {
         base: "w-full",
       },
+      false: {},
     },
     isClearable: {
       true: {

--- a/packages/core/theme/src/components/select.ts
+++ b/packages/core/theme/src/components/select.ts
@@ -5,7 +5,7 @@ import {tv} from "../utils/tv";
 
 const select = tv({
   slots: {
-    base: ["group inline-flex flex-col relative w-full"],
+    base: ["group inline-flex flex-col relative"],
     label: [
       "block",
       "absolute",
@@ -145,6 +145,9 @@ const select = tv({
     fullWidth: {
       true: {
         base: "w-full",
+      },
+      false: {
+        base: "min-w-40",
       },
     },
     isDisabled: {


### PR DESCRIPTION
Closes #3745

## 📝 Description

> Fixes the full width functionality.

## ⛳️ Current behavior (updates)

Even when the full-width is set to `false`, the component takes the full-width of the parent. This should not be the case.
Examples for the bug are:
* Input:

https://github.com/user-attachments/assets/e2cc9ef8-fc4a-4047-85b4-be45788280d2

* Select:

https://github.com/user-attachments/assets/b20053d9-9985-4af1-a366-4251debf8edd

## 🚀 New behavior

The PR fixes the full-width functionality:
* Input

https://github.com/user-attachments/assets/1596cfee-78de-46dd-96c2-b45a4cc124d7

* Select:

https://github.com/user-attachments/assets/8504926a-dd10-4f7b-a73a-9ba18f9c822d

In select the min-w-40 is added so that the select component has atleast width of 10rem.

## 💣 Is this a breaking change (Yes/No): No





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- No new features introduced in this update.
  
- **Bug Fixes**
	- Resolved issues with the rendering of the `fullWidth` variant in input and select components for improved functionality.

- **Documentation**
	- Enhanced visual presentation and functionality of dateInput, input, and select components for a better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->