### PR TITLE
fix(date-picker): adding props from calendarProps to the getCalendarProps

### DIFF
--- a/.changeset/flat-pants-accept.md
+++ b/.changeset/flat-pants-accept.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-picker": patch
+---
+
+Fixes getCalendarProps to propagate the classNames in the calendarProps.

--- a/.changeset/flat-pants-accept.md
+++ b/.changeset/flat-pants-accept.md
@@ -2,4 +2,4 @@
 "@nextui-org/date-picker": patch
 ---
 
-Fixes getCalendarProps to propagate the classNames in the calendarProps.
+Fixes getCalendarProps to propagate the classNames in the calendarProps. (#3769)

--- a/packages/components/date-picker/src/use-date-picker.ts
+++ b/packages/components/date-picker/src/use-date-picker.ts
@@ -204,8 +204,11 @@ export function useDatePicker<T extends DateValue>({
       ...ariaCalendarProps,
       ...calendarProps,
       classNames: {
-        base: slots.calendar({class: classNames?.calendar}),
-        content: slots.calendarContent({class: classNames?.calendarContent}),
+        ...calendarProps.classNames,
+        base: slots.calendar({class: clsx(classNames?.base, calendarProps.classNames?.base)}),
+        content: slots.calendarContent({
+          class: clsx(classNames?.calendarContent, calendarProps.classNames?.content),
+        }),
       },
     };
   };


### PR DESCRIPTION
Closes #3769 

## 📝 Description

> The classNames in the calendarProps does not get applied to the calendar.

## ⛳️ Current behavior (updates)

So currently, the classNames in calendarProps are not propagated to the Calendar due to which the styling does not get applied.
```
calendarProps={{
    classNames: {
      grid: 'bg-red-800',
    },
}}
```
As of now, adding the above prop to the date-picker gives following result (does not apply the mentioned style to the grid i.e. `bg-red-800`): 
<img width="283" alt="Screenshot 2024-09-17 at 12 02 43 PM" src="https://github.com/user-attachments/assets/2baecf7b-f4cc-40fd-a8ae-9e3b48adabac">

## 🚀 New behavior

The PR propagates the calendarProps's classNames so that styling do get apply to them. 
```
calendarProps={{
    classNames: {
      grid: 'bg-red-800',
    },
}}
```
After the changes in this PR, adding the above prop to the date-picker gives following result (applies the mentioned styling to the grid i.e. `bg-red-800` ):
<img width="283" alt="Screenshot 2024-09-17 at 12 04 15 PM" src="https://github.com/user-attachments/assets/c04c7da1-7667-4182-b16d-a156276851b2">

## 💣 Is this a breaking change (Yes/No): No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the date picker component for improved styling flexibility by allowing users to apply custom class names more effectively.
  
- **Bug Fixes**
	- Resolved issues with class name propagation in the calendar component, ensuring that styles are applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->