### PR TITLE
fix(input): ensure clear button is not focusable when disabled

### DIFF
--- a/.changeset/two-waves-own.md
+++ b/.changeset/two-waves-own.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+clear button should not receive focus when input is disabled.

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -38,9 +38,9 @@ describe("Input", () => {
   });
 
   it("should disable the clear button when isDisabled", () => {
-    const {container} = render(<Input isClearable isDisabled label="test input" />);
+    const {getByRole} = render(<Input isClearable isDisabled label="test input" />);
 
-    const clearButton = container.querySelector("button");
+    const clearButton = getByRole("button");
 
     expect(clearButton).toBeDisabled();
   });
@@ -139,7 +139,7 @@ describe("Input", () => {
 
     const ref = React.createRef<HTMLInputElement>();
 
-    const {container} = render(
+    const {getByRole} = render(
       <Input
         ref={ref}
         isClearable
@@ -149,7 +149,7 @@ describe("Input", () => {
       />,
     );
 
-    const clearButton = container.querySelector("button")!;
+    const clearButton = getByRole("button")!;
 
     expect(clearButton).not.toBeNull();
 
@@ -194,7 +194,7 @@ describe("Input", () => {
 
     const ref = React.createRef<HTMLInputElement>();
 
-    const {container} = render(
+    const {getByRole} = render(
       <Input
         ref={ref}
         isClearable
@@ -205,7 +205,7 @@ describe("Input", () => {
       />,
     );
 
-    const clearButton = container.querySelector("button")!;
+    const clearButton = getByRole("button")!;
 
     expect(clearButton).not.toBeNull();
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -37,6 +37,14 @@ describe("Input", () => {
     expect(container.querySelector("input")).toHaveAttribute("disabled");
   });
 
+  it("should set tabIndex to -1 when isDisabled is true", () => {
+    const {getByRole} = render(<Input isClearable isDisabled label="test input" />);
+
+    const clearButton = getByRole("button");
+
+    expect(clearButton).toHaveAttribute("tabIndex", "-1");
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {container} = render(<Input isRequired label="test input" validationBehavior="native" />);
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -45,6 +45,14 @@ describe("Input", () => {
     expect(clearButton).toBeDisabled();
   });
 
+  it("should not allow clear button to be focusable", () => {
+    const {getByRole} = render(<Input isClearable label="test input" />);
+
+    const clearButton = getByRole("button");
+
+    expect(clearButton).toHaveAttribute("tabIndex", "-1");
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {container} = render(<Input isRequired label="test input" validationBehavior="native" />);
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -37,12 +37,12 @@ describe("Input", () => {
     expect(container.querySelector("input")).toHaveAttribute("disabled");
   });
 
-  it("should set tabIndex to -1 when isDisabled is true", () => {
-    const {getByRole} = render(<Input isClearable isDisabled label="test input" />);
+  it("should disable the clear button when isDisabled", () => {
+    const {container} = render(<Input isClearable isDisabled label="test input" />);
 
-    const clearButton = getByRole("button");
+    const clearButton = container.querySelector("button");
 
-    expect(clearButton).toHaveAttribute("tabIndex", "-1");
+    expect(clearButton).toBeDisabled();
   });
 
   it("should have required attribute when isRequired with native validationBehavior", () => {
@@ -139,7 +139,7 @@ describe("Input", () => {
 
     const ref = React.createRef<HTMLInputElement>();
 
-    const {getByRole} = render(
+    const {container} = render(
       <Input
         ref={ref}
         isClearable
@@ -149,7 +149,7 @@ describe("Input", () => {
       />,
     );
 
-    const clearButton = getByRole("button");
+    const clearButton = container.querySelector("button")!;
 
     expect(clearButton).not.toBeNull();
 
@@ -194,7 +194,7 @@ describe("Input", () => {
 
     const ref = React.createRef<HTMLInputElement>();
 
-    const {getByRole} = render(
+    const {container} = render(
       <Input
         ref={ref}
         isClearable
@@ -205,7 +205,7 @@ describe("Input", () => {
       />,
     );
 
-    const clearButton = getByRole("button");
+    const clearButton = container.querySelector("button")!;
 
     expect(clearButton).not.toBeNull();
 
@@ -264,7 +264,7 @@ describe("Input with React Hook Form", () => {
     input1 = document.querySelector("input[name=withDefaultValue]")!;
     input2 = document.querySelector("input[name=withoutDefaultValue]")!;
     input3 = document.querySelector("input[name=requiredField]")!;
-    submitButton = document.querySelector("button")!;
+    submitButton = document.querySelector('button[type="submit"]')!;
   });
 
   it("should work with defaultValues", () => {

--- a/packages/components/input/src/input.tsx
+++ b/packages/components/input/src/input.tsx
@@ -36,7 +36,7 @@ const Input = forwardRef<"input", InputProps>((props, ref) => {
 
   const end = useMemo(() => {
     if (isClearable) {
-      return <span {...getClearButtonProps()}>{endContent || <CloseFilledIcon />}</span>;
+      return <button {...getClearButtonProps()}>{endContent || <CloseFilledIcon />}</button>;
     }
 
     return endContent;

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -511,6 +511,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       return {
         ...props,
         type: "button",
+        tabIndex: -1,
         disabled: originalProps.isDisabled,
         "aria-label": "clear input",
         "data-slot": "clear-button",

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -510,8 +510,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     (props = {}) => {
       return {
         ...props,
-        role: "button",
-        tabIndex: originalProps?.isDisabled ? -1 : 0,
+        type: "button",
+        disabled: originalProps.isDisabled,
         "aria-label": "clear input",
         "data-slot": "clear-button",
         "data-focus-visible": dataAttr(isClearButtonFocusVisible),

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -511,7 +511,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       return {
         ...props,
         role: "button",
-        tabIndex: 0,
+        tabIndex: originalProps?.isDisabled ? -1 : 0,
         "aria-label": "clear input",
         "data-slot": "clear-button",
         "data-focus-visible": dataAttr(isClearButtonFocusVisible),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR fixes an issue where the `clear button` inside the `Input` component could still receive focus when the input is disabled (`isDisabled`). The button is now properly excluded from the tab order by setting `tabIndex` to `-1` when the input is disabled.

## ⛳️ Current behavior (updates)
https://github.com/user-attachments/assets/cc929087-c1ee-4887-a0b0-6888a2ca3ed1

Currently, the `clear button` in the `Input` component can still receive focus via the Tab key when the input is disabled. This behavior can cause accessibility issues and an inconsistent user experience.


## 🚀 New behavior

With this fix, the `clear button` will no longer be focusable when the input is disabled. The `tabIndex` for the `clear button` is set to `-1` when `isDisabled` is true, preventing it from being part of the tab order.


## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information

This fix enhances accessibility and user experience by ensuring that the `clear button` behaves correctly when the input is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility for the clear button in the input component by preventing focus when the input is disabled.
	- Updated the clear button from a `<span>` to a `<button>` element for improved semantic meaning and usability.
- **Bug Fixes**
	- Adjusted the `tabIndex` property for the clear button to ensure compliance with keyboard navigation standards.
- **Tests**
	- Added new test cases to verify the correct behavior of the clear button's state when the input is disabled and ensure it is not focusable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->