### PR TITLE
fix(autocomplete): popover should remain open after clicking clear button

### DIFF
--- a/.changeset/dirty-moles-refuse.md
+++ b/.changeset/dirty-moles-refuse.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/autocomplete": minor
+"@nextui-org/autocomplete": patch
 ---
 
-added state.open() and removed state.close() from onPress prop of clear button so that dropdown does not close when clear button is clicked
+Improves handling of clear button in autocomplete component. Clicking the clear button will now clear the selected value without closing the dropdown.

--- a/.changeset/dirty-moles-refuse.md
+++ b/.changeset/dirty-moles-refuse.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": minor
+---
+
+added state.open() and removed state.close() from onPress prop of clear button so that dropdown does not close when clear button is clicked

--- a/.changeset/dirty-moles-refuse.md
+++ b/.changeset/dirty-moles-refuse.md
@@ -2,4 +2,4 @@
 "@nextui-org/autocomplete": patch
 ---
 
-Improves handling of clear button in autocomplete component. Clicking the clear button will now clear the selected value without closing the dropdown.
+Clicking the clear button clears the selected value without closing the dropdown. (#3788)

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -235,6 +235,55 @@ describe("Autocomplete", () => {
     expect(autocomplete).toHaveFocus();
   });
 
+  it("should keep the ListBox open after clicking clear button", async () => {
+    const wrapper = render(
+      <Autocomplete aria-label="Favorite Animal" data-testid="autocomplete" label="Favorite Animal">
+        <AutocompleteItem key="penguin" value="penguin">
+          Penguin
+        </AutocompleteItem>
+        <AutocompleteItem key="zebra" value="zebra">
+          Zebra
+        </AutocompleteItem>
+        <AutocompleteItem key="shark" value="shark">
+          Shark
+        </AutocompleteItem>
+      </Autocomplete>,
+    );
+
+    const autocomplete = wrapper.getByTestId("autocomplete");
+
+    // open the select listbox
+    await act(async () => {
+      await userEvent.click(autocomplete);
+    });
+
+    // assert that the autocomplete listbox is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
+
+    let options = wrapper.getAllByRole("option");
+
+    // select the target item
+    await act(async () => {
+      await userEvent.click(options[0]);
+    });
+
+    const {container} = wrapper;
+
+    const clearButton = container.querySelector(
+      "[data-slot='inner-wrapper'] button:nth-of-type(1)",
+    )!;
+
+    expect(clearButton).not.toBeNull();
+
+    // select the target item
+    await act(async () => {
+      await userEvent.click(clearButton);
+    });
+
+    // assert that the autocomplete listbox is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
+  });
+
   it("should clear value after clicking clear button (controlled)", async () => {
     const wrapper = render(
       <ControlledAutocomplete data-testid="autocomplete" items={itemsData}>
@@ -277,6 +326,47 @@ describe("Autocomplete", () => {
 
     // assert that input is focused
     expect(autocomplete).toHaveFocus();
+  });
+
+  it("should keep the ListBox open after clicking clear button (controlled)", async () => {
+    const wrapper = render(
+      <ControlledAutocomplete data-testid="autocomplete" items={itemsData}>
+        {(item) => <AutocompleteItem key={item.value}>{item.value}</AutocompleteItem>}
+      </ControlledAutocomplete>,
+    );
+
+    const autocomplete = wrapper.getByTestId("autocomplete");
+
+    // open the select listbox
+    await act(async () => {
+      await userEvent.click(autocomplete);
+    });
+
+    // assert that the autocomplete listbox is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
+
+    let options = wrapper.getAllByRole("option");
+
+    // select the target item
+    await act(async () => {
+      await userEvent.click(options[0]);
+    });
+
+    const {container} = wrapper;
+
+    const clearButton = container.querySelector(
+      "[data-slot='inner-wrapper'] button:nth-of-type(1)",
+    )!;
+
+    expect(clearButton).not.toBeNull();
+
+    // select the target item
+    await act(async () => {
+      await userEvent.click(clearButton);
+    });
+
+    // assert that the autocomplete listbox is open
+    expect(autocomplete).toHaveAttribute("aria-expanded", "true");
   });
 
   it("should open and close listbox by clicking selector button", async () => {

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -223,7 +223,7 @@ describe("Autocomplete", () => {
 
     expect(clearButton).not.toBeNull();
 
-    // select the target item
+    // click the clear button
     await act(async () => {
       await userEvent.click(clearButton);
     });
@@ -275,7 +275,7 @@ describe("Autocomplete", () => {
 
     expect(clearButton).not.toBeNull();
 
-    // select the target item
+    // click the clear button
     await act(async () => {
       await userEvent.click(clearButton);
     });
@@ -316,7 +316,7 @@ describe("Autocomplete", () => {
 
     expect(clearButton).not.toBeNull();
 
-    // select the target item
+    /// click the clear button
     await act(async () => {
       await userEvent.click(clearButton);
     });
@@ -360,7 +360,7 @@ describe("Autocomplete", () => {
 
     expect(clearButton).not.toBeNull();
 
-    // select the target item
+    // click the clear button
     await act(async () => {
       await userEvent.click(clearButton);
     });

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -385,16 +385,15 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       },
       onPress: (e: PressEvent) => {
         slotsProps.clearButtonProps?.onPress?.(e);
-
         if (state.selectedItem) {
           state.setInputValue("");
           state.setSelectedKey(null);
         } else {
           if (allowsCustomValue) {
             state.setInputValue("");
-            state.close();
           }
         }
+        state.open();
       },
       "data-visible": !!state.selectedItem || state.inputValue?.length > 0,
       className: slots.clearButton({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3783 <!-- Github issue # here -->

## 📝 Description

Added `state.open()`  so that dropdown does not close when clear button is clicked.
based on [this](https://github.com/nextui-org/nextui/pull/2148) PR

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the autocomplete component to keep the dropdown open when the clear button is pressed, allowing for a smoother user interaction experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->