### PR TITLE
docs(accordion): add overflow to custom motion example

### DIFF
--- a/apps/docs/content/components/accordion/custom-motion.ts
+++ b/apps/docs/content/components/accordion/custom-motion.ts
@@ -12,6 +12,7 @@ export default function App() {
             y: 0,
             opacity: 1,
             height: "auto",
+            overflowY: "unset",
             transition: {
               height: {
                 type: "spring",
@@ -29,6 +30,7 @@ export default function App() {
             y: -10,
             opacity: 0,
             height: 0,
+            overflowY: "hidden",
             transition: {
               height: {
                 easings: "ease",


### PR DESCRIPTION
## 📝 Description

Add overflow values (from default enter/exit animation) to fix overflow in custom motion example so it looks a bit nicer.

## ⛳️ Current behavior (updates)

Accordion item content overflow is visible during exit animation

## 🚀 New behavior

Accordion item content overflow is not visible during exit animation

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the accordion component's motion properties for improved visual behavior during open and close transitions.
	- Implemented flexible overflow management when the accordion is open and hidden overflow when closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->