### PR TITLE
fix(image): add missing `w` to `getWrapperProps` dependency

### DIFF
--- a/.changeset/shy-mails-live.md
+++ b/.changeset/shy-mails-live.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/image": patch
+---
+
+add missing `w` to `getWrapperProps` dependency (#3801)

--- a/packages/components/image/src/use-image.ts
+++ b/packages/components/image/src/use-image.ts
@@ -188,7 +188,7 @@ export function useImage(originalProps: UseImageProps) {
         maxWidth: w,
       },
     };
-  }, [slots, showFallback, fallbackSrc, classNames?.wrapper]);
+  }, [slots, showFallback, fallbackSrc, classNames?.wrapper, w]);
 
   const getBlurredImgProps = useCallback<PropGetter>(() => {
     return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3801

## 📝 Description

as titled

## ⛳️ Current behavior (updates)

[pr3802-before.webm](https://github.com/user-attachments/assets/06dc2684-7b26-4c41-bfbe-3aece0f71cc3)

## 🚀 New behavior

[pr3802-after.webm](https://github.com/user-attachments/assets/fdb74c74-8380-4276-ae13-9f1f2240b788)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `getWrapperProps` function to include a missing dependency, enhancing functionality and reliability.
	- Modified the `useEffect` dependency array in the `useImage` function to ensure proper reactivity to changes in the `w` value, improving image rendering and layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->