### PR TITLE
docs(accordion): note `use client;` directive

### DIFF
--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -35,6 +35,10 @@ NextUI exports 2 accordion-related components:
 - **Accordion**: The main component to display a list of accordion items.
 - **AccordionItem**: The item component to display a single accordion item.
 
+<Blockquote color="primary">
+**Note**: Specify `use client;` directive explicitly until the issue [#1403](https://github.com/nextui-org/nextui/issues/1403) is resolved.
+</Blockquote>
+
 <ImportTabs
   commands={{
     main: 'import {Accordion, AccordionItem} from "@nextui-org/react";',


### PR DESCRIPTION
Refer to https://github.com/nextui-org/nextui/issues/1403

Note: I think other components like Dropdown should be also documented, but did not include it in this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a note in the accordion component documentation to specify the `use client;` directive explicitly until issue [#1403](https://github.com/nextui-org/nextui/issues/1403) is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->