### PR TITLE
fix(date-picker): resolve override of calendarProps className

### DIFF
--- a/.changeset/hungry-kangaroos-kick.md
+++ b/.changeset/hungry-kangaroos-kick.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/date-picker": major
+---
+
+Fixed: Resolved an issue where the className property in the date-picker's calendarProps was being overridden. This ensures that custom styles applied to the calendar are now respected and correctly rendered.

--- a/packages/components/date-picker/src/use-date-picker.ts
+++ b/packages/components/date-picker/src/use-date-picker.ts
@@ -10,7 +10,7 @@ import type {DatePickerSlots, SlotsToClasses} from "@nextui-org/theme";
 
 import {useProviderContext} from "@nextui-org/system";
 import {useMemo, useRef} from "react";
-import {datePicker} from "@nextui-org/theme";
+import {datePicker, cn} from "@nextui-org/theme";
 import {useDatePickerState} from "@react-stately/datepicker";
 import {AriaDatePickerProps, useDatePicker as useAriaDatePicker} from "@react-aria/datepicker";
 import {clsx, dataAttr, objectToDeps} from "@nextui-org/shared-utils";
@@ -204,8 +204,11 @@ export function useDatePicker<T extends DateValue>({
       ...ariaCalendarProps,
       ...calendarProps,
       classNames: {
-        base: slots.calendar({class: classNames?.calendar}),
-        content: slots.calendarContent({class: classNames?.calendarContent}),
+        ...calendarProps.classNames,
+        base: slots.calendar({class: cn(calendarProps?.classNames?.base, classNames?.calendar)}),
+        content: slots.calendarContent({
+          class: cn(calendarProps?.classNames?.content, classNames?.calendarContent),
+        }),
       },
     };
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR fixes an issue where the classNames property in the date-picker's calendarProps was being overridden, preventing custom styles from being applied.

## ⛳️ Current behavior (updates)

Currently, any custom styles set for the date-picker's calendar are ignored due to the classNames being overridden.

## 🚀 New behavior

With this change, the classNames property in calendarProps is now respected, allowing developers to apply custom styles as intended.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced class name handling for the date-picker component, allowing custom styles to be applied effectively.
  
- **Bug Fixes**
	- Resolved an issue where custom styles for the calendar were being overridden, ensuring proper rendering of user-defined styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->