### PR TITLE
feat(autocomplete): add autoHighlight prop

### DIFF
--- a/.changeset/angry-pillows-accept.md
+++ b/.changeset/angry-pillows-accept.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/autocomplete": minor
+"@nextui-org/listbox": minor
+---
+
+add prop isAutoHighlight to enable/disable the automatic focus on autocomplete items (#2186)

--- a/.changeset/angry-pillows-accept.md
+++ b/.changeset/angry-pillows-accept.md
@@ -3,4 +3,4 @@
 "@nextui-org/listbox": minor
 ---
 
-add prop isAutoHighlight to enable/disable the automatic focus on autocomplete items (#2186)
+add prop autoHighlight to enable/disable the automatic focus on autocomplete items (#2186)

--- a/apps/docs/content/components/autocomplete/auto-highlight.ts
+++ b/apps/docs/content/components/autocomplete/auto-highlight.ts
@@ -1,0 +1,53 @@
+const data = `export const animals = [
+  {label: "Cat", value: "cat", description: "The second most popular pet in the world"},
+  {label: "Dog", value: "dog", description: "The most popular pet in the world"},
+  {label: "Elephant", value: "elephant", description: "The largest land animal"},
+  {label: "Lion", value: "lion", description: "The king of the jungle"},
+  {label: "Tiger", value: "tiger", description: "The largest cat species"},
+  {label: "Giraffe", value: "giraffe", description: "The tallest land animal"},
+  {
+    label: "Dolphin",
+    value: "dolphin",
+    description: "A widely distributed and diverse group of aquatic mammals",
+  },
+  {label: "Penguin", value: "penguin", description: "A group of aquatic flightless birds"},
+  {label: "Zebra", value: "zebra", description: "A several species of African equids"},
+  {
+    label: "Shark",
+    value: "shark",
+    description: "A group of elasmobranch fish characterized by a cartilaginous skeleton",
+  },
+  {
+    label: "Whale",
+    value: "whale",
+    description: "Diverse group of fully aquatic placental marine mammals",
+  },
+  {label: "Otter", value: "otter", description: "A carnivorous mammal in the subfamily Lutrinae"},
+  {label: "Crocodile", value: "crocodile", description: "A large semiaquatic reptile"},
+];`;
+
+const App = `import {Autocomplete, AutocompleteItem} from "@nextui-org/react";
+import {animals} from "./data";
+
+export default function App() {
+  return (
+      <Autocomplete
+        isAutoHighlight
+        label="Favorite Animal"
+        placeholder="Search an animal"
+        className="max-w-xs"
+        defaultItems={animals}
+      >
+        {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+      </Autocomplete>
+  );
+}`;
+
+const react = {
+  "/App.jsx": App,
+  "/data.js": data,
+};
+
+export default {
+  ...react,
+};

--- a/apps/docs/content/components/autocomplete/auto-highlight.ts
+++ b/apps/docs/content/components/autocomplete/auto-highlight.ts
@@ -32,7 +32,7 @@ import {animals} from "./data";
 export default function App() {
   return (
       <Autocomplete
-        isAutoHighlight
+        autoHighlight
         label="Favorite Animal"
         placeholder="Search an animal"
         className="max-w-xs"

--- a/apps/docs/content/components/autocomplete/index.ts
+++ b/apps/docs/content/components/autocomplete/index.ts
@@ -26,7 +26,7 @@ import customSectionsStyle from "./custom-sections-style";
 import customStyles from "./custom-styles";
 import customEmptyContentMessage from "./custom-empty-content-message";
 import readOnly from "./read-only";
-import isAutoHighlight from "./auto-highlight";
+import autoHighlight from "./auto-highlight";
 
 export const autocompleteContent = {
   usage,
@@ -57,5 +57,5 @@ export const autocompleteContent = {
   customStyles,
   customEmptyContentMessage,
   readOnly,
-  isAutoHighlight,
+  autoHighlight,
 };

--- a/apps/docs/content/components/autocomplete/index.ts
+++ b/apps/docs/content/components/autocomplete/index.ts
@@ -26,6 +26,7 @@ import customSectionsStyle from "./custom-sections-style";
 import customStyles from "./custom-styles";
 import customEmptyContentMessage from "./custom-empty-content-message";
 import readOnly from "./read-only";
+import isAutoHighlight from "./auto-highlight";
 
 export const autocompleteContent = {
   usage,
@@ -56,4 +57,5 @@ export const autocompleteContent = {
   customStyles,
   customEmptyContentMessage,
   readOnly,
+  isAutoHighlight,
 };

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -324,9 +324,9 @@ You can use the `AutocompleteSection` component to group autocomplete items.
 
 ### Auto Highlight
 
-If you pass the `isAutoHighlight` property to the Autocomplete, the Listbox will show the first list item automatically highlighted.
+If you pass the `autoHighlight` property to the Autocomplete, the Listbox will show the first list item automatically highlighted.
 
-<CodeDemo title="Auto Highlight" files={autocompleteContent.isAutoHighlight} />
+<CodeDemo title="Auto Highlight" files={autocompleteContent.autoHighlight} />
 
 ### Custom Sections Style
 

--- a/apps/docs/content/docs/components/autocomplete.mdx
+++ b/apps/docs/content/docs/components/autocomplete.mdx
@@ -84,7 +84,7 @@ the end of the label and the autocomplete will be required.
 
 ### Read Only
 
-If you pass the `isReadOnly` property to the Autocomplete, the Listbox will open to display 
+If you pass the `isReadOnly` property to the Autocomplete, the Listbox will open to display
 all available options, but users won't be able to select any of the listed options.
 
 <CodeDemo title="Read Only" highlightedLines="8" files={autocompleteContent.readOnly} />
@@ -321,6 +321,12 @@ import {useInfiniteScroll} from "@nextui-org/use-infinite-scroll";
 You can use the `AutocompleteSection` component to group autocomplete items.
 
 <CodeDemo title="With Sections" files={autocompleteContent.sections} />
+
+### Auto Highlight
+
+If you pass the `isAutoHighlight` property to the Autocomplete, the Listbox will show the first list item automatically highlighted.
+
+<CodeDemo title="Auto Highlight" files={autocompleteContent.isAutoHighlight} />
 
 ### Custom Sections Style
 

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -861,3 +861,75 @@ describe("Autocomplete with React Hook Form", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });
+
+it("should auto-highlight the first non-disabled item when isAutoHighlight is true", async () => {
+  const {getByRole, getAllByRole} = render(
+    <Autocomplete
+      isAutoHighlight
+      aria-label="Favorite Animal"
+      items={itemsData}
+      label="Favorite Animal"
+    >
+      {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+    </Autocomplete>,
+  );
+
+  const input = getByRole("combobox");
+
+  await act(async () => {
+    await userEvent.click(input);
+  });
+
+  const options = getAllByRole("option");
+
+  expect(options[0]).toHaveAttribute("data-hover", "true");
+});
+
+it("should skip disabled items when auto-highlighting", async () => {
+  const {getByRole, getAllByRole} = render(
+    <Autocomplete
+      isAutoHighlight
+      aria-label="Favorite Animal"
+      disabledKeys={["cat", "dog"]}
+      items={itemsData}
+      label="Favorite Animal"
+    >
+      {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+    </Autocomplete>,
+  );
+
+  const input = getByRole("combobox");
+
+  await act(async () => {
+    await userEvent.click(input);
+  });
+
+  const options = getAllByRole("option");
+
+  expect(options[2]).toHaveAttribute("data-hover", "true");
+});
+
+it("should not auto-highlight when isAutoHighlight is false", async () => {
+  const {getByRole, getAllByRole} = render(
+    <Autocomplete
+      aria-label="Favorite Animal"
+      isAutoHighlight={false}
+      items={itemsData}
+      label="Favorite Animal"
+    >
+      {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+    </Autocomplete>,
+  );
+
+  const input = getByRole("combobox");
+
+  await act(async () => {
+    await userEvent.click(input);
+  });
+
+  const options = getAllByRole("option");
+
+  options.forEach((option) => {
+    expect(option).not.toHaveAttribute("data-hover", "true");
+  });
+});

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -862,10 +862,10 @@ describe("Autocomplete with React Hook Form", () => {
   });
 });
 
-it("should auto-highlight the first non-disabled item when isAutoHighlight is true", async () => {
+it("should auto-highlight the first non-disabled item when autoHighlight is true", async () => {
   const {getByRole, getAllByRole} = render(
     <Autocomplete
-      isAutoHighlight
+      autoHighlight
       aria-label="Favorite Animal"
       items={itemsData}
       label="Favorite Animal"
@@ -888,7 +888,7 @@ it("should auto-highlight the first non-disabled item when isAutoHighlight is tr
 it("should skip disabled items when auto-highlighting", async () => {
   const {getByRole, getAllByRole} = render(
     <Autocomplete
-      isAutoHighlight
+      autoHighlight
       aria-label="Favorite Animal"
       disabledKeys={["cat", "dog"]}
       items={itemsData}
@@ -909,11 +909,11 @@ it("should skip disabled items when auto-highlighting", async () => {
   expect(options[2]).toHaveAttribute("data-hover", "true");
 });
 
-it("should not auto-highlight when isAutoHighlight is false", async () => {
+it("should not auto-highlight when autoHighlight is false", async () => {
   const {getByRole, getAllByRole} = render(
     <Autocomplete
       aria-label="Favorite Animal"
-      isAutoHighlight={false}
+      autoHighlight={false}
       items={itemsData}
       label="Favorite Animal"
     >

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -325,12 +325,14 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   // focus first non-disabled item
   useEffect(() => {
-    let key = state.collection.getFirstKey();
+    if (isAutoHighlight) {
+      let key = state.collection.getFirstKey();
 
-    while (key && state.disabledKeys.has(key)) {
-      key = state.collection.getKeyAfter(key);
+      while (key && state.disabledKeys.has(key)) {
+        key = state.collection.getKeyAfter(key);
+      }
+      state.selectionManager.setFocusedKey(key);
     }
-    state.selectionManager.setFocusedKey(key);
   }, [state.collection, state.disabledKeys]);
 
   useEffect(() => {
@@ -345,14 +347,6 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       }
     }
   }, [isOpen]);
-
-  useEffect(() => {
-    if (isAutoHighlight && isOpen && state.collection.size > 0) {
-      const firstKey = state.collection.getFirstKey();
-
-      state.selectionManager.setFocusedKey(firstKey);
-    }
-  }, [isAutoHighlight, isOpen, state.inputValue, state.collection]);
 
   // to prevent the error message:
   // stopPropagation is now the default behavior for events in React Spectrum.

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -110,6 +110,11 @@ interface Props<T> extends Omit<HTMLNextUIProps<"input">, keyof ComboBoxProps<T>
    * Callback fired when the select menu is closed.
    */
   onClose?: () => void;
+  /**
+   * Whether to automatically highlight the first item in the list as the user types.
+   * @default false
+   */
+  isAutoHighlight?: boolean;
 }
 
 export type UseAutocompleteProps<T> = Props<T> &
@@ -165,6 +170,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     onOpenChange,
     onClose,
     isReadOnly = false,
+    isAutoHighlight = false,
     ...otherProps
   } = props;
 
@@ -330,6 +336,14 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (isAutoHighlight && isOpen && state.collection.size > 0) {
+      const firstKey = state.collection.getFirstKey();
+
+      state.selectionManager.setFocusedKey(firstKey);
+    }
+  }, [isAutoHighlight, isOpen, state.inputValue, state.collection]);
+
   // to prevent the error message:
   // stopPropagation is now the default behavior for events in React Spectrum.
   // You can use continuePropagation() to revert this behavior.
@@ -423,6 +437,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       ...mergeProps(slotsProps.listboxProps, listBoxProps, {
         shouldHighlightOnFocus: true,
       }),
+      isAutoHighlight,
     } as ListboxProps);
 
   const getPopoverProps = (props: DOMAttributes = {}) => {
@@ -506,6 +521,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     disableAnimation,
     allowsCustomValue,
     selectorIcon,
+    isAutoHighlight,
     getBaseProps,
     getInputProps,
     getListBoxProps,

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -114,7 +114,7 @@ interface Props<T> extends Omit<HTMLNextUIProps<"input">, keyof ComboBoxProps<T>
    * Whether to automatically highlight the first item in the list as the user types.
    * @default false
    */
-  isAutoHighlight?: boolean;
+  autoHighlight?: boolean;
 }
 
 export type UseAutocompleteProps<T> = Props<T> &
@@ -170,7 +170,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     onOpenChange,
     onClose,
     isReadOnly = false,
-    isAutoHighlight = false,
+    autoHighlight = false,
     ...otherProps
   } = props;
 
@@ -325,7 +325,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
 
   // focus first non-disabled item
   useEffect(() => {
-    if (isAutoHighlight) {
+    if (autoHighlight) {
       let key = state.collection.getFirstKey();
 
       while (key && state.disabledKeys.has(key)) {
@@ -440,7 +440,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       ...mergeProps(slotsProps.listboxProps, listBoxProps, {
         shouldHighlightOnFocus: true,
       }),
-      isAutoHighlight,
+      autoHighlight,
     } as ListboxProps);
 
   const getPopoverProps = (props: DOMAttributes = {}) => {
@@ -524,7 +524,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     disableAnimation,
     allowsCustomValue,
     selectorIcon,
-    isAutoHighlight,
+    autoHighlight,
     getBaseProps,
     getInputProps,
     getListBoxProps,

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -65,7 +65,7 @@ export default {
         type: "boolean",
       },
     },
-    isAutoHighlight: {
+    autoHighlight: {
       control: {
         type: "boolean",
       },
@@ -810,7 +810,7 @@ const WithReactHookFormTemplate = (args: AutocompleteProps) => {
 
 const AutoHighlightTemplate = ({color, variant, ...args}: AutocompleteProps<Animal>) => (
   <Autocomplete
-    isAutoHighlight
+    autoHighlight
     className="max-w-xs"
     color={color}
     defaultItems={animalsData}

--- a/packages/components/autocomplete/stories/autocomplete.stories.tsx
+++ b/packages/components/autocomplete/stories/autocomplete.stories.tsx
@@ -65,6 +65,11 @@ export default {
         type: "boolean",
       },
     },
+    isAutoHighlight: {
+      control: {
+        type: "boolean",
+      },
+    },
     validationBehavior: {
       control: {
         type: "select",
@@ -803,6 +808,21 @@ const WithReactHookFormTemplate = (args: AutocompleteProps) => {
   );
 };
 
+const AutoHighlightTemplate = ({color, variant, ...args}: AutocompleteProps<Animal>) => (
+  <Autocomplete
+    isAutoHighlight
+    className="max-w-xs"
+    color={color}
+    defaultItems={animalsData}
+    label="Favorite Animal"
+    placeholder="Select an animal"
+    variant={variant}
+    {...args}
+  >
+    {(item) => <AutocompleteItem key={item.value}>{item.label}</AutocompleteItem>}
+  </Autocomplete>
+);
+
 export const Default = {
   render: Template,
   args: {
@@ -1057,6 +1077,13 @@ export const CustomStylesWithCustomItems = {
 
 export const FullyControlled = {
   render: FullyControlledTemplate,
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const WithAutoHighlight = {
+  render: AutoHighlightTemplate,
   args: {
     ...defaultProps,
   },

--- a/packages/components/listbox/src/listbox.tsx
+++ b/packages/components/listbox/src/listbox.tsx
@@ -24,7 +24,7 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
     disableAnimation,
     getEmptyContentProps,
     getListProps,
-    isAutoHighlight,
+    autoHighlight,
   } = useListbox<T>({...props, ref});
 
   const content = (
@@ -52,8 +52,8 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
           <ListboxItem
             key={item.key}
             {...itemProps}
+            autoHighlighted={autoHighlight && state.selectionManager.focusedKey === item.key}
             classNames={mergeProps(itemClasses, item.props?.classNames)}
-            isAutoHighlighted={isAutoHighlight && state.selectionManager.focusedKey === item.key}
             shouldHighlightOnFocus={shouldHighlightOnFocus}
           />
         );

--- a/packages/components/listbox/src/listbox.tsx
+++ b/packages/components/listbox/src/listbox.tsx
@@ -24,6 +24,7 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
     disableAnimation,
     getEmptyContentProps,
     getListProps,
+    isAutoHighlight,
   } = useListbox<T>({...props, ref});
 
   const content = (
@@ -52,6 +53,7 @@ function Listbox<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListE
             key={item.key}
             {...itemProps}
             classNames={mergeProps(itemClasses, item.props?.classNames)}
+            isAutoHighlighted={isAutoHighlight && state.selectionManager.focusedKey === item.key}
             shouldHighlightOnFocus={shouldHighlightOnFocus}
           />
         );

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -21,6 +21,7 @@ import {ListState} from "@react-stately/list";
 interface Props<T extends object> extends ListboxItemBaseProps<T> {
   item: Node<T>;
   state: ListState<T>;
+  isAutoHighlighted?: boolean;
 }
 
 export type UseListboxItemProps<T extends object> = Props<T> &
@@ -46,6 +47,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     onPress,
     onClick,
     shouldHighlightOnFocus,
+    isAutoHighlighted = false,
     hideSelectedIcon = false,
     isReadOnly = false,
     ...otherProps
@@ -111,7 +113,8 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
 
   const isHighlighted =
     (shouldHighlightOnFocus && isFocused) ||
-    (isMobile ? isHovered || isPressed : isHovered || (isFocused && !isFocusVisible));
+    (isMobile ? isHovered || isPressed : isHovered || (isFocused && !isFocusVisible)) ||
+    isAutoHighlighted;
 
   const getItemProps: PropGetter = (props = {}) => ({
     ref: domRef,
@@ -178,6 +181,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     selectedIcon,
     hideSelectedIcon,
     disableAnimation,
+    isHighlighted,
     getItemProps,
     getLabelProps,
     getWrapperProps,

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -21,7 +21,7 @@ import {ListState} from "@react-stately/list";
 interface Props<T extends object> extends ListboxItemBaseProps<T> {
   item: Node<T>;
   state: ListState<T>;
-  isAutoHighlighted?: boolean;
+  autoHighlighted?: boolean;
 }
 
 export type UseListboxItemProps<T extends object> = Props<T> &
@@ -47,7 +47,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
     onPress,
     onClick,
     shouldHighlightOnFocus,
-    isAutoHighlighted = false,
+    autoHighlighted = false,
     hideSelectedIcon = false,
     isReadOnly = false,
     ...otherProps
@@ -114,7 +114,7 @@ export function useListboxItem<T extends object>(originalProps: UseListboxItemPr
   const isHighlighted =
     (shouldHighlightOnFocus && isFocused) ||
     (isMobile ? isHovered || isPressed : isHovered || (isFocused && !isFocusVisible)) ||
-    isAutoHighlighted;
+    autoHighlighted;
 
   const getItemProps: PropGetter = (props = {}) => ({
     ref: domRef,

--- a/packages/components/listbox/src/use-listbox.ts
+++ b/packages/components/listbox/src/use-listbox.ts
@@ -96,7 +96,7 @@ interface Props<T> extends Omit<HTMLNextUIProps<"ul">, "children"> {
    * Whether to automatically highlight the first item in the list.
    * @default false
    */
-  isAutoHighlight?: boolean;
+  autoHighlight?: boolean;
 }
 
 export type UseListboxProps<T = object> = Props<T> & AriaListBoxOptions<T> & ListboxVariantProps;
@@ -123,7 +123,7 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
     hideEmptyContent = false,
     shouldHighlightOnFocus = false,
     classNames,
-    isAutoHighlight = false,
+    autoHighlight = false,
     ...otherProps
   } = props;
 
@@ -187,7 +187,7 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
     disableAnimation,
     className,
     itemClasses,
-    isAutoHighlight,
+    autoHighlight,
     getBaseProps,
     getListProps,
     getEmptyContentProps,

--- a/packages/components/listbox/src/use-listbox.ts
+++ b/packages/components/listbox/src/use-listbox.ts
@@ -92,6 +92,11 @@ interface Props<T> extends Omit<HTMLNextUIProps<"ul">, "children"> {
    * The menu items classNames.
    */
   itemClasses?: ListboxItemProps["classNames"];
+  /**
+   * Whether to automatically highlight the first item in the list.
+   * @default false
+   */
+  isAutoHighlight?: boolean;
 }
 
 export type UseListboxProps<T = object> = Props<T> & AriaListBoxOptions<T> & ListboxVariantProps;
@@ -118,6 +123,7 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
     hideEmptyContent = false,
     shouldHighlightOnFocus = false,
     classNames,
+    isAutoHighlight = false,
     ...otherProps
   } = props;
 
@@ -181,6 +187,7 @@ export function useListbox<T extends object>(props: UseListboxProps<T>) {
     disableAnimation,
     className,
     itemClasses,
+    isAutoHighlight,
     getBaseProps,
     getListProps,
     getEmptyContentProps,


### PR DESCRIPTION
Closes # N/A

## 📝 Description

> Introduces a new `autoHighlight ` prop to the Autocomplete component, which automatically highlights the first item in the dropdown list as the user types.

## ⛳️ Current behavior (updates)

> Currently, the Autocomplete component does not automatically highlight any option when the user types. Users need to manually navigate through the list to select an option.

## 🚀 New behavior

> - A new `autoHighlight ` prop is added to the Autocomplete component.
> - When `autoHighlight ` is set to true, the first item in the dropdown list is automatically highlighted as the user types.
> - Users can immediately press Enter to select the highlighted option without needing to navigate through the list.
> - If `isAutoHighlighted` is false or not provided, the component behaves as it did previously.

## 💣 Is this a breaking change (Yes/No):

> No

## 📝 Additional Information

> Added SB test and sample to documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an autocomplete component for selecting animals with automatic highlighting for the first suggestion.
  - Added a new property, `autoHighlight`, to enhance user experience in both autocomplete and listbox components.

- **Documentation**
  - Updated documentation for the `Autocomplete` component to include new features and clarify existing properties.
  - Expanded API section with detailed descriptions of new properties and events related to the autocomplete functionality.

- **Bug Fixes**
  - Improved logic for highlighting items in the listbox based on user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->