### PR TITLE
fix(docs): highlighted line in Select dynamic items

### DIFF
--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -54,7 +54,7 @@ Select follows the [Collection Components API](https://react-spectrum.adobe.com/
 - **Static**: The usage example above shows the static implementation, which can be used when the full list of options is known ahead of time.
 - **Dynamic**: The example below can be used when the options come from an external data source such as an API call, or update over time.
 
-<CodeDemo title="Dynamic items" highlightedLines="8" files={selectContent.dynamic} />
+<CodeDemo title="Dynamic items" highlightedLines="7" files={selectContent.dynamic} />
 
 ### Multiple Selection
 


### PR DESCRIPTION
## 📝 Description

Hello. In the code section of the Dynamic items subsection of the documentation for the Selector component, I found that the highlighted line is **highlighted incorrectly**, see the image for more details
![image](https://github.com/user-attachments/assets/1c165b2e-64e6-4971-9b0e-591854f84738)


## ⛳️ Current behavior (updates)

Incorrectly highlighted line

## 🚀 New behavior

Changed the highlighted line

## 💣 Is this a breaking change (Yes/No): Yes

I've wasted a lot of time and made a lot of mistakes that I shouldn't have because I didn't notice this, and I don't expect anyone else to (and it's night time)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated examples and highlighted lines in the documentation for the `Select` component, enhancing clarity for "Dynamic items," "Disabled," "Required," "Sizes," and "Label Placements."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->