### PR TITLE
fix: incorrect domain for images

### DIFF
--- a/apps/docs/config/site.ts
+++ b/apps/docs/config/site.ts
@@ -33,7 +33,7 @@ export const siteConfig = {
   links: {
     github: "https://github.com/nextui-org/nextui",
     twitter: "https://twitter.com/getnextui",
-    docs: "https://nextui-docs-v2.vercel.app",
+    docs: "https://nextui.org",
     discord: "https://discord.gg/9b6yyZKmH4",
     sponsor: "https://patreon.com/jrgarciadev",
     portfolio: "https://jrgarciadev.com",

--- a/apps/docs/content/components/image/blurred.ts
+++ b/apps/docs/content/components/image/blurred.ts
@@ -5,7 +5,7 @@ export default function App() {
     <Image
       isBlurred
       width={240}
-      src="https://nextui-docs-v2.vercel.app/images/album-cover.png"
+      src="https://nextui.org/images/album-cover.png"
       alt="NextUI Album Cover"
       className="m-5"
     />

--- a/apps/docs/content/components/image/fallback.ts
+++ b/apps/docs/content/components/image/fallback.ts
@@ -5,7 +5,7 @@ export default function App() {
     <Image
       width={300}
       height={200}
-      src="https://app.requestly.io/delay/1000/https://nextui-docs-v2.vercel.app/images/fruit-4.jpeg"
+      src="https://app.requestly.io/delay/1000/https://nextui.org/images/fruit-4.jpeg"
       fallbackSrc="https://via.placeholder.com/300x200"
       alt="NextUI Image with fallback"
     />

--- a/apps/docs/content/components/image/loading.ts
+++ b/apps/docs/content/components/image/loading.ts
@@ -6,7 +6,7 @@ export default function App() {
       width={300}
       height={200}
       alt="NextUI hero Image with delay"
-      src="https://app.requestly.io/delay/5000/https://nextui-docs-v2.vercel.app/images/hero-card-complete.jpeg"
+      src="https://app.requestly.io/delay/5000/https://nextui.org/images/hero-card-complete.jpeg"
     />
   );
 }`;

--- a/apps/docs/content/components/image/nextjs.ts
+++ b/apps/docs/content/components/image/nextjs.ts
@@ -7,7 +7,7 @@ export default function App() {
       as={NextImage}
       width={300}
       height={200}
-      src="https://nextui-docs-v2.vercel.app/images/hero-card-complete.jpeg"
+      src="https://nextui.org/images/hero-card-complete.jpeg"
       alt="NextUI hero Image"
     />
   );

--- a/apps/docs/content/components/image/usage.ts
+++ b/apps/docs/content/components/image/usage.ts
@@ -5,7 +5,7 @@ export default function App() {
     <Image
       width={300}
       alt="NextUI hero Image"
-      src="https://nextui-docs-v2.vercel.app/images/hero-card-complete.jpeg"
+      src="https://nextui.org/images/hero-card-complete.jpeg"
     />
   );
 }`;

--- a/apps/docs/content/components/image/zoomed.ts
+++ b/apps/docs/content/components/image/zoomed.ts
@@ -6,7 +6,7 @@ export default function App() {
       isZoomed
       width={240}
       alt="NextUI Fruit Image with Zoom"
-      src="https://nextui-docs-v2.vercel.app/images/fruit-1.jpeg"
+      src="https://nextui.org/images/fruit-1.jpeg"
     />
   );
 }`;

--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -526,7 +526,7 @@ describe("Dropdown", () => {
         <DropdownTrigger>
           <Image
             alt="NextUI hero Image"
-            src="https://nextui-docs-v2.vercel.app/images/hero-card-complete.jpeg"
+            src="https://nextui.org/images/hero-card-complete.jpeg"
             width={300}
           />
         </DropdownTrigger>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

due to the domain migration, some outdated image paths failed. 

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/3c006e57-f507-4b81-a216-a6df518934a9)

## 🚀 New behavior

<img width="489" alt="image" src="https://github.com/user-attachments/assets/3e1096d5-9c97-4585-8e49-eef0d218ec73">

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation links to point to the new `nextui.org` domain.
	- Changed image sources in the documentation to reflect the new URLs.

- **Tests**
	- Added comprehensive tests for the `Dropdown` component, covering rendering, interactions, keyboard navigation, and accessibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->