### PR TITLE
fix(autocomplete): exit animation on popover close

### DIFF
--- a/.changeset/mighty-birds-deny.md
+++ b/.changeset/mighty-birds-deny.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+Return null if there are items for exit animation on popover close to work

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -31,13 +31,15 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
     getEndContentWrapperProps,
   } = useAutocomplete<T>({...props, ref});
 
+  const listboxProps = getListBoxProps();
+
   const popoverContent = isOpen ? (
     <FreeSoloPopover {...getPopoverProps()}>
       <ScrollShadow {...getListBoxWrapperProps()}>
-        <Listbox {...getListBoxProps()} />
+        <Listbox {...listboxProps} />
       </ScrollShadow>
     </FreeSoloPopover>
-  ) : getListBoxProps().state?.collection.size === 0 ? (
+  ) : listboxProps.state?.collection.size === 0 ? (
     <div {...getEmptyPopoverProps()} />
   ) : null;
 

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -37,9 +37,9 @@ function Autocomplete<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLI
         <Listbox {...getListBoxProps()} />
       </ScrollShadow>
     </FreeSoloPopover>
-  ) : (
+  ) : getListBoxProps().state?.collection.size === 0 ? (
     <div {...getEmptyPopoverProps()} />
-  );
+  ) : null;
 
   return (
     <Component {...getBaseProps()}>


### PR DESCRIPTION
## 📝 Description

The div when the popover is closed interferes with the exit animation, so this checks for number of items - if there are any items, use `null` (similar to Select). Otherwise if there are no items, keep default behaviour of rendering an empty hidden div.

In relation to: https://github.com/nextui-org/nextui/pull/2674

## ⛳️ Current behavior (updates)

Autocomplete on close doesn't animate.

https://github.com/user-attachments/assets/2687f01d-beb7-45e3-b3b3-8971a80bf094

## 🚀 New behavior

Autocomplete on close animates.

https://github.com/user-attachments/assets/98ea5b4c-5306-4e73-84ed-59c8e51faf65

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Tried with/without `allowsCustomValue=true` and with/without `AutocompleteItem`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved exit animation handling for the popover component in the autocomplete functionality.
	- Enhanced rendering logic for the popover to display an empty state when there are no items.

- **Bug Fixes**
	- Fixed issues with popover behavior when closing with items present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->