### PR TITLE
fix(select): label placement discrepancy in Select

### DIFF
--- a/.changeset/dull-bags-divide.md
+++ b/.changeset/dull-bags-divide.md
@@ -2,4 +2,4 @@
 "@nextui-org/select": patch
 ---
 
-The PR updates label placement in select components to use shouldLabelBeOutside instead of isOutsideLeft, resolving multiline label placement issues (#3841).
+update label placement in Select to use `shouldLabelBeOutside` instead of `isOutsideLeft`, resolving multiline label placement issues (#3841).

--- a/.changeset/dull-bags-divide.md
+++ b/.changeset/dull-bags-divide.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+The PR makes changes to use the label placement in select according to the shouldLabelBeOutside rather than isOutsideLeft. This resolves the label placement issues in case of multiline.(fixes issue: #3841)

--- a/.changeset/dull-bags-divide.md
+++ b/.changeset/dull-bags-divide.md
@@ -2,4 +2,4 @@
 "@nextui-org/select": patch
 ---
 
-The PR makes changes to use the label placement in select according to the shouldLabelBeOutside rather than isOutsideLeft. This resolves the label placement issues in case of multiline.(fixes issue: #3841)
+The PR updates label placement in select components to use shouldLabelBeOutside instead of isOutsideLeft, resolving multiline label placement issues (#3841).

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -720,6 +720,63 @@ describe("Select", () => {
       expect(onChange).toBeCalledTimes(1);
     });
   });
+
+  it("should place the label outside when labelPlacement is outside", async () => {
+    const labelContent = "Favorite Animal Label";
+
+    render(
+      <Select
+        aria-label="Favorite Animal"
+        data-testid="select"
+        label={labelContent}
+        labelPlacement="outside"
+        placeholder="placeholder"
+      >
+        <SelectItem key="penguin" value="penguin">
+          Penguin
+        </SelectItem>
+        <SelectItem key="zebra" value="zebra">
+          Zebra
+        </SelectItem>
+        <SelectItem key="shark" value="shark">
+          Shark
+        </SelectItem>
+      </Select>,
+    );
+
+    const base = document.querySelector("[data-slot=base]");
+    const trigger = document.querySelector("[data-slot=trigger]");
+
+    expect(base).toHaveTextContent(labelContent);
+    expect(trigger).not.toHaveTextContent(labelContent);
+  });
+
+  it("should place the label inside when labelPlacement prop is not passed", async () => {
+    const labelContent = "Favorite Animal Label";
+
+    render(
+      <Select
+        aria-label="Favorite Animal"
+        data-testid="select"
+        label={labelContent}
+        placeholder="placeholder"
+      >
+        <SelectItem key="penguin" value="penguin">
+          Penguin
+        </SelectItem>
+        <SelectItem key="zebra" value="zebra">
+          Zebra
+        </SelectItem>
+        <SelectItem key="shark" value="shark">
+          Shark
+        </SelectItem>
+      </Select>,
+    );
+
+    const trigger = document.querySelector("[data-slot=trigger]");
+
+    expect(trigger).toHaveTextContent(labelContent);
+  });
 });
 
 describe("Select with React Hook Form", () => {

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -721,7 +721,7 @@ describe("Select", () => {
     });
   });
 
-  it("should place the label outside when labelPlacement is outside", async () => {
+  it("should place the label outside when labelPlacement is outside", () => {
     const labelContent = "Favorite Animal Label";
 
     render(
@@ -751,7 +751,7 @@ describe("Select", () => {
     expect(trigger).not.toHaveTextContent(labelContent);
   });
 
-  it("should place the label inside when labelPlacement prop is not passed", async () => {
+  it("should place the label inside when labelPlacement prop is not passed", () => {
     const labelContent = "Favorite Animal Label";
 
     render(

--- a/packages/components/select/src/select.tsx
+++ b/packages/components/select/src/select.tsx
@@ -29,7 +29,7 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
     endContent,
     placeholder,
     renderValue,
-    isOutsideLeft,
+    shouldLabelBeOutside,
     disableAnimation,
     getBaseProps,
     getLabelProps,
@@ -117,10 +117,10 @@ function Select<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLSelectE
   return (
     <div {...getBaseProps()}>
       <HiddenSelect {...getHiddenSelectProps()} />
-      {isOutsideLeft ? labelContent : null}
+      {shouldLabelBeOutside ? labelContent : null}
       <div {...getMainWrapperProps()}>
         <Component {...getTriggerProps()}>
-          {!isOutsideLeft ? labelContent : null}
+          {!shouldLabelBeOutside ? labelContent : null}
           <div {...getInnerWrapperProps()}>
             {startContent}
             <span {...getValueProps()}>{renderSelectedItem}</span>


### PR DESCRIPTION
Closes #3841 

#### 📝 Description

The PR makes changes to use the label placement in select according to the shouldLabelBeOutside rather than isOutsideLeft. This resolves the label placement issues in case of multiline.

#### ⛳️ Current behavior (updates)

Label is not placed outside when the multiline is true.
Eg. for the below code sample:
```
<Select
    labelPlacement={"outside"}
    label="User Properties"
    placeholder="Select properties"
    className="w-full"
    variant="bordered"
    selectedKeys={selection}
    items={properties}
    isMultiline={true}
>
    {properties.map((prop) => (
        <SelectItem key={prop} value={prop}>
            {prop}
        </SelectItem>
    ))}
</Select>
```
The output is follows:
<img width="642" alt="Screenshot 2024-10-07 at 12 21 54 PM" src="https://github.com/user-attachments/assets/b76a99dd-ee0e-4005-912b-74b037bdac33">

#### 🚀 New behavior

After the changes in the PR, the same code above appears as follows:
<img width="642" alt="Screenshot 2024-10-07 at 12 28 12 PM" src="https://github.com/user-attachments/assets/13122b27-7760-4f52-99b3-81013ca78a1b">

### Additional Details
There shouldn't be any side effect to this as it targets only the following variant: 
```
{
      labelPlacement: "outside",
      isMultiline: true,
      class: {
        label: "pb-1.5",
      },
    },
```
Again, just for sanity check. Some tests are made as follows:
* When labelPlacement is outside-left and multiline is true:
<img width="642" alt="Screenshot 2024-10-07 at 12 31 14 PM" src="https://github.com/user-attachments/assets/22eb4b18-0737-407e-9faf-c990312fc477">

* When labelPlacement is inside multiline is true:
<img width="642" alt="Screenshot 2024-10-07 at 12 31 37 PM" src="https://github.com/user-attachments/assets/34441c12-d123-4afe-bfce-a9009b8ed8fe">

* When labelPlacement is outside multiline is false:
<img width="642" alt="Screenshot 2024-10-07 at 12 37 16 PM" src="https://github.com/user-attachments/assets/3b8d13dc-529b-4533-8c8f-309af04cdfee">

* When labelPlacement is outside-left multiline is false:
<img width="642" alt="Screenshot 2024-10-07 at 12 37 27 PM" src="https://github.com/user-attachments/assets/25820063-95a5-4009-b262-20091df45f1c">

* When labelPlacement is inside multiline is false:
<img width="642" alt="Screenshot 2024-10-07 at 12 37 03 PM" src="https://github.com/user-attachments/assets/ca98ae43-b4c0-4026-b085-2ed8e60d0ba5">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved label placement logic in the select component for better handling of multiline scenarios.
  
- **Bug Fixes**
	- Resolved issues related to label placement, enhancing usability and accessibility.

- **Documentation**
	- Updated property name from `isOutsideLeft` to `shouldLabelBeOutside` for clarity in the select component's props interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->