### PR TITLE
fix(docs): avoid translating the code block

### DIFF
--- a/apps/docs/components/docs/components/codeblock.tsx
+++ b/apps/docs/components/docs/components/codeblock.tsx
@@ -144,13 +144,13 @@ const Codeblock = forwardRef<HTMLPreElement, CodeblockProps>(
         {({className, style, tokens, getLineProps, getTokenProps}) => (
           <div className="w-full" data-language={language}>
             <pre
-              translate="no"
               ref={ref}
               className={clsx(className, classNameProp, "flex max-w-full", {
                 "flex-col": isMultiLine,
                 "scrollbar-hide overflow-x-scroll": hideScrollBar,
               })}
               style={style}
+              translate="no"
             >
               {tokens.map((line, i) => {
                 const lineProps = getLineProps({line, key: i});

--- a/apps/docs/components/docs/components/codeblock.tsx
+++ b/apps/docs/components/docs/components/codeblock.tsx
@@ -144,6 +144,7 @@ const Codeblock = forwardRef<HTMLPreElement, CodeblockProps>(
         {({className, style, tokens, getLineProps, getTokenProps}) => (
           <div className="w-full" data-language={language}>
             <pre
+              translate="no"
               ref={ref}
               className={clsx(className, classNameProp, "flex max-w-full", {
                 "flex-col": isMultiLine,


### PR DESCRIPTION
## 📝 Description

When using  a translation extension to translate the website, the translation extension can mistakenly translate code snippets as well, which should be a bug.

## ⛳️ Current behavior (updates)

When using Google Translate to translate from English to Chinese:

![image](https://github.com/user-attachments/assets/89faaefe-5382-42b6-8a81-cb343e672e09)


## 🚀 New behavior

![image](https://github.com/user-attachments/assets/bafaa3f1-c505-4a82-8588-dcc889b85f13)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Reference: [How to disable google translate from HTML in Chrome - StackOverflow](https://stackoverflow.com/questions/12238396/how-to-disable-google-translate-from-html-in-chrome)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a `translate` attribute to the `Codeblock` component to prevent browser translation of code content, enhancing accessibility and presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->