### PR TITLE
fix(listbox): change listBoxItem key to optional

### DIFF
--- a/.changeset/curly-zoos-thank.md
+++ b/.changeset/curly-zoos-thank.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/listbox": patch
+---
+
+change ListboxItem key to optional (#3880)

--- a/packages/components/listbox/src/base/listbox-item-base.tsx
+++ b/packages/components/listbox/src/base/listbox-item-base.tsx
@@ -91,7 +91,7 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"li", T>, "childre
 
 export type ListboxItemBaseProps<T extends object = {}> = Props<T> &
   ListboxItemVariantProps &
-  AriaOptionProps &
+  Omit<AriaOptionProps, "key"> &
   FocusableProps &
   PressEvents;
 

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -350,6 +350,56 @@ describe("Select", () => {
     });
   });
 
+  it("should pre-select items based on defaultSelectedKeys (numeric keys)", () => {
+    const items = [
+      {key: 1, value: "Penguin"},
+      {key: 2, value: "Zebra"},
+      {key: 3, value: "Shark"},
+    ];
+
+    const wrapper = render(
+      <Select
+        isOpen
+        defaultSelectedKeys={[1, 2]} // Numeric keys for selection
+        items={items}
+        label="Test Default Selected Keys"
+        selectionMode="multiple"
+      >
+        {(item) => <SelectItem>{item.value}</SelectItem>}
+      </Select>,
+    );
+
+    const selectedOptions = wrapper.getAllByRole("option", {selected: true});
+
+    expect(selectedOptions.length).toBe(2);
+    expect(selectedOptions.map((opt) => opt.textContent)).toEqual(["Penguin", "Zebra"]);
+  });
+
+  it("should pre-select items based on defaultSelectedKeys (numeric ids)", () => {
+    const items = [
+      {id: 1, value: "Penguin"},
+      {id: 2, value: "Zebra"},
+      {id: 3, value: "Shark"},
+    ];
+
+    const wrapper = render(
+      <Select
+        isOpen
+        defaultSelectedKeys={[1, 2]} // Numeric ids for selection
+        items={items}
+        label="Test Default Selected IDs"
+        selectionMode="multiple"
+      >
+        {(item) => <SelectItem>{item.value}</SelectItem>}
+      </Select>,
+    );
+
+    const selectedOptions = wrapper.getAllByRole("option", {selected: true});
+
+    expect(selectedOptions.length).toBe(2);
+    expect(selectedOptions.map((opt) => opt.textContent)).toEqual(["Penguin", "Zebra"]);
+  });
+
   it("onSelectionChange should be called with a Set of item ids upon selection", async () => {
     const itemsWithId = [
       {id: 1, value: "penguin"},

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -352,9 +352,9 @@ describe("Select", () => {
 
   it("onSelectionChange should be called with a Set of item ids upon selection", async () => {
     const itemsWithId = [
-      {id: "1", value: "penguin"},
-      {id: "2", value: "zebra"},
-      {id: "3", value: "shark"},
+      {id: 1, value: "penguin"},
+      {id: 2, value: "zebra"},
+      {id: 3, value: "shark"},
     ];
 
     const onSelectionChangeId = jest.fn();
@@ -365,7 +365,7 @@ describe("Select", () => {
         label="Test with ID"
         onSelectionChange={onSelectionChangeId}
       >
-        {(item) => <SelectItem key={item.id}>{item.value}</SelectItem>}
+        {(item) => <SelectItem>{item.value}</SelectItem>}
       </Select>,
     );
 
@@ -392,9 +392,9 @@ describe("Select", () => {
 
   it("onSelectionChange should be called with a Set of item keys upon selection", async () => {
     const itemsWithKey = [
-      {key: "1", value: "penguin"},
-      {key: "2", value: "zebra"},
-      {key: "3", value: "shark"},
+      {key: 1, value: "penguin"},
+      {key: 2, value: "zebra"},
+      {key: 3, value: "shark"},
     ];
 
     const onSelectionChangeKey = jest.fn();
@@ -405,7 +405,7 @@ describe("Select", () => {
         label="Test with Key"
         onSelectionChange={onSelectionChangeKey}
       >
-        {(item) => <SelectItem key={item.key}>{item.value}</SelectItem>}
+        {(item) => <SelectItem>{item.value}</SelectItem>}
       </Select>,
     );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes https://github.com/nextui-org/nextui/issues/3880

## 📝 Description

In `SelectBox` and other collections, when `items` include `id` or `key`, these values are treated as the component's `key`.
This allows numeric values to remain as numbers. However, using `key` directly in the component (e.g, `<SelectItem key={1} />`) results in the value being converted to a string.

This PR makes `key` optional since `id` from the item object can be used directly.

Reference: [ListBox – React Aria](https://react-spectrum.adobe.com/react-aria/ListBox.html#content)

## ⛳️ Current behavior (updates)

`key` is required and always converted to a string.

## 🚀 New behavior

`key` is now optional.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Select` component with improved pre-selection functionality based on numeric keys and IDs.
  
- **Bug Fixes**
	- Updated tests to ensure correct initialization and selection behavior in the `Select` component.

- **Tests**
	- Added new test cases for the `Select` component to improve functionality and coverage.
	- Adjusted existing tests to accommodate changes in identifier types for item selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->