### PR TITLE
fix: onOpenChange triggering when modal opens

### DIFF
--- a/.changeset/early-ghosts-fix.md
+++ b/.changeset/early-ghosts-fix.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/modal": minor
+"@nextui-org/use-disclosure": minor
+---
+
+Added useEffect in useModal to fire onOpenChange when onOpen changes to true.
+In useDisclosure, onOpenChange now depends on arg onOpen, than state(onOpen).

--- a/packages/components/modal/src/use-modal.ts
+++ b/packages/components/modal/src/use-modal.ts
@@ -3,7 +3,7 @@ import type {HTMLMotionProps} from "framer-motion";
 
 import {AriaModalOverlayProps} from "@react-aria/overlays";
 import {useAriaModalOverlay} from "@nextui-org/use-aria-modal-overlay";
-import {useCallback, useId, useRef, useState, useMemo, ReactNode} from "react";
+import {useCallback, useId, useRef, useState, useMemo, ReactNode, useEffect} from "react";
 import {modal} from "@nextui-org/theme";
 import {
   HTMLNextUIProps,
@@ -128,6 +128,12 @@ export function useModal(originalProps: UseModalProps) {
       }
     },
   });
+
+  useEffect(() => {
+    if (isOpen) {
+      onOpenChange?.(isOpen);
+    }
+  }, [isOpen]);
 
   const {modalProps, underlayProps} = useAriaModalOverlay(
     {

--- a/packages/hooks/use-disclosure/src/index.ts
+++ b/packages/hooks/use-disclosure/src/index.ts
@@ -44,11 +44,14 @@ export function useDisclosure(props: UseDisclosureProps = {}) {
     onOpenPropCallbackRef?.();
   }, [isControlled, onOpenPropCallbackRef]);
 
-  const onOpenChange = useCallback(() => {
-    const action = isOpen ? onClose : onOpen;
+  const onOpenChange = useCallback(
+    (isOpen: boolean) => {
+      const action = isOpen ? onOpen : onClose;
 
-    action();
-  }, [isOpen, onOpen, onClose]);
+      action();
+    },
+    [isOpen, onOpen, onClose],
+  );
 
   return {
     isOpen: !!isOpen,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3887 <!-- Github issue # here -->

## 📝 Description
The changes in this PR makes the onOpenChange fire when modal opens, making it consistent.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

- onOpenChange fires only when modal closes and not when it opens.
- onOpenChange in useDisclosure decides which action to fire on isOpen state.

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

- onOpenChange fires on both states consistently.
- Added useEffect, so when isOpen changes to true, onOpenChange is called.
- onOpenChange in useDisclosure decides which action to fire on basis of isOpen argument, used to do isOpen state earlier.

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
- onClose function in modal is basically coming from useOuterlayTriggerState, but onOpen is just a normal function. Thats why we need that useEffect to fire onOpenChange explicitly.
- Make sure to pass the isOpen variable when you are wrapping onOpenChange inside a function. Like this onOpenChange(isOpen).