### PR TITLE
fix(theme): apply tw nested group

### DIFF
--- a/.changeset/happy-parrots-search.md
+++ b/.changeset/happy-parrots-search.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+apply tw nested group (#3544, #2324, #2959)

--- a/apps/docs/content/components/table/custom-styles.ts
+++ b/apps/docs/content/components/table/custom-styles.ts
@@ -611,13 +611,13 @@ export default function App() {
       td: [
         // changing the rows border radius
         // first
-        "group-data-[first=true]:first:before:rounded-none",
-        "group-data-[first=true]:last:before:rounded-none",
+        "group-data-[first=true]/tr:first:before:rounded-none",
+        "group-data-[first=true]/tr:last:before:rounded-none",
         // middle
-        "group-data-[middle=true]:before:rounded-none",
+        "group-data-[middle=true]/tr:before:rounded-none",
         // last
-        "group-data-[last=true]:first:before:rounded-none",
-        "group-data-[last=true]:last:before:rounded-none",
+        "group-data-[last=true]/tr:first:before:rounded-none",
+        "group-data-[last=true]/tr:last:before:rounded-none",
       ],
     }),
     [],
@@ -966,13 +966,13 @@ export default function App() {
       td: [
         // changing the rows border radius
         // first
-        "group-data-[first=true]:first:before:rounded-none",
-        "group-data-[first=true]:last:before:rounded-none",
+        "group-data-[first=true]/tr:first:before:rounded-none",
+        "group-data-[first=true]/tr:last:before:rounded-none",
         // middle
-        "group-data-[middle=true]:before:rounded-none",
+        "group-data-[middle=true]/tr:before:rounded-none",
         // last
-        "group-data-[last=true]:first:before:rounded-none",
-        "group-data-[last=true]:last:before:rounded-none",
+        "group-data-[last=true]/tr:first:before:rounded-none",
+        "group-data-[last=true]/tr:last:before:rounded-none",
       ],
     }),
     [],

--- a/packages/core/theme/src/components/table.ts
+++ b/packages/core/theme/src/components/table.ts
@@ -56,9 +56,9 @@ const table = tv({
     table: "min-w-full h-auto",
     thead: "[&>tr]:first:rounded-lg",
     tbody: "",
-    tr: ["group", "outline-none", ...dataFocusVisibleClasses],
+    tr: ["group/tr", "outline-none", ...dataFocusVisibleClasses],
     th: [
-      "group",
+      "group/th",
       "px-3",
       "h-10",
       "text-start",
@@ -95,8 +95,8 @@ const table = tv({
       "before:opacity-0",
       "data-[selected=true]:before:opacity-100",
       // disabled
-      "group-data-[disabled=true]:text-foreground-300",
-      "group-data-[disabled=true]:cursor-not-allowed",
+      "group-data-[disabled=true]/tr:text-foreground-300",
+      "group-data-[disabled=true]/tr:cursor-not-allowed",
     ],
     tfoot: "",
     sortIcon: [
@@ -107,7 +107,7 @@ const table = tv({
       "inline-block",
       "transition-transform-opacity",
       "data-[visible=true]:opacity-100",
-      "group-data-[hover=true]:opacity-100",
+      "group-data-[hover=true]/th:opacity-100",
       "data-[direction=ascending]:rotate-180",
     ],
     emptyWrapper: "text-foreground-400 align-middle text-center h-40",
@@ -178,9 +178,9 @@ const table = tv({
     isStriped: {
       true: {
         td: [
-          "group-data-[odd=true]:before:bg-default-100",
-          "group-data-[odd=true]:before:opacity-100",
-          "group-data-[odd=true]:before:-z-10",
+          "group-data-[odd=true]/tr:before:bg-default-100",
+          "group-data-[odd=true]/tr:before:opacity-100",
+          "group-data-[odd=true]/tr:before:-z-10",
         ],
       },
     },
@@ -199,8 +199,8 @@ const table = tv({
       true: {
         tr: "cursor-default",
         td: [
-          "group-aria-[selected=false]:group-data-[hover=true]:before:bg-default-100",
-          "group-aria-[selected=false]:group-data-[hover=true]:before:opacity-70",
+          "group-aria-[selected=false]/tr:group-data-[hover=true]/tr:before:bg-default-100",
+          "group-aria-[selected=false]/tr:group-data-[hover=true]/tr:before:opacity-70",
         ],
       },
     },
@@ -208,13 +208,13 @@ const table = tv({
       true: {
         td: [
           // first
-          "group-data-[first=true]:first:before:rounded-ts-lg",
-          "group-data-[first=true]:last:before:rounded-te-lg",
+          "group-data-[first=true]/tr:first:before:rounded-ts-lg",
+          "group-data-[first=true]/tr:last:before:rounded-te-lg",
           // middle
-          "group-data-[middle=true]:before:rounded-none",
+          "group-data-[middle=true]/tr:before:rounded-none",
           // last
-          "group-data-[last=true]:first:before:rounded-bs-lg",
-          "group-data-[last=true]:last:before:rounded-be-lg",
+          "group-data-[last=true]/tr:first:before:rounded-bs-lg",
+          "group-data-[last=true]/tr:last:before:rounded-be-lg",
         ],
       },
       false: {
@@ -259,42 +259,42 @@ const table = tv({
       isStriped: true,
       color: "default",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-default/60",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-default/60",
       },
     },
     {
       isStriped: true,
       color: "primary",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-primary/20",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-primary/20",
       },
     },
     {
       isStriped: true,
       color: "secondary",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-secondary/20",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-secondary/20",
       },
     },
     {
       isStriped: true,
       color: "success",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-success/20",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-success/20",
       },
     },
     {
       isStriped: true,
       color: "warning",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-warning/20",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-warning/20",
       },
     },
     {
       isStriped: true,
       color: "danger",
       class: {
-        td: "group-data-[odd=true]:data-[selected=true]:before:bg-danger/20",
+        td: "group-data-[odd=true]/tr:data-[selected=true]/tr:before:bg-danger/20",
       },
     },
   ],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- closes #3544
- closes #2324
- closes #2959

## 📝 Description

<!--- Add a brief description -->

Applied nested group to components so that styles from other components won't mess up with others. 

## ⛳️ Current behavior (updates)

let's say there is a switch component inside a table row with select button. clicking select button would also toggle the switch. The reason is that when we click select, `data-selected` for select will be set to `true`. However, all `group-data-[selected=true]:*` in switch component will be applied as well since all components share the same parent `group`.

original PR: https://github.com/nextui-org/nextui/pull/3658. rollback due to breaking changes and not all components are required to apply.

[pr3909-before-demo.webm](https://github.com/user-attachments/assets/6d3af46d-f287-4c4a-9881-f322e49c1d15)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

[pr3909-after-demo.webm](https://github.com/user-attachments/assets/083b872e-8d65-4f80-97f4-d8257daa926f)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

Yes. Users need to add `/tr` or `/th` to custom styles for table.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a nested group feature for enhanced Tailwind CSS styling.
	- Improved styling capabilities for table components with updated class names.

- **Bug Fixes**
	- Enhanced specificity in table row styling to ensure correct visual representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->