### PR TITLE
fix(theme): removed pseudo cancel btn from input

### DIFF
--- a/.changeset/forty-doors-flash.md
+++ b/.changeset/forty-doors-flash.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-Removed the pseudo cancel btn from input(#3907)
+remove the pseudo cancel btn from input (#3907)

--- a/.changeset/forty-doors-flash.md
+++ b/.changeset/forty-doors-flash.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+Removed the pseudo cancel btn from input(#3907)

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -46,6 +46,7 @@ const input = tv({
       "data-[has-end-content=true]:pe-1.5",
       "file:cursor-pointer file:bg-transparent file:border-0",
       "autofill:bg-transparent bg-clip-text",
+      "input-search-cancel-button-none",
     ],
     clearButton: [
       "p-2",

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -46,7 +46,6 @@ const input = tv({
       "data-[has-end-content=true]:pe-1.5",
       "file:cursor-pointer file:bg-transparent file:border-0",
       "autofill:bg-transparent bg-clip-text",
-      "input-search-cancel-button-none",
     ],
     clearButton: [
       "p-2",
@@ -191,7 +190,7 @@ const input = tv({
     },
     isClearable: {
       true: {
-        input: "peer pe-6",
+        input: "peer pe-6 input-search-cancel-button-none",
         clearButton: "peer-data-[filled=true]:opacity-70 peer-data-[filled=true]:block",
       },
     },

--- a/packages/core/theme/src/utilities/custom.ts
+++ b/packages/core/theme/src/utilities/custom.ts
@@ -17,4 +17,9 @@ export default {
   ".tap-highlight-transparent": {
     "-webkit-tap-highlight-color": "transparent",
   },
+  ".input-search-cancel-button-none": {
+    "&::-webkit-search-cancel-button": {
+      "-webkit-appearance": "none",
+    },
+  },
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #3907 <!-- Github issue # here -->

## 📝 Description
Pseudo Cancel Button used to come with input element in chrome unintentionally when the input type is search.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)
Pseudo Cancel Button comes with input element in chrome when the type is search.
![Screenshot from 2024-10-18 04-38-40](https://github.com/user-attachments/assets/f3264c17-b599-4b22-b03a-fe8ee479ba9b)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior
Removed the cancel button which was unintentional.
![Screenshot from 2024-10-18 04-41-06](https://github.com/user-attachments/assets/6756ccf0-99cc-469d-8573-965ac629599e)

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):
No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Removed the pseudo cancel button from input components for a cleaner appearance.

- **Bug Fixes**
	- Addressed the issue of the pseudo cancel button display in input components as noted in issue #3907.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->