### PR TITLE
fix(theme): support RTL for breadcrumbs

### DIFF
--- a/.changeset/quick-geckos-punch.md
+++ b/.changeset/quick-geckos-punch.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+separator icon RTL support in Breadcrumbs component (#2486)

--- a/packages/core/theme/src/components/breadcrumbs.ts
+++ b/packages/core/theme/src/components/breadcrumbs.ts
@@ -23,7 +23,7 @@ const breadcrumbItem = tv({
       // focus ring
       ...dataFocusVisibleClasses,
     ],
-    separator: "text-default-400 px-1",
+    separator: "text-default-400 px-1 rtl:rotate-180",
   },
   variants: {
     color: {


### PR DESCRIPTION
Closes #2486

## 📝 Description
Added rotation for separator icon in RTL layout.

## ⛳️ Current behavior (updates)
![image](https://github.com/user-attachments/assets/68a11480-a582-457b-8d0a-0f0fa28ad591)


## 🚀 New behavior
![image](https://github.com/user-attachments/assets/c848b398-a338-47d2-ad48-987a062fc462)


## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced breadcrumb component with right-to-left language support for improved visual representation.
- **Bug Fixes**
	- Adjusted separator styling to accommodate right-to-left text direction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->