### PR TITLE
fix: avatar filter disableAnimation to dom prop

### DIFF
--- a/packages/components/avatar/src/use-avatar.ts
+++ b/packages/components/avatar/src/use-avatar.ts
@@ -124,6 +124,7 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
     imgProps,
     className,
     onError,
+    disableAnimation: disableAnimationProp,
     ...otherProps
   } = originalProps;
 
@@ -134,8 +135,7 @@ export function useAvatar(originalProps: UseAvatarProps = {}) {
 
   const {isFocusVisible, isFocused, focusProps} = useFocusRing();
   const {isHovered, hoverProps} = useHover({isDisabled});
-  const disableAnimation =
-    originalProps.disableAnimation ?? globalContext?.disableAnimation ?? false;
+  const disableAnimation = disableAnimationProp ?? globalContext?.disableAnimation ?? false;
 
   const imageStatus = useImage({src, onError, ignoreFallback});
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

![Google Chrome 2024-10-26 22 06 27](https://github.com/user-attachments/assets/6706e3cb-341a-457a-bf17-4331c0f32083)

`otherProps` has invaild dom property `disableAnimation`

![Cursor 2024-10-26 22 06 50](https://github.com/user-attachments/assets/bf48f263-2727-473f-a375-4163354f85ed)

![image](https://github.com/user-attachments/assets/f9d58a45-57f0-4852-8f76-d9ed589fb197)

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `useAvatar` functionality by allowing users to disable animations through a new property.
  
- **Improvements**
  - Improved clarity in how the `disableAnimation` property is handled, making it easier for users to override settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->