### PR TITLE
fix(tabs): corrected inert value for true condition

### DIFF
--- a/.changeset/twelve-papayas-clean.md
+++ b/.changeset/twelve-papayas-clean.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/tabs": patch
+---
+
+revise the inert attribute in `TabPanel` (#3972)

--- a/packages/components/tabs/src/tab-panel.tsx
+++ b/packages/components/tabs/src/tab-panel.tsx
@@ -69,7 +69,10 @@ const TabPanel = forwardRef<"div", TabPanelProps>((props, ref) => {
       data-focus={isFocused}
       data-focus-visible={isFocusVisible}
       data-inert={!isSelected ? "true" : undefined}
-      inert={!isSelected ? "true" : undefined}
+      // makes the browser ignore the element and its children when tabbing
+      // TODO: invert inert when switching to React 19 (ref: https://github.com/facebook/react/issues/17157)
+      // @ts-ignore
+      inert={!isSelected ? "" : undefined}
       {...(isSelected && mergeProps(tabPanelProps, focusProps, otherProps))}
       className={slots.panel?.({class: tabPanelStyles})}
       data-slot="panel"


### PR DESCRIPTION
Closes #3972 

## 📝 Description

- The value of inert is set to true when `inert=""` and to false when `inert=undefined`. A similar fix was done in `Calendar` #3054 .
- `inert` was added to tabs in this pr #2973 

## ⛳️ Current behavior (updates)

`inert={!isSelected ? "true" : undefined}`

## 🚀 New behavior

`inert={!isSelected ? "" : undefined}`

## 💣 Is this a breaking change (Yes/No):


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accessibility of the `TabPanel` component by modifying the handling of the `inert` attribute, enhancing user experience during tab navigation.
- **Bug Fixes**
	- Addressed issues related to the visibility and focus management of tab panel content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->