### PR TITLE
fix(docs): yarn global command in installation page

### DIFF
--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -26,7 +26,7 @@ Execute one of the following commands in your terminal:
 <PackageManagers
   commands={{
     npm: "npm install -g nextui-cli",
-    yarn: "yarn add -g nextui-cli",
+    yarn: "yarn add global nextui-cli",
     pnpm: "pnpm add -g nextui-cli",
     bun: "bun add -g nextui-cli",
   }}


### PR DESCRIPTION
### Docs update:
Update yarn command to install nextui-cli because `yarn add -g <package>` doesnt work and needs to use `yarn add global <package>`

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

Modify the yarn installation script to not throw error

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

New script doesn't throws error with the latest version of yarn installed

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

No.

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for NextUI, including a revised Yarn command for global installation.
	- Enhanced clarity in both automatic and manual installation sections, with detailed commands for various package managers.
	- Added notes on Tailwind CSS setup and compatibility of NextUI version 2 with React 18 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->