### PR TITLE
feat(calendar): add CalendarPickerItem with auto-collapse on select

### DIFF
--- a/packages/components/calendar/src/calendar-picker-item.tsx
+++ b/packages/components/calendar/src/calendar-picker-item.tsx
@@ -9,6 +9,8 @@ import {useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {dataAttr} from "@nextui-org/shared-utils";
 import {mergeProps} from "@react-aria/utils";
 
+import {useCalendarContext} from "./calendar-context";
+
 const CalendarPickerItem = forwardRef<
   HTMLButtonElement,
   HTMLNextUIProps<"button"> & AriaButtonProps
@@ -24,6 +26,8 @@ const CalendarPickerItem = forwardRef<
     } as AriaButtonProps,
     domRef,
   );
+
+  const {setIsHeaderExpanded} = useCalendarContext();
 
   const {isFocusVisible, isFocused, focusProps} = useFocusRing({
     autoFocus,
@@ -46,6 +50,11 @@ const CalendarPickerItem = forwardRef<
         ariaButtonProps,
         filterDOMProps(otherProps, {enabled: true}),
       )}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsHeaderExpanded?.(false);
+      }}
     >
       {children}
     </button>


### PR DESCRIPTION
#4002 

## 📝 Description

This pull request introduces an auto-collapse behavior to the CalendarPickerItem component within the DatePicker functionality. The new feature automatically collapses the header after a user selects either a month or year, streamlining the date selection process by reducing required user interactions.

## ⛳️ Current behavior (updates)

Currently, after selecting a year or month in the DatePicker:

The header remains expanded
Users need to manually collapse the header
Requires additional clicks to complete the date selection process

## 🚀 New behavior

With this enhancement:

Header automatically collapses after month selection
Header automatically collapses after year selection
Smoother transition between selection states
Reduced number of clicks needed to complete date selection

## 💣 Is this a breaking change (Yes/No):

No - This enhancement maintains backward compatibility while improving the user experience.

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `CalendarPickerItem` component to control the expansion state of the calendar header through user interactions.
  
- **Bug Fixes**
	- Updated button functionality to prevent default actions and event propagation, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->