### PR TITLE
fix: div-in-p issue in tooltip

### DIFF
--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -7,7 +7,7 @@ import {Children, cloneElement, isValidElement} from "react";
 import {getTransformOrigins} from "@nextui-org/aria-utils";
 import {mergeProps} from "@react-aria/utils";
 
-import {UseTooltipProps, useTooltip} from "./use-tooltip";
+import {UseTooltipProps, isLazyElement, useTooltip} from "./use-tooltip";
 
 export interface TooltipProps extends Omit<UseTooltipProps, "disableTriggerFocus" | "backdrop"> {}
 
@@ -41,8 +41,10 @@ const Tooltip = forwardRef<"div", TooltipProps>((props, ref) => {
 
     if (childrenNum !== 1) throw new Error();
 
-    if (!isValidElement(children)) {
+    if (!isValidElement(children) && !isLazyElement(children)) {
       trigger = <p {...getTriggerProps()}>{children}</p>;
+    } else if (isLazyElement(children)) {
+      trigger = <div {...getTriggerProps()}>{children}</div>;
     } else {
       const child = children as React.ReactElement & {
         ref?: React.Ref<any>;

--- a/packages/components/tooltip/src/use-tooltip.ts
+++ b/packages/components/tooltip/src/use-tooltip.ts
@@ -4,7 +4,7 @@ import type {OverlayTriggerProps} from "@react-types/overlays";
 import type {HTMLMotionProps} from "framer-motion";
 import type {OverlayOptions} from "@nextui-org/aria-utils";
 
-import {ReactNode, Ref, useId, useImperativeHandle} from "react";
+import {ReactElement, ReactNode, Ref, useId, useImperativeHandle} from "react";
 import {useTooltipTriggerState} from "@react-stately/tooltip";
 import {mergeProps} from "@react-aria/utils";
 import {useTooltip as useReactAriaTooltip, useTooltipTrigger} from "@react-aria/tooltip";
@@ -90,6 +90,8 @@ export type UseTooltipProps = Props &
   OverlayTriggerProps &
   OverlayOptions &
   PopoverVariantProps;
+
+export type LazyElement = ReactElement | ReactNode | null | undefined;
 
 export function useTooltip(originalProps: UseTooltipProps) {
   const globalContext = useProviderContext();
@@ -292,6 +294,19 @@ export function useTooltip(originalProps: UseTooltipProps) {
     getTriggerProps,
     getTooltipProps,
   };
+}
+
+export function isLazyElement(element: LazyElement): boolean {
+  if (typeof element !== "object" || element === null) {
+    return false;
+  }
+
+  // Check if it's a ReactElement and has the $$typeof property of React.lazy
+  const reactElement = element as ReactNode & {
+    $$typeof: symbol;
+  };
+
+  return reactElement.$$typeof === Symbol.for("react.lazy");
 }
 
 export type UseTooltipReturn = ReturnType<typeof useTooltip>;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

This PR adds support for using React lazy or server components inside a Tooltip component

## ⛳️ Current behavior (updates)

Currently, in Next 14 and above, passing a lazy or server component inside a tooltip results in an error.
`In HTML, <div> cannot be a descendant of <p>.
This will cause a hydration error.`
## 🚀 New behavior

A new check has been added to render lazy and server components in a div instead of a p tag to prevent hydration issues. 

## 💣 Is this a breaking change (Yes/No):
 No - This condition will only work with lazy and server components.

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `Tooltip` component to support lazy-loaded React elements.
  - Improved validation for the `children` prop to ensure it is a valid React element or a lazy element.

- **Bug Fixes**
  - Added error handling for invalid `children`, defaulting to a `<p>` element when necessary.

- **Documentation**
  - Updated type definitions and utility functions for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->