### PR TITLE
fix(docs): tabs.mdx

### DIFF
--- a/apps/docs/content/docs/components/tabs.mdx
+++ b/apps/docs/content/docs/components/tabs.mdx
@@ -169,10 +169,10 @@ function AppTabs() {
   return (
     <div className="flex flex-col gap-2">
       <Tabs selectedKey={pathname} aria-label="Tabs">
-        <Tab id="/" href="/" title="Home" />
-        <Tab id="/photos" href="/photos" title="Photos" />
-        <Tab id="/music" href="/music" title="Music" />
-        <Tab id="/videos" href="/videos" title="Videos" />
+        <Tab key="/" href="/" title="Home" />
+        <Tab key="/photos" href="/photos" title="Photos" />
+        <Tab key="/music" href="/music" title="Music" />
+        <Tab key="/videos" href="/videos" title="Videos" />
       </Tabs>
       <Routes>
         <Route path="/" element={<HomePage />} />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Updated the react router tabs using example, the `id` prop of Tab component isn't working with `selectedKey`, the working one is `key`

## ⛳️ Current behavior (updates)

Tabs docs provides an example with react router, but this example doesn't work properly, the `selectedKey` doesn't affect the component UI if no `key` prop is given

<image src="https://files.catbox.moe/cf8u8p.png"/>
## 🚀 New behavior

Tabs docs now provides a working example with react router

<image src="https://files.catbox.moe/kdklri.png"/>

## 💣 Is this a breaking change (Yes/No):

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Tabs component documentation to include a `key` prop for the `Tab` component, enhancing tab identification.
	- Expanded usage examples for integrating the Tabs component with routing libraries like Next.js and React Router.
	- Improved clarity and completeness of examples, particularly on synchronizing the selected tab with the current URL.
	- Retained existing sections on dynamic rendering, disabled tabs, and accessibility compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->