### PR TITLE
Fixed yarn installation typo

### DIFF
--- a/apps/docs/content/docs/guide/installation.mdx
+++ b/apps/docs/content/docs/guide/installation.mdx
@@ -26,7 +26,7 @@ Execute one of the following commands in your terminal:
 <PackageManagers
   commands={{
     npm: "npm install -g nextui-cli",
-    yarn: "yarn add -g nextui-cli",
+    yarn: "yarn global add nextui-cli",
     pnpm: "pnpm add -g nextui-cli",
     bun: "bun add -g nextui-cli",
   }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here --> N/A

## 📝 Description
The command `yarn add -g nextui-cli` is invalid. There is no `-g` flag in yarn. `global` is a command which must immediately follow yarn. 

Source: https://classic.yarnpkg.com/lang/en/docs/cli/global/

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->
When trying to use yarn to install `nextui-cli` using the command provided in docs, yarn will return an error.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
Updated the command in docs based on https://classic.yarnpkg.com/lang/en/docs/cli/global/

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
