### PR TITLE
refactor(docs): specify versions for date packages

### DIFF
--- a/apps/docs/content/docs/components/date-input.mdx
+++ b/apps/docs/content/docs/components/date-input.mdx
@@ -104,9 +104,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -129,9 +129,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -153,9 +153,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -177,9 +177,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -200,9 +200,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -223,9 +223,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-input.mdx
+++ b/apps/docs/content/docs/components/date-input.mdx
@@ -129,9 +129,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -177,9 +177,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-picker.mdx
+++ b/apps/docs/content/docs/components/date-picker.mdx
@@ -119,9 +119,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -144,9 +144,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -168,9 +168,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -192,9 +192,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -214,9 +214,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -246,9 +246,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-picker.mdx
+++ b/apps/docs/content/docs/components/date-picker.mdx
@@ -144,9 +144,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -192,9 +192,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -214,9 +214,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -246,9 +246,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-range-picker.mdx
+++ b/apps/docs/content/docs/components/date-range-picker.mdx
@@ -136,9 +136,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -161,9 +161,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -185,9 +185,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date",
-    yarn: "yarn add @internationalized/date",
-    pnpm: "pnpm add @internationalized/date",
+    npm: "npm install @internationalized/date@3.5.5",
+    yarn: "yarn add @internationalized/date@3.5.5",
+    pnpm: "pnpm add @internationalized/date@3.5.5",
   }}
 />
 
@@ -209,9 +209,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -231,9 +231,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -256,9 +256,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 
@@ -276,9 +276,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date @react-aria/i18n",
-    yarn: "yarn add @internationalized/date @react-aria/i18n",
-    pnpm: "pnpm add @internationalized/date @react-aria/i18n",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-range-picker.mdx
+++ b/apps/docs/content/docs/components/date-range-picker.mdx
@@ -161,9 +161,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -209,9 +209,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -231,9 +231,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -256,9 +256,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 
@@ -276,9 +276,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
-    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.11.1",
+    npm: "npm install @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    yarn: "yarn add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
+    pnpm: "pnpm add @internationalized/date@3.5.5 @react-aria/i18n@3.12.2",
   }}
 />
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -40,7 +40,7 @@
     "@nextui-org/use-is-mobile": "workspace:*",
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@react-aria/focus": "3.17.1",
-    "@react-aria/i18n": "3.11.1",
+    "@react-aria/i18n": "3.12.2",
     "@react-aria/interactions": "3.21.3",
     "@react-aria/selection": "3.18.1",
     "@react-aria/ssr": "3.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
         specifier: 3.17.1
         version: 3.17.1(react@18.3.1)
       '@react-aria/i18n':
-        specifier: 3.11.1
-        version: 3.11.1(react@18.3.1)
+        specifier: 3.12.2
+        version: 3.12.2(react@18.3.1)
       '@react-aria/interactions':
         specifier: 3.21.3
         version: 3.21.3(react@18.3.1)
@@ -6636,11 +6636,6 @@ packages:
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
-
-  '@react-aria/i18n@3.11.1':
-    resolution: {integrity: sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==}
-    peerDependencies:
-      react: ^18.2.0
 
   '@react-aria/i18n@3.12.2':
     resolution: {integrity: sha512-PvEyC6JWylTpe8dQEWqQwV6GiA+pbTxHQd//BxtMSapRW3JT9obObAnb/nFhj3HthkUvqHyj0oO1bfeN+mtD8A==}
@@ -19539,18 +19534,6 @@ snapshots:
       '@swc/helpers': 0.5.15
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/i18n@3.11.1(react@18.3.1)':
-    dependencies:
-      '@internationalized/date': 3.5.5
-      '@internationalized/message': 3.1.5
-      '@internationalized/number': 3.5.4
-      '@internationalized/string': 3.2.4
-      '@react-aria/ssr': 3.9.5(react@18.3.1)
-      '@react-aria/utils': 3.25.2(react@18.3.1)
-      '@react-types/shared': 3.24.1(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
 
   '@react-aria/i18n@3.12.2(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

For date related components, users may need to install `@internationalized/date` and `@react-aria/i18n`, in the existing documentation, the commands would lead them to install the latest one. However, the installed versions may not be same as the ones using in the packages. Hence, the discrepancy causes some unexpected behaviour. 

This PR simply add the current package version in the commands to ensure the versions are consistent.

related:
- https://github.com/nextui-org/nextui/issues/3604
- https://github.com/nextui-org/nextui/issues/4137
- https://github.com/nextui-org/nextui/issues/3963

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
