### PR TITLE
fix(deps): missing peer / dev dependency for framer-motion

### DIFF
--- a/.changeset/calm-weeks-tie.md
+++ b/.changeset/calm-weeks-tie.md
@@ -1,0 +1,10 @@
+---
+"@nextui-org/accordion": patch
+"@nextui-org/button": patch
+"@nextui-org/card": patch
+"@nextui-org/date-picker": patch
+"@nextui-org/navbar": patch
+"@nextui-org/snippet": patch
+---
+
+fix missing peer / dev dependency for framer-motion

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -42,7 +42,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "framer-motion": ">=11.5.6",
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
     "@nextui-org/theme": ">=2.3.0-beta.0",
     "@nextui-org/system": ">=2.3.0-beta.0"
   },

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -57,6 +57,7 @@
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
+    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -59,6 +59,7 @@
     "@nextui-org/button": "workspace:*",
     "@nextui-org/avatar": "workspace:*",
     "@nextui-org/image": "workspace:*",
+    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@nextui-org/system": ">=2.3.0-beta.0",
     "@nextui-org/theme": ">=2.3.0-beta.0",
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },
@@ -64,6 +65,7 @@
     "@nextui-org/system": "workspace:*",
     "@nextui-org/test-utils": "workspace:*",
     "@nextui-org/theme": "workspace:*",
+    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/packages/components/navbar/package.json
+++ b/packages/components/navbar/package.json
@@ -64,6 +64,7 @@
     "@nextui-org/input": "workspace:*",
     "@nextui-org/link": "workspace:*",
     "@nextui-org/shared-icons": "workspace:*",
+    "framer-motion": "11.9.0",
     "react-lorem-component": "0.13.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",

--- a/packages/components/snippet/package.json
+++ b/packages/components/snippet/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",
     "@nextui-org/system": "workspace:*",
+    "framer-motion": "11.9.0",
     "clean-package": "2.2.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,9 +982,6 @@ importers:
       '@react-types/shared':
         specifier: 3.25.0
         version: 3.25.0(react@18.3.1)
-      framer-motion:
-        specifier: '>=11.5.6 || >=12.0.0-alpha.1'
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -998,6 +995,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      framer-motion:
+        specifier: 11.9.0
+        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1125,9 +1125,6 @@ importers:
       '@react-types/shared':
         specifier: 3.25.0
         version: 3.25.0(react@18.3.1)
-      framer-motion:
-        specifier: '>=11.5.6 || >=12.0.0-alpha.1'
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -1153,6 +1150,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      framer-motion:
+        specifier: 11.9.0
+        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1431,6 +1431,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      framer-motion:
+        specifier: 11.9.0
+        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -2066,9 +2069,6 @@ importers:
       '@react-stately/utils':
         specifier: 3.10.4
         version: 3.10.4(react@18.3.1)
-      framer-motion:
-        specifier: '>=11.5.6 || >=12.0.0-alpha.1'
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-remove-scroll:
         specifier: ^2.5.6
         version: 2.6.0(@types/react@18.2.8)(react@18.3.1)
@@ -2100,6 +2100,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      framer-motion:
+        specifier: 11.9.0
+        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -2610,9 +2613,6 @@ importers:
       '@react-aria/utils':
         specifier: 3.25.3
         version: 3.25.3(react@18.3.1)
-      framer-motion:
-        specifier: '>=11.5.6 || >=12.0.0-alpha.1'
-        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@nextui-org/system':
         specifier: workspace:*
@@ -2623,6 +2623,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      framer-motion:
+        specifier: 11.9.0
+        version: 11.9.0(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

The previous PR https://github.com/nextui-org/nextui/pull/4140 resolves the calendar framer-motion error caused in user's react 19 + nextsj 15 repo. Hence, this PR is to cover all components.

![image](https://github.com/user-attachments/assets/ea0b44f2-185b-4e44-8713-95f1c3e20e4a)


## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
