### PR TITLE
fix: input focus error in accordion

### DIFF
--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -417,8 +417,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
           class: clsx(classNames?.inputWrapper, isFilled ? "is-filled" : ""),
         }),
         ...mergeProps(props, hoverProps),
-        onClick: (e) => {
-          if (domRef.current && e.currentTarget === e.target) {
+        onClick: () => {
+          if (domRef.current) {
             domRef.current.focus();
           }
         },
@@ -445,8 +445,8 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         ...props,
         ref: innerWrapperRef,
         "data-slot": "inner-wrapper",
-        onClick: (e) => {
-          if (domRef.current && e.currentTarget === e.target) {
+        onClick: () => {
+          if (domRef.current) {
             domRef.current.focus();
           }
         },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Fix: input focus error when using in accordion with selected/default expand keys on page loaded.

Mini-reproduction: [nextui-input-focus-error](https://codesandbox.io/p/sandbox/nextui-input-focus-error-3v3746)

## ⛳️ Current behavior (updates)

Change input wrapper `onClick` property, removed condition `e.currentTarget === e.target`

## 🚀 New behavior

Input component focus behavior normal in accordion component with selected/default expand keys

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Nothing!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved click event handling for input components, streamlining focus logic.
  
- **Refactor**
	- Simplified internal code structure for clarity and conciseness while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->