### PR TITLE
fix(input): teaxtarea label squish

### DIFF
--- a/.changeset/gorgeous-impalas-move.md
+++ b/.changeset/gorgeous-impalas-move.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+fixed textarea label squish

--- a/packages/core/theme/src/components/input.ts
+++ b/packages/core/theme/src/components/input.ts
@@ -29,6 +29,7 @@ const input = tv({
       "z-10",
       "pointer-events-none",
       "origin-top-left",
+      "flex-shrink-0",
       // Using RTL here as Tailwind CSS doesn't support `start` and `end` logical properties for transforms yet.
       "rtl:origin-top-right",
       "subpixel-antialiased",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4110

## 📝 Description

- `Textarea`'s `inner-wrapper`'s `h-full` causes `label` to be squished
- can be reproduced in storybook by setting `minRows` on `Textarea`
- more prominent when `minRows` is set to a low value

## ⛳️ Current behavior (updates)

![1](https://github.com/user-attachments/assets/1b308e53-bf05-47b7-aff9-06700ef2f86f)


## 🚀 New behavior

![2](https://github.com/user-attachments/assets/2cefd63f-38c7-49e1-b95a-1755b12212df)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

`useInput` also affects `Input` but no visible changes are expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the textarea label being squished, ensuring proper display and alignment.
  
- **New Features**
	- Added a new class to the input component to prevent the label from shrinking when space is limited, enhancing visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->