### PR TITLE
fix: should not export list item internal variables type

### DIFF
--- a/.changeset/ninety-mails-yell.md
+++ b/.changeset/ninety-mails-yell.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/menu": patch
+"@nextui-org/theme": patch
+---
+
+Fix should not export list item internal variables type

--- a/apps/docs/components/docs/components/code-demo/react-live-demo.tsx
+++ b/apps/docs/components/docs/components/code-demo/react-live-demo.tsx
@@ -5,6 +5,7 @@ import * as Components from "@nextui-org/react";
 import * as intlDateUtils from "@internationalized/date";
 import * as reactAriaI18n from "@react-aria/i18n";
 import * as reactHookForm from "react-hook-form";
+import {SandpackFiles} from "@codesandbox/sandpack-react/types";
 
 import {BgGridContainer} from "@/components/bg-grid-container";
 import {GradientBox, GradientBoxProps} from "@/components/gradient-box";
@@ -12,7 +13,7 @@ import {CopyButton} from "@/components/copy-button";
 
 export interface ReactLiveDemoProps {
   code: string;
-  files: string[];
+  files: SandpackFiles;
   noInline?: boolean;
   height?: string | number;
   isCentered?: boolean;
@@ -47,7 +48,7 @@ export const ReactLiveDemo: React.FC<ReactLiveDemoProps> = ({
         <div className="absolute top-[-28px] right-[-8px]">
           <CopyButton
             className="opacity-0 group-hover/code-demo:opacity-100 transition-opacity text-zinc-400"
-            value={files?.[DEFAULT_FILE]}
+            value={files?.[DEFAULT_FILE] as string}
           />
         </div>
       )}

--- a/packages/components/listbox/src/use-listbox-item.ts
+++ b/packages/components/listbox/src/use-listbox-item.ts
@@ -1,7 +1,7 @@
 import type {ListboxItemBaseProps} from "./base/listbox-item-base";
 
 import {useMemo, useRef, useCallback, Fragment} from "react";
-import {listboxItem} from "@nextui-org/theme";
+import {listboxItem, MenuItemVariantProps} from "@nextui-org/theme";
 import {
   HTMLNextUIProps,
   mapPropsVariants,
@@ -29,7 +29,10 @@ export type UseListboxItemProps<T extends object> = Props<T> &
 export function useListboxItem<T extends object>(originalProps: UseListboxItemProps<T>) {
   const globalContext = useProviderContext();
 
-  const [props, variantProps] = mapPropsVariants(originalProps, listboxItem.variantKeys);
+  const [props, variantProps] = mapPropsVariants(
+    originalProps,
+    listboxItem.variantKeys as (keyof MenuItemVariantProps)[],
+  );
 
   const {
     as,

--- a/packages/components/menu/src/menu.tsx
+++ b/packages/components/menu/src/menu.tsx
@@ -74,10 +74,7 @@ function Menu<T extends object>(props: Props<T>, ref: ForwardedRef<HTMLUListElem
   );
 }
 
-export type MenuProps<T extends object = object> = Omit<
-  Props<T>,
-  "hasChildItems" | "hasTitleTextChild" | "hasDescriptionTextChild"
-> & {ref?: Ref<HTMLElement>};
+export type MenuProps<T extends object = object> = Props<T> & {ref?: Ref<HTMLElement>};
 
 // forwardRef doesn't support generic parameters, so cast the result to the correct type
 export default forwardRef(Menu) as <T extends object>(props: MenuProps<T>) => ReactElement;

--- a/packages/components/menu/src/use-menu-item.ts
+++ b/packages/components/menu/src/use-menu-item.ts
@@ -2,7 +2,7 @@ import type {MenuItemBaseProps} from "./base/menu-item-base";
 import type {Node} from "@react-types/shared";
 
 import {useMemo, useRef, useCallback, Fragment} from "react";
-import {menuItem} from "@nextui-org/theme";
+import {menuItem, MenuItemVariantProps} from "@nextui-org/theme";
 import {
   HTMLNextUIProps,
   mapPropsVariants,
@@ -29,7 +29,10 @@ export type UseMenuItemProps<T extends object> = Props<T> &
 export function useMenuItem<T extends object>(originalProps: UseMenuItemProps<T>) {
   const globalContext = useProviderContext();
 
-  const [props, variantProps] = mapPropsVariants(originalProps, menuItem.variantKeys);
+  const [props, variantProps] = mapPropsVariants(
+    originalProps,
+    menuItem.variantKeys as (keyof MenuItemVariantProps)[],
+  );
 
   const {
     as,

--- a/packages/core/theme/src/components/menu.ts
+++ b/packages/core/theme/src/components/menu.ts
@@ -529,7 +529,10 @@ export type MenuVariantProps = VariantProps<typeof menu>;
 export type MenuSlots = keyof ReturnType<typeof menu>;
 export type MenuSectionVariantProps = VariantProps<typeof menuSection>;
 export type MenuSectionSlots = keyof ReturnType<typeof menuSection>;
-export type MenuItemVariantProps = VariantProps<typeof menuItem>;
+export type MenuItemVariantProps = Omit<
+  VariantProps<typeof menuItem>,
+  "hasDescriptionTextChild" | "hasTitleTextChild"
+>;
 export type MenuItemSlots = keyof ReturnType<typeof menuItem>;
 
 export {menu, menuItem, menuSection};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

related #4157

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated type definitions for `MenuProps` and `MenuItemVariantProps`, enhancing flexibility in component usage.
	- Enhanced type safety and structure for the `files` property in the `ReactLiveDemo` component.
  
- **Bug Fixes**
	- Adjusted properties in type definitions to ensure accurate representation of component capabilities.
	- Improved encapsulation by preventing the export of internal variable types for list items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->