### PR TITLE
fix: accordion item focus effect input focus event

### DIFF
--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -90,6 +90,12 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
               initial="exit"
               style={{willChange}}
               variants={transitionVariants}
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+              onFocus={(e) => {
+                e.stopPropagation();
+              }}
               onKeyDown={(e) => {
                 e.stopPropagation();
               }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

Fix: input focus error when using in accordion with selected/default expand keys on page loaded.

Mini-reproduction: [nextui-input-focus-error](https://codesandbox.io/p/sandbox/nextui-input-focus-error-3v3746)

## ⛳️ Current behavior (updates)

Add `onClick`, `onFocus` event in accordion item content render.

## 🚀 New behavior

Input component focus behavior normal in accordion component with selected/default expand keys

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Nothing!
