### PR TITLE
Update data-slot for the error message in the select.

### DIFF
--- a/.changeset/dirty-trainers-love.md
+++ b/.changeset/dirty-trainers-love.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/select": patch
+---
+
+Update the data-slot attribute of the Select component from "errorMessage" to "error-message" to maintain consistency across all components.

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -651,7 +651,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
       return {
         ...props,
         ...errorMessageProps,
-        "data-slot": "errorMessage",
+        "data-slot": "error-message",
         className: slots.errorMessage({class: clsx(classNames?.errorMessage, props?.className)}),
       };
     },


### PR DESCRIPTION
All components use the `data-slot="error-message"` attribute, except for the select component. I observed this behavior when a test in my application started failing.

<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Standardized the naming convention for the `data-slot` attribute to improve consistency.
	- Minor code organization adjustments for clarity, including comment reordering and a TODO for future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->