### PR TITLE
fix(select): hideEmptyContent API

### DIFF
--- a/.changeset/rotten-jobs-pull.md
+++ b/.changeset/rotten-jobs-pull.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/use-aria-multiselect": patch
+"@nextui-org/select": patch
+---
+
+add hideEmptyContent API to select

--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -606,8 +606,8 @@ the popover and listbox components.
     {
       attribute: "hideEmptyContent",
       type: "boolean",
-      description: "Whether to hide the listbox when there are no items.",
-      default: "true"
+      description: "Whether the listbox will be prevented from opening when there are no items.",
+      default: "false"
     },
     {
       attribute: "popoverProps",

--- a/apps/docs/content/docs/components/select.mdx
+++ b/apps/docs/content/docs/components/select.mdx
@@ -485,7 +485,7 @@ the popover and listbox components.
     },
     {
       attribute: "endContent",
-      type: "ReactNode", 
+      type: "ReactNode",
       description: "Element to be rendered in the right side of the select.",
       default: "-"
     },
@@ -515,7 +515,7 @@ the popover and listbox components.
     },
     {
       attribute: "itemHeight",
-      type: "number", 
+      type: "number",
       description: "The fixed height of each item in pixels. Required when using virtualization.",
       default: "32"
     },
@@ -602,6 +602,12 @@ the popover and listbox components.
       type: "boolean",
       description: "Whether the select should disable the rotation of the selector icon.",
       default: "false"
+    },
+    {
+      attribute: "hideEmptyContent",
+      type: "boolean",
+      description: "Whether to hide the listbox when there are no items.",
+      default: "true"
     },
     {
       attribute: "popoverProps",

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -848,6 +848,8 @@ describe("Select", () => {
 
     // assert that the select is not open
     expect(select).not.toHaveAttribute("aria-expanded", "true");
+    // assert that the listbox is not rendered
+    expect(wrapper.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
   it("should open dropdown when hideEmptyContent is false", async () => {
@@ -869,6 +871,13 @@ describe("Select", () => {
 
     // assert that the select is open
     expect(select).toHaveAttribute("aria-expanded", "true");
+
+    const listbox = wrapper.getByRole("listbox");
+
+    // assert that the listbox is rendered
+    expect(listbox).toBeInTheDocument();
+    // assert that the listbox items are not rendered
+    expect(wrapper.queryByRole("option")).not.toBeInTheDocument();
   });
 });
 

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -828,6 +828,48 @@ describe("Select", () => {
       "Invalid value",
     );
   });
+
+  it("should not open dropdown when hideEmptyContent is true", async () => {
+    const wrapper = render(
+      <Select
+        hideEmptyContent
+        aria-label="Favorite Animal"
+        data-testid="hide-empty-content-true-test"
+        label="Favorite Animal"
+      >
+        {[]}
+      </Select>,
+    );
+
+    const select = wrapper.getByTestId("hide-empty-content-true-test");
+
+    // open the select dropdown
+    await user.click(select);
+
+    // assert that the select is not open
+    expect(select).not.toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should open dropdown when hideEmptyContent is false", async () => {
+    const wrapper = render(
+      <Select
+        aria-label="Favorite Animal"
+        data-testid="hide-empty-content-false-test"
+        hideEmptyContent={false}
+        label="Favorite Animal"
+      >
+        {[]}
+      </Select>,
+    );
+
+    const select = wrapper.getByTestId("hide-empty-content-false-test");
+
+    // open the select dropdown
+    await user.click(select);
+
+    // assert that the select is open
+    expect(select).toHaveAttribute("aria-expanded", "true");
+  });
 });
 
 describe("Select virtualization tests", () => {

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -166,6 +166,11 @@ export type UseSelectProps<T> = Omit<
      * @default undefined
      */
     isVirtualized?: boolean;
+    /**
+     * Whether the listbox should be openable when there are no items.
+     * @default true
+     */
+    hideEmptyContent?: boolean;
   };
 
 export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
@@ -209,6 +214,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     onClose,
     className,
     classNames,
+    hideEmptyContent = true,
     ...otherProps
   } = props;
 
@@ -263,6 +269,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     isDisabled: originalProps.isDisabled,
     isInvalid: originalProps.isInvalid,
     defaultOpen,
+    hideEmptyContent,
     onOpenChange: (open) => {
       onOpenChange?.(open);
       if (!open) {

--- a/packages/components/select/src/use-select.ts
+++ b/packages/components/select/src/use-select.ts
@@ -167,8 +167,8 @@ export type UseSelectProps<T> = Omit<
      */
     isVirtualized?: boolean;
     /**
-     * Whether the listbox should be openable when there are no items.
-     * @default true
+     * Whether the listbox will be prevented from opening when there are no items.
+     * @default false
      */
     hideEmptyContent?: boolean;
   };
@@ -214,7 +214,7 @@ export function useSelect<T extends object>(originalProps: UseSelectProps<T>) {
     onClose,
     className,
     classNames,
-    hideEmptyContent = true,
+    hideEmptyContent = false,
     ...otherProps
   } = props;
 

--- a/packages/components/select/stories/select.stories.tsx
+++ b/packages/components/select/stories/select.stories.tsx
@@ -411,6 +411,31 @@ const StartContentTemplate = ({color, variant, ...args}: SelectProps) => (
   </Select>
 );
 
+const EmptyTemplate = ({color, variant, ...args}: SelectProps) => (
+  <div className="w-full justify-center flex gap-2">
+    <Select
+      hideEmptyContent
+      className="max-w-xs"
+      color={color}
+      label="Hide empty content"
+      variant={variant}
+      {...args}
+    >
+      {[]}
+    </Select>
+    <Select
+      className="max-w-xs"
+      color={color}
+      hideEmptyContent={false}
+      label="Show empty content"
+      variant={variant}
+      {...args}
+    >
+      {[]}
+    </Select>
+  </div>
+);
+
 const CustomItemsTemplate = ({color, variant, ...args}: SelectProps<User>) => (
   <div className="w-full justify-center flex gap-2">
     <Select
@@ -858,6 +883,14 @@ export const AsyncLoading = {
 
 export const StartContent = {
   render: StartContentTemplate,
+
+  args: {
+    ...defaultProps,
+  },
+};
+
+export const EmptyContent = {
+  render: EmptyTemplate,
 
   args: {
     ...defaultProps,

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-state.ts
@@ -86,6 +86,8 @@ export function useMultiSelectState<T extends {}>(props: MultiSelectProps<T>): M
     value: listState.selectedKeys,
   });
 
+  const shouldHideContent = listState.collection.size === 0 && props.hideEmptyContent;
+
   return {
     ...validationState,
     ...listState,
@@ -95,19 +97,13 @@ export function useMultiSelectState<T extends {}>(props: MultiSelectProps<T>): M
       triggerState.close();
     },
     open(focusStrategy: FocusStrategy | null = null) {
-      // Don't open if the collection is empty and hideEmptyContent is true.
-      if (listState.collection.size === 0 && props.hideEmptyContent) {
-        return;
-      }
+      if (shouldHideContent) return;
 
       setFocusStrategy(focusStrategy);
       triggerState.open();
     },
     toggle(focusStrategy: FocusStrategy | null = null) {
-      // Don't toggle if the collection is empty and hideEmptyContent is true.
-      if (listState.collection.size === 0 && props.hideEmptyContent) {
-        return;
-      }
+      if (shouldHideContent) return;
 
       setFocusStrategy(focusStrategy);
       triggerState.toggle();

--- a/packages/hooks/use-aria-multiselect/src/use-multiselect-state.ts
+++ b/packages/hooks/use-aria-multiselect/src/use-multiselect-state.ts
@@ -36,6 +36,10 @@ export interface MultiSelectProps<T>
    * @default true
    */
   shouldFlip?: boolean;
+  /**
+   * Whether the menu should be hidden when there are no items.
+   */
+  hideEmptyContent?: boolean;
 }
 
 export interface MultiSelectState<T>
@@ -91,18 +95,23 @@ export function useMultiSelectState<T extends {}>(props: MultiSelectProps<T>): M
       triggerState.close();
     },
     open(focusStrategy: FocusStrategy | null = null) {
-      // Don't open if the collection is empty.
-      if (listState.collection.size !== 0) {
-        setFocusStrategy(focusStrategy);
-        triggerState.open();
+      // Don't open if the collection is empty and hideEmptyContent is true.
+      if (listState.collection.size === 0 && props.hideEmptyContent) {
+        return;
       }
+
+      setFocusStrategy(focusStrategy);
+      triggerState.open();
     },
     toggle(focusStrategy: FocusStrategy | null = null) {
-      if (listState.collection.size !== 0) {
-        setFocusStrategy(focusStrategy);
-        triggerState.toggle();
-        validationState.commitValidation();
+      // Don't toggle if the collection is empty and hideEmptyContent is true.
+      if (listState.collection.size === 0 && props.hideEmptyContent) {
+        return;
       }
+
+      setFocusStrategy(focusStrategy);
+      triggerState.toggle();
+      validationState.commitValidation();
     },
     isFocused,
     setFocused,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #2422

## 📝 Description

- added `hideEmptyContent` to `Select`, which toggles whether to show dropdown when there is no content
- note that it defaults to `false` in `useSelect`, which is different from current behavior
- added `Select` storybook for `hideEmptyContent`

## ⛳️ Current behavior (updates)

see video below

## 🚀 New behavior

old on the left, new on the right

https://github.com/user-attachments/assets/df04818f-1bc7-4d53-8e55-59741c671658


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `hideEmptyContent` property in the `Select` component, allowing users to control the visibility of empty content in the dropdown.
  - Added examples in the storybook demonstrating the behavior of the `Select` component with empty content scenarios.

- **Documentation**
  - Enhanced documentation for the `Select` component, detailing the new `hideEmptyContent` property and updating existing property descriptions for clarity.

- **Tests**
  - Added new test cases to verify the behavior of the `Select` component when using the `hideEmptyContent` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->