### PR TITLE
chore(docs): remove non-existing attribute in switch page

### DIFF
--- a/apps/docs/content/docs/components/switch.mdx
+++ b/apps/docs/content/docs/components/switch.mdx
@@ -198,12 +198,6 @@ In case you need to customize the switch even further, you can use the `useSwitc
       default: "-"
     },
     {
-      attribute: "isRequired",
-      type: "boolean",
-      description: "Whether user input is required on the input before form submission.",
-      default: "false"
-    },
-    {
       attribute: "isReadOnly",
       type: "boolean",
       description: "Whether the input can be selected but not changed by the user.",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

In switch doc page, `isRequired` is in the prop list while this prop doesn't exist, since switch is not meant to be required by concept (ref: https://github.com/nextui-org/nextui/issues/1610#issuecomment-1721377481)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed the `isRequired` prop from the Switch component documentation.
	- Added new sections for "Data Attributes" and "Accessibility" to enhance understanding of the component's functionality.
	- Expanded existing sections for clearer guidance on installation, usage, and API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->