### PR TITLE
fix: disable number change in case of scrolling

### DIFF
--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -82,6 +82,10 @@ export interface Props<T extends HTMLInputElement | HTMLTextAreaElement = HTMLIn
    * React aria onChange event.
    */
   onValueChange?: (value: string) => void;
+  /**
+   * disable  the number chnage on scrolling
+   */
+  disableScrollChange?: boolean;
 }
 
 type AutoCapitalize = AriaTextFieldOptions<"input">["autoCapitalize"];
@@ -116,6 +120,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     validationBehavior = formValidationBehavior ?? globalContext?.validationBehavior ?? "native",
     innerWrapperRef: innerWrapperRefProp,
     onValueChange = () => {},
+    disableScrollChange,
     ...otherProps
   } = props;
 
@@ -125,6 +130,11 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     },
     [onValueChange],
   );
+  const handleScrollingChange = (e: React.WheelEvent<HTMLInputElement>) => {
+    if (disableScrollChange) {
+      (e.target as HTMLInputElement).blur();
+    }
+  };
 
   const [isFocusWithin, setFocusWithin] = useState(false);
 
@@ -386,6 +396,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         "aria-readonly": dataAttr(originalProps.isReadOnly),
         onChange: chain(inputProps.onChange, onChange),
         ref: domRef,
+        onWheel: handleScrollingChange,
       };
     },
     [
@@ -402,6 +413,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
       originalProps.isReadOnly,
       originalProps.isRequired,
       onChange,
+      disableScrollChange,
     ],
   );
 


### PR DESCRIPTION
Closes  https://github.com/nextui-org/nextui/issues/4238

## 📝 Description
added a prop disableScrollChange to disable change in the input when the type is number

## ⛳️ Current behavior (updates)

disable change in number on scrolling with mouse wheel or touchpad, since it can change value without user noticing when in scrollable container

## 🚀 New behavior

prop added to disable if needed

## 💣 Is this a breaking change (Yes/No):

No
## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional property `disableScrollChange` to enhance input control during scrolling.
	- Added functionality to prevent value changes when the input is scrolled, improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->