### PR TITLE
fix: missing react-types package added

### DIFF
--- a/.changeset/gorgeous-mice-think.md
+++ b/.changeset/gorgeous-mice-think.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system": patch
+---
+
+Fix, mising react-types package added to the system package

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -106,7 +106,7 @@
     "@next/env": "14.3.0-canary.43",
     "@react-types/calendar": "3.4.10",
     "@react-types/datepicker": "3.8.3",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@tailwindcss/typography": "^0.5.9",
     "@types/canvas-confetti": "^1.4.2",
     "@types/marked": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@commitlint/config-conventional": "^17.2.0",
     "@react-bootstrap/babel-preset": "^2.1.0",
     "@react-types/link": "3.5.7",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@storybook/react": "^8.4.5",
     "@swc/core": "^1.3.35",
     "@swc/jest": "^0.2.24",

--- a/packages/components/accordion/package.json
+++ b/packages/components/accordion/package.json
@@ -61,7 +61,7 @@
     "@react-stately/tree": "3.8.5",
     "@react-aria/button": "3.10.1",
     "@react-types/accordion": "3.0.0-alpha.24",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/autocomplete/package.json
+++ b/packages/components/autocomplete/package.json
@@ -62,7 +62,7 @@
     "@react-aria/visually-hidden": "3.8.17",
     "@react-stately/combobox": "3.10.0",
     "@react-types/combobox": "3.13.0",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/avatar": "workspace:*",

--- a/packages/components/breadcrumbs/package.json
+++ b/packages/components/breadcrumbs/package.json
@@ -47,7 +47,7 @@
     "@react-aria/breadcrumbs": "3.5.18",
     "@react-aria/utils": "3.26.0",
     "@react-types/breadcrumbs": "3.7.8",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -50,7 +50,7 @@
     "@react-aria/interactions": "3.22.4",
     "@react-aria/utils": "3.26.0",
     "@react-aria/focus": "3.18.4",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-types/button": "3.10.0"
   },
   "devDependencies": {

--- a/packages/components/calendar/package.json
+++ b/packages/components/calendar/package.json
@@ -59,7 +59,7 @@
     "@react-stately/utils": "3.10.4",
     "@react-types/calendar": "3.4.10",
     "@react-aria/interactions": "3.22.4",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "scroll-into-view-if-needed": "3.0.10",
     "@types/lodash.debounce": "^4.0.7"
   },

--- a/packages/components/card/package.json
+++ b/packages/components/card/package.json
@@ -49,7 +49,7 @@
     "@react-aria/utils": "3.26.0",
     "@react-aria/interactions": "3.22.4",
     "@react-aria/button": "3.10.1",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -53,7 +53,7 @@
     "@react-stately/checkbox": "3.6.9",
     "@react-stately/toggle": "3.7.8",
     "@react-types/checkbox": "3.8.4",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/chip": "workspace:*",

--- a/packages/components/date-input/package.json
+++ b/packages/components/date-input/package.json
@@ -48,7 +48,7 @@
     "@react-aria/i18n": "3.12.3",
     "@react-stately/datepicker": "3.10.3",
     "@react-types/datepicker": "3.8.3",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-aria/utils": "3.26.0"
   },
   "devDependencies": {

--- a/packages/components/date-picker/package.json
+++ b/packages/components/date-picker/package.json
@@ -58,7 +58,7 @@
     "@react-stately/overlays": "3.6.11",
     "@react-stately/utils": "3.10.4",
     "@react-types/datepicker": "3.8.3",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/radio": "workspace:*",

--- a/packages/components/divider/package.json
+++ b/packages/components/divider/package.json
@@ -42,7 +42,7 @@
     "@nextui-org/shared-utils": "workspace:*",
     "@nextui-org/react-rsc-utils": "workspace:*",
     "@nextui-org/system-rsc": "workspace:*",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -51,7 +51,7 @@ const getMenuItem = <T extends object>(props: Partial<MenuProps<T>> | undefined,
 
     if (mergedChildren && mergedChildren.length) {
       const item = ((mergedChildren as CollectionElement<T>[]).find((item) => {
-        if (item.key === key) {
+        if (item && item.key === key) {
           return item;
         }
       }) || {}) as {props: MenuProps};

--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -45,7 +45,7 @@
     "@nextui-org/system": "workspace:*",
     "@nextui-org/theme": "workspace:*",
     "@react-aria/utils": "3.26.0",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-stately/form": "3.0.6",
     "@react-types/form": "^3.7.8"
   },

--- a/packages/components/input/package.json
+++ b/packages/components/input/package.json
@@ -50,7 +50,7 @@
     "@react-aria/textfield": "3.14.10",
     "@react-aria/utils": "3.26.0",
     "@react-stately/utils": "3.10.4",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-types/textfield": "3.9.7",
     "react-textarea-autosize": "^8.5.3"
   },

--- a/packages/components/listbox/package.json
+++ b/packages/components/listbox/package.json
@@ -52,7 +52,7 @@
     "@react-aria/focus": "3.18.4",
     "@react-aria/interactions": "3.22.4",
     "@react-types/menu": "3.9.12",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/avatar": "workspace:*",

--- a/packages/components/menu/package.json
+++ b/packages/components/menu/package.json
@@ -53,7 +53,7 @@
     "@react-stately/menu": "3.8.3",
     "@react-stately/tree": "3.8.5",
     "@react-types/menu": "3.9.12",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -50,7 +50,7 @@
     "@react-aria/visually-hidden": "3.8.17",
     "@react-stately/radio": "3.10.8",
     "@react-types/radio": "3.8.4",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/select/package.json
+++ b/packages/components/select/package.json
@@ -58,7 +58,7 @@
     "@react-aria/interactions": "3.22.4",
     "@react-aria/utils": "3.26.0",
     "@react-aria/visually-hidden": "3.8.17",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@tanstack/react-virtual": "3.10.9"
   },
   "devDependencies": {

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -49,7 +49,7 @@
     "@react-aria/utils": "3.26.0",
     "@react-aria/visually-hidden": "3.8.17",
     "@react-stately/toggle": "3.7.8",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "@nextui-org/theme": "workspace:*",

--- a/packages/components/tabs/package.json
+++ b/packages/components/tabs/package.json
@@ -52,7 +52,7 @@
     "@react-aria/tabs": "3.9.7",
     "@react-aria/utils": "3.26.0",
     "@react-stately/tabs": "3.6.10",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-types/tabs": "3.3.10",
     "scroll-into-view-if-needed": "3.0.10"
   },

--- a/packages/core/system-rsc/package.json
+++ b/packages/core/system-rsc/package.json
@@ -46,7 +46,7 @@
     "clean-package": "2.2.0"
   },
   "dependencies": {
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "clsx": "^1.2.1"
   },
   "clean-package": "../../../clean-package.config.json",

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -61,6 +61,7 @@
     "@react-aria/overlays": "3.23.4",
     "@react-aria/utils": "3.26.0",
     "@react-stately/utils": "3.10.4",
-    "@react-types/datepicker": "3.8.3"
+    "@react-types/datepicker": "3.8.3",
+    "@react-types/shared": "3.25.0"
   }
 }

--- a/packages/core/system/package.json
+++ b/packages/core/system/package.json
@@ -62,6 +62,6 @@
     "@react-aria/utils": "3.26.0",
     "@react-stately/utils": "3.10.4",
     "@react-types/datepicker": "3.8.3",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   }
 }

--- a/packages/hooks/use-aria-accordion-item/package.json
+++ b/packages/hooks/use-aria-accordion-item/package.json
@@ -37,7 +37,7 @@
     "@react-aria/button": "3.10.1",
     "@react-aria/focus": "3.18.4",
     "@react-stately/tree": "3.8.5",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0"

--- a/packages/hooks/use-aria-accordion/package.json
+++ b/packages/hooks/use-aria-accordion/package.json
@@ -40,7 +40,7 @@
     "@react-aria/utils": "3.26.0",
     "@react-stately/tree": "3.8.5",
     "@react-types/accordion": "3.0.0-alpha.24",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0"

--- a/packages/hooks/use-aria-button/package.json
+++ b/packages/hooks/use-aria-button/package.json
@@ -41,7 +41,7 @@
     "@react-aria/interactions": "3.22.4",
     "@react-aria/utils": "3.26.0",
     "@react-types/button": "3.10.0",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/hooks/use-aria-link/package.json
+++ b/packages/hooks/use-aria-link/package.json
@@ -41,7 +41,7 @@
     "@react-aria/interactions": "3.22.4",
     "@react-aria/utils": "3.26.0",
     "@react-types/link": "3.5.8",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/hooks/use-aria-menu/package.json
+++ b/packages/hooks/use-aria-menu/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@react-aria/utils": "3.26.0",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-aria/menu": "3.15.5",
     "@react-aria/interactions": "3.22.4",
     "@react-stately/tree": "3.8.5",

--- a/packages/hooks/use-aria-modal-overlay/package.json
+++ b/packages/hooks/use-aria-modal-overlay/package.json
@@ -37,7 +37,7 @@
     "@react-aria/overlays": "3.23.4",
     "@react-aria/utils": "3.26.0",
     "@react-stately/overlays": "3.6.11",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",

--- a/packages/hooks/use-aria-multiselect/package.json
+++ b/packages/hooks/use-aria-multiselect/package.json
@@ -47,7 +47,7 @@
     "@react-types/button": "3.10.0",
     "@react-types/overlays": "3.8.10",
     "@react-types/select": "3.9.7",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",

--- a/packages/hooks/use-aria-toggle-button/package.json
+++ b/packages/hooks/use-aria-toggle-button/package.json
@@ -41,7 +41,7 @@
     "@react-aria/utils": "3.26.0",
     "@react-stately/toggle": "3.7.8",
     "@react-types/button": "3.10.0",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/packages/hooks/use-intersection-observer/package.json
+++ b/packages/hooks/use-intersection-observer/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@react-aria/utils": "3.26.0",
     "@react-aria/ssr": "3.9.6",
-    "@react-types/shared": "3.25.0",
+    "@react-types/shared": "3.26.0",
     "@react-aria/interactions": "3.22.4"
   },
   "peerDependencies": {

--- a/packages/utilities/aria-utils/package.json
+++ b/packages/utilities/aria-utils/package.json
@@ -45,7 +45,7 @@
     "@react-stately/collections": "3.11.0",
     "@react-stately/overlays": "3.6.11",
     "@react-types/overlays": "3.8.10",
-    "@react-types/shared": "3.25.0"
+    "@react-types/shared": "3.26.0"
   },
   "devDependencies": {
     "clean-package": "2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3278,6 +3278,9 @@ importers:
       '@react-types/datepicker':
         specifier: 3.8.3
         version: 3.8.3(react@18.2.0)
+      '@react-types/shared':
+        specifier: 3.25.0
+        version: 3.25.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: 3.5.7
         version: 3.5.7(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@storybook/react':
         specifier: ^8.4.5
         version: 8.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@8.4.5(prettier@2.8.8))(typescript@4.9.5)
@@ -534,8 +534,8 @@ importers:
         specifier: 3.8.3
         version: 3.8.3(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@tailwindcss/typography':
         specifier: ^0.5.9
         version: 0.5.15(tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@20.2.5)(typescript@5.6.3)))
@@ -666,8 +666,8 @@ importers:
         specifier: 3.0.0-alpha.24
         version: 3.0.0-alpha.24(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -803,8 +803,8 @@ importers:
         specifier: 3.13.0
         version: 3.13.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -944,8 +944,8 @@ importers:
         specifier: 3.7.8
         version: 3.7.8(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -1005,8 +1005,8 @@ importers:
         specifier: 3.10.0
         version: 3.10.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -1087,8 +1087,8 @@ importers:
         specifier: 3.4.10
         version: 3.4.10(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@types/lodash.debounce':
         specifier: ^4.0.7
         version: 4.0.9
@@ -1148,8 +1148,8 @@ importers:
         specifier: 3.26.0
         version: 3.26.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/avatar':
         specifier: workspace:*
@@ -1227,8 +1227,8 @@ importers:
         specifier: 3.8.4
         version: 3.8.4(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/chip':
         specifier: workspace:*
@@ -1359,8 +1359,8 @@ importers:
         specifier: 3.8.3
         version: 3.8.3(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -1438,8 +1438,8 @@ importers:
         specifier: 3.8.3
         version: 3.8.3(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/radio':
         specifier: workspace:*
@@ -1478,8 +1478,8 @@ importers:
         specifier: workspace:*
         version: link:../../core/system-rsc
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/theme':
         specifier: workspace:*
@@ -1652,8 +1652,8 @@ importers:
         specifier: ^3.7.8
         version: 3.7.8(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -1729,8 +1729,8 @@ importers:
         specifier: 3.10.4
         version: 3.10.4(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@react-types/textfield':
         specifier: 3.9.7
         version: 3.9.7(react@18.2.0)
@@ -1919,8 +1919,8 @@ importers:
         specifier: 3.9.12
         version: 3.9.12(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@tanstack/react-virtual':
         specifier: 3.10.9
         version: 3.10.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1998,8 +1998,8 @@ importers:
         specifier: 3.9.12
         version: 3.9.12(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -2394,8 +2394,8 @@ importers:
         specifier: 3.8.4
         version: 3.8.4(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/button':
         specifier: workspace:*
@@ -2532,8 +2532,8 @@ importers:
         specifier: 3.8.17
         version: 3.8.17(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@tanstack/react-virtual':
         specifier: 3.10.9
         version: 3.10.9(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2796,8 +2796,8 @@ importers:
         specifier: 3.7.8
         version: 3.7.8(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       '@nextui-org/shared-icons':
         specifier: workspace:*
@@ -2945,8 +2945,8 @@ importers:
         specifier: 3.6.10
         version: 3.6.10(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       '@react-types/tabs':
         specifier: 3.3.10
         version: 3.3.10(react@18.2.0)
@@ -3279,8 +3279,8 @@ importers:
         specifier: 3.8.3
         version: 3.8.3(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3298,8 +3298,8 @@ importers:
   packages/core/system-rsc:
     dependencies:
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -3384,8 +3384,8 @@ importers:
         specifier: 3.0.0-alpha.24
         version: 3.0.0-alpha.24(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3406,8 +3406,8 @@ importers:
         specifier: 3.8.5
         version: 3.8.5(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3431,8 +3431,8 @@ importers:
         specifier: 3.10.0
         version: 3.10.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3456,8 +3456,8 @@ importers:
         specifier: 3.5.8
         version: 3.5.8(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3493,8 +3493,8 @@ importers:
         specifier: 3.9.12
         version: 3.9.12(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -3518,8 +3518,8 @@ importers:
         specifier: 3.6.11
         version: 3.6.11(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3573,8 +3573,8 @@ importers:
         specifier: 3.9.7
         version: 3.9.7(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3601,8 +3601,8 @@ importers:
         specifier: 3.10.0
         version: 3.10.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3719,8 +3719,8 @@ importers:
         specifier: 3.26.0
         version: 3.26.0(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -3949,8 +3949,8 @@ importers:
         specifier: 3.8.10
         version: 3.8.10(react@18.2.0)
       '@react-types/shared':
-        specifier: 3.25.0
-        version: 3.25.0(react@18.2.0)
+        specifier: 3.26.0
+        version: 3.26.0(react@18.2.0)
     devDependencies:
       clean-package:
         specifier: 2.2.0
@@ -7074,16 +7074,6 @@ packages:
 
   '@react-types/select@3.9.7':
     resolution: {integrity: sha512-Jva4ixfB4EEdy+WmZkUoLiQI7vVfHPxM73VuL7XDxvAO+YKiIztDTcU720QVNhxTMmQvCxfRBXWar8aodCjLiw==}
-    peerDependencies:
-      react: 18.2.0
-
-  '@react-types/shared@3.24.1':
-    resolution: {integrity: sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==}
-    peerDependencies:
-      react: 18.2.0
-
-  '@react-types/shared@3.25.0':
-    resolution: {integrity: sha512-OZSyhzU6vTdW3eV/mz5i6hQwQUhkRs7xwY2d1aqPvTdMe0+2cY7Fwp45PAiwYLEj73i9ro2FxF9qC4DvHGSCgQ==}
     peerDependencies:
       react: 18.2.0
 
@@ -18407,7 +18397,7 @@ snapshots:
       '@react-aria/link': 3.7.6(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-types/breadcrumbs': 3.7.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18418,7 +18408,7 @@ snapshots:
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/toggle': 3.7.8(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18432,7 +18422,7 @@ snapshots:
       '@react-stately/calendar': 3.5.5(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
       '@react-types/calendar': 3.4.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18448,7 +18438,7 @@ snapshots:
       '@react-stately/form': 3.0.6(react@18.2.0)
       '@react-stately/toggle': 3.7.8(react@18.2.0)
       '@react-types/checkbox': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18467,7 +18457,7 @@ snapshots:
       '@react-stately/form': 3.0.6(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
       '@react-types/combobox': 3.13.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18490,7 +18480,7 @@ snapshots:
       '@react-types/calendar': 3.4.10(react@18.2.0)
       '@react-types/datepicker': 3.8.3(react@18.2.0)
       '@react-types/dialog': 3.5.13(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18501,7 +18491,7 @@ snapshots:
       '@react-aria/overlays': 3.23.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-types/dialog': 3.5.13(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18510,7 +18500,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
       react: 18.2.0
@@ -18529,7 +18519,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/form': 3.0.6(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18538,7 +18528,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/form': 3.0.6(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18555,7 +18545,7 @@ snapshots:
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-types/checkbox': 3.8.4(react@18.2.0)
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18568,7 +18558,7 @@ snapshots:
       '@internationalized/string': 3.2.4
       '@react-aria/ssr': 3.9.6(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18576,7 +18566,7 @@ snapshots:
     dependencies:
       '@react-aria/ssr': 3.9.6(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18591,7 +18581,7 @@ snapshots:
   '@react-aria/label@3.7.12(react@18.2.0)':
     dependencies:
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18601,7 +18591,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-types/link': 3.5.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18614,7 +18604,7 @@ snapshots:
       '@react-stately/collections': 3.11.0(react@18.2.0)
       '@react-stately/list': 3.11.0(react@18.2.0)
       '@react-types/listbox': 3.5.2(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18636,7 +18626,7 @@ snapshots:
       '@react-stately/tree': 3.8.5(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
       '@react-types/menu': 3.9.12(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18652,7 +18642,7 @@ snapshots:
       '@react-stately/overlays': 3.6.11(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
       '@react-types/overlays': 3.8.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18663,7 +18653,7 @@ snapshots:
       '@react-aria/label': 3.7.12(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-types/progress': 3.5.7(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18677,7 +18667,7 @@ snapshots:
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/radio': 3.10.8(react@18.2.0)
       '@react-types/radio': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18688,7 +18678,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18700,7 +18690,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -18713,7 +18703,7 @@ snapshots:
       '@react-aria/label': 3.7.12(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/slider': 3.5.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/slider': 3.7.6(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18724,7 +18714,7 @@ snapshots:
       '@react-aria/live-announcer': 3.4.0
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-types/button': 3.10.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18743,7 +18733,7 @@ snapshots:
     dependencies:
       '@react-aria/toggle': 3.10.9(react@18.2.0)
       '@react-stately/toggle': 3.7.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/switch': 3.5.6(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18762,7 +18752,7 @@ snapshots:
       '@react-stately/table': 3.12.3(react@18.2.0)
       '@react-types/checkbox': 3.8.4(react@18.2.0)
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/table': 3.10.2(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18775,7 +18765,7 @@ snapshots:
       '@react-aria/selection': 3.20.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/tabs': 3.6.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/tabs': 3.3.10(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18789,7 +18779,7 @@ snapshots:
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/form': 3.0.6(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/textfield': 3.9.7(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18812,7 +18802,7 @@ snapshots:
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/toggle': 3.7.8(react@18.2.0)
       '@react-types/checkbox': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18822,7 +18812,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/tooltip': 3.4.13(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/tooltip': 3.4.12(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -18831,7 +18821,7 @@ snapshots:
     dependencies:
       '@react-aria/ssr': 3.9.6(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
       react: 18.2.0
@@ -18851,7 +18841,7 @@ snapshots:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
       '@react-stately/virtualizer': 3.7.1(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18860,7 +18850,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.22.4(react@18.2.0)
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18897,7 +18887,7 @@ snapshots:
       '@internationalized/date': 3.5.6
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/calendar': 3.4.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18906,19 +18896,19 @@ snapshots:
       '@react-stately/form': 3.0.6(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/checkbox': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/collections@3.10.9(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/collections@3.11.0(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18931,19 +18921,19 @@ snapshots:
       '@react-stately/select': 3.6.8(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/combobox': 3.13.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/data@3.11.4(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/data@3.11.7(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18955,7 +18945,7 @@ snapshots:
       '@react-stately/overlays': 3.6.11(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/datepicker': 3.8.3(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18965,13 +18955,13 @@ snapshots:
 
   '@react-stately/form@3.0.5(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/form@3.0.6(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18980,7 +18970,7 @@ snapshots:
       '@react-stately/collections': 3.11.0(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -18990,7 +18980,7 @@ snapshots:
       '@react-stately/table': 3.12.2(react@18.2.0)
       '@react-stately/virtualizer': 3.7.1(react@18.2.0)
       '@react-types/grid': 3.2.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/table': 3.10.1(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -19000,7 +18990,7 @@ snapshots:
       '@react-stately/collections': 3.11.0(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19008,7 +18998,7 @@ snapshots:
     dependencies:
       '@react-stately/overlays': 3.6.11(react@18.2.0)
       '@react-types/menu': 3.9.12(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19024,7 +19014,7 @@ snapshots:
       '@react-stately/form': 3.0.6(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/radio': 3.8.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19034,7 +19024,7 @@ snapshots:
       '@react-stately/list': 3.11.0(react@18.2.0)
       '@react-stately/overlays': 3.6.11(react@18.2.0)
       '@react-types/select': 3.9.7(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19042,14 +19032,14 @@ snapshots:
     dependencies:
       '@react-stately/collections': 3.11.0(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/slider@3.5.8(react@18.2.0)':
     dependencies:
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/slider': 3.7.6(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -19062,7 +19052,7 @@ snapshots:
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/table': 3.10.2(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -19075,7 +19065,7 @@ snapshots:
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/table': 3.10.2(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -19083,7 +19073,7 @@ snapshots:
   '@react-stately/tabs@3.6.10(react@18.2.0)':
     dependencies:
       '@react-stately/list': 3.11.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@react-types/tabs': 3.3.10(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
@@ -19115,7 +19105,7 @@ snapshots:
       '@react-stately/collections': 3.10.9(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-stately/utils': 3.10.3(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19124,7 +19114,7 @@ snapshots:
       '@react-stately/collections': 3.11.0(react@18.2.0)
       '@react-stately/selection': 3.17.0(react@18.2.0)
       '@react-stately/utils': 3.10.4(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
@@ -19151,42 +19141,42 @@ snapshots:
   '@react-stately/virtualizer@3.7.1(react@18.2.0)':
     dependencies:
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-stately/virtualizer@4.1.0(react@18.2.0)':
     dependencies:
       '@react-aria/utils': 3.26.0(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       '@swc/helpers': 0.5.15
       react: 18.2.0
 
   '@react-types/accordion@3.0.0-alpha.24(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/breadcrumbs@3.7.8(react@18.2.0)':
     dependencies:
       '@react-types/link': 3.5.8(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/button@3.10.0(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/calendar@3.4.10(react@18.2.0)':
     dependencies:
       '@internationalized/date': 3.5.6
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/checkbox@3.8.4(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/checkbox@3.9.0(react@18.2.0)':
@@ -19196,7 +19186,7 @@ snapshots:
 
   '@react-types/combobox@3.13.0(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/datepicker@3.8.3(react@18.2.0)':
@@ -19204,13 +19194,13 @@ snapshots:
       '@internationalized/date': 3.5.6
       '@react-types/calendar': 3.4.10(react@18.2.0)
       '@react-types/overlays': 3.8.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/dialog@3.5.13(react@18.2.0)':
     dependencies:
       '@react-types/overlays': 3.8.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/form@3.7.8(react@18.2.0)':
@@ -19220,61 +19210,53 @@ snapshots:
 
   '@react-types/grid@3.2.8(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/grid@3.2.9(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/link@3.5.7(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/link@3.5.8(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/listbox@3.5.2(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/menu@3.9.12(react@18.2.0)':
     dependencies:
       '@react-types/overlays': 3.8.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/overlays@3.8.10(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/progress@3.5.7(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/radio@3.8.4(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/select@3.9.7(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
-      react: 18.2.0
-
-  '@react-types/shared@3.24.1(react@18.2.0)':
-    dependencies:
-      react: 18.2.0
-
-  '@react-types/shared@3.25.0(react@18.2.0)':
-    dependencies:
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/shared@3.26.0(react@18.2.0)':
@@ -19283,45 +19265,45 @@ snapshots:
 
   '@react-types/slider@3.7.6(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/switch@3.5.6(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/table@3.10.1(react@18.2.0)':
     dependencies:
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/table@3.10.2(react@18.2.0)':
     dependencies:
       '@react-types/grid': 3.2.9(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/tabs@3.3.10(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/textfield@3.9.3(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.24.1(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/textfield@3.9.7(react@18.2.0)':
     dependencies:
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@react-types/tooltip@3.4.12(react@18.2.0)':
     dependencies:
       '@react-types/overlays': 3.8.10(react@18.2.0)
-      '@react-types/shared': 3.25.0(react@18.2.0)
+      '@react-types/shared': 3.26.0(react@18.2.0)
       react: 18.2.0
 
   '@rehooks/local-storage@2.4.5(react@18.2.0)':


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a missing dependency issue by adding `react-types` to enhance functionality and type safety.

- **New Features**
	- Updated the dependency `@react-types/shared` to version `3.26.0` across multiple packages, improving overall functionality and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->