### PR TITLE
fix(checkbox, radio, select): missing data pressed attribute due to labelProps

### DIFF
--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -195,6 +195,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
 
   const {
     inputProps,
+    labelProps,
     isSelected,
     isDisabled,
     isReadOnly,
@@ -277,7 +278,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       "data-readonly": dataAttr(inputProps.readOnly),
       "data-focus-visible": dataAttr(isFocusVisible),
       "data-indeterminate": dataAttr(isIndeterminate),
-      ...mergeProps(hoverProps, otherProps),
+      ...mergeProps(hoverProps, labelProps, otherProps),
     };
   }, [
     slots,

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -115,7 +115,7 @@ export function useRadio(props: UseRadioProps) {
     descriptionId,
   ]);
 
-  const {inputProps, isDisabled, isSelected, isPressed} = useReactAriaRadio(
+  const {inputProps, labelProps, isDisabled, isSelected, isPressed} = useReactAriaRadio(
     {
       value,
       children: typeof children === "function" ? true : children,
@@ -166,7 +166,7 @@ export function useRadio(props: UseRadioProps) {
         "data-hover-unselected": dataAttr(isHovered && !isSelected),
         "data-readonly": dataAttr(inputProps.readOnly),
         "aria-required": dataAttr(isRequired),
-        ...mergeProps(hoverProps, otherProps),
+        ...mergeProps(hoverProps, labelProps, otherProps),
       };
     },
     [

--- a/packages/components/switch/src/use-switch.ts
+++ b/packages/components/switch/src/use-switch.ts
@@ -155,7 +155,11 @@ export function useSwitch(originalProps: UseSwitchProps = {}) {
     state.setSelected(isInputRefChecked);
   }, [inputRef.current]);
 
-  const {inputProps, isPressed, isReadOnly} = useReactAriaSwitch(ariaSwitchProps, state, inputRef);
+  const {inputProps, labelProps, isPressed, isReadOnly} = useReactAriaSwitch(
+    ariaSwitchProps,
+    state,
+    inputRef,
+  );
   const {focusProps, isFocused, isFocusVisible} = useFocusRing({autoFocus: inputProps.autoFocus});
   const {hoverProps, isHovered} = useHover({
     isDisabled: inputProps.disabled,
@@ -180,7 +184,7 @@ export function useSwitch(originalProps: UseSwitchProps = {}) {
 
   const getBaseProps: PropGetter = (props) => {
     return {
-      ...mergeProps(hoverProps, otherProps, props),
+      ...mergeProps(hoverProps, labelProps, otherProps, props),
       ref: domRef,
       className: slots.base({class: clsx(baseStyles, props?.className)}),
       "data-disabled": dataAttr(isDisabled),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4260

## 📝 Description

- affects `Checkbox`, `Radio`, and `Switch`
- focus visible state should not be applied on pointer click
- missing `data-pressed` attribute

https://github.com/user-attachments/assets/c9a9583d-2ac5-41a3-b03e-a42ca3354c71



## 🚀 New behavior

- affects `Checkbox`, `Radio`, and `Switch`
- fixes focus visible state on pointer click
- fixes `data-pressed` not being applied


https://github.com/user-attachments/assets/e38f4525-940b-4094-84fe-3fb4e790cf39



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

- caused by #4220
- affects `Checkbox`, `Radio`, and `Switch` components
- occurs when parent container is focusable (see [sandbox](https://codesandbox.io/p/github/Peterl561/4260/main?file=%2Fsrc%2FApp.tsx))
- the aforementioned PR removed `pressProps` returned by `usePress` from `getBaseProps`
- this led to 2 issues
  - removed `onMouseDown` handlers from base component, which was calling `e.preventDefault()`
  - caused `data-pressed` attribute to no longer be applied
- to fix this, we can use `labelProps` from the affected components' respective hooks to replace the removed `pressProps`
  - this works because `labelProps` is actually just `pressProps` from the `usePress` called internally in `react-aria`'s component hooks
  - it also does not regress the previous issue (#4210) addressed in the causative PR