### PR TITLE
fix: prevent multiple parent focus events on click

### DIFF
--- a/.changeset/tricky-panthers-build.md
+++ b/.changeset/tricky-panthers-build.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/checkbox": patch
+"@nextui-org/switch": patch
+"@nextui-org/radio": patch
+---
+
+fixed checkbox, radio, and switch triggering focus on focusable parent multiple times

--- a/.changeset/tricky-panthers-build.md
+++ b/.changeset/tricky-panthers-build.md
@@ -4,4 +4,4 @@
 "@nextui-org/radio": patch
 ---
 
-fixed checkbox, radio, and switch triggering focus on focusable parent multiple times
+fixed checkbox, radio, and switch triggering focus on focusable parent multiple times (#4260)

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -90,6 +90,22 @@ describe("Checkbox", () => {
     expect(onFocus).toHaveBeenCalled();
   });
 
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <Checkbox data-testid="checkbox-test">Checkbox</Checkbox>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("checkbox-test");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {container} = render(
       <Checkbox isRequired validationBehavior="native">

--- a/packages/components/checkbox/src/use-checkbox.ts
+++ b/packages/components/checkbox/src/use-checkbox.ts
@@ -264,6 +264,16 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
 
   const baseStyles = clsx(classNames?.base, className);
 
+  const mouseProps = useMemo(
+    () => ({
+      onMouseDown: (e: React.MouseEvent<HTMLLabelElement>) => {
+        // prevent parent from being focused
+        e.preventDefault();
+      },
+    }),
+    [],
+  );
+
   const getBaseProps: PropGetter = useCallback(() => {
     return {
       ref: domRef,
@@ -277,7 +287,7 @@ export function useCheckbox(props: UseCheckboxProps = {}) {
       "data-readonly": dataAttr(inputProps.readOnly),
       "data-focus-visible": dataAttr(isFocusVisible),
       "data-indeterminate": dataAttr(isIndeterminate),
-      ...mergeProps(hoverProps, otherProps),
+      ...mergeProps(hoverProps, mouseProps, otherProps),
     };
   }, [
     slots,

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -142,6 +142,26 @@ describe("Radio", () => {
     expect(onFocus).toHaveBeenCalled();
   });
 
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <RadioGroup defaultValue="1" label="Options">
+          <Radio data-testid="radio-test-1" value="1">
+            Option 1
+          </Radio>
+        </RadioGroup>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("radio-test-1");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {getByRole, getAllByRole} = render(
       <RadioGroup isRequired label="Options" validationBehavior="native">

--- a/packages/components/radio/src/use-radio.ts
+++ b/packages/components/radio/src/use-radio.ts
@@ -150,6 +150,16 @@ export function useRadio(props: UseRadioProps) {
 
   const baseStyles = clsx(classNames?.base, className);
 
+  const mouseProps = useMemo(
+    () => ({
+      onMouseDown: (e: React.MouseEvent<HTMLLabelElement>) => {
+        // prevent parent from being focused
+        e.preventDefault();
+      },
+    }),
+    [],
+  );
+
   const getBaseProps: PropGetter = useCallback(
     (props = {}) => {
       return {
@@ -166,7 +176,7 @@ export function useRadio(props: UseRadioProps) {
         "data-hover-unselected": dataAttr(isHovered && !isSelected),
         "data-readonly": dataAttr(inputProps.readOnly),
         "aria-required": dataAttr(isRequired),
-        ...mergeProps(hoverProps, otherProps),
+        ...mergeProps(hoverProps, mouseProps, otherProps),
       };
     },
     [

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -184,6 +184,22 @@ describe("Switch", () => {
     expect(wrapper.getByTestId("start-icon")).toBeInTheDocument();
     expect(wrapper.getByTestId("end-icon")).toBeInTheDocument();
   });
+
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <Switch data-testid="switch-test">Switch</Switch>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("switch-test");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("Switch with React Hook Form", () => {

--- a/packages/components/switch/src/use-switch.ts
+++ b/packages/components/switch/src/use-switch.ts
@@ -178,9 +178,19 @@ export function useSwitch(originalProps: UseSwitchProps = {}) {
 
   const baseStyles = clsx(classNames?.base, className);
 
+  const mouseProps = useMemo(
+    () => ({
+      onMouseDown: (e: React.MouseEvent<HTMLLabelElement>) => {
+        // prevent parent from being focused
+        e.preventDefault();
+      },
+    }),
+    [],
+  );
+
   const getBaseProps: PropGetter = (props) => {
     return {
-      ...mergeProps(hoverProps, otherProps, props),
+      ...mergeProps(hoverProps, mouseProps, otherProps, props),
       ref: domRef,
       className: slots.base({class: clsx(baseStyles, props?.className)}),
       "data-disabled": dataAttr(isDisabled),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4260

## 📝 Description

- caused by #4220
- affects `Checkbox`, `Radio`, and `Switch` components
- occurs when parent container is focusable (see [sandbox](https://codesandbox.io/p/github/Peterl561/4260/main?file=%2Fsrc%2FApp.tsx))
- need to call `preventDefault` to prevent parent focus from firing multiple times

## ⛳️ Current behavior (updates)


https://github.com/user-attachments/assets/11655fd6-a81c-4e53-b7ba-dda01fb51d62



## 🚀 New behavior


https://github.com/user-attachments/assets/8ab62565-d06a-4a62-976c-80bd9a6e3f46



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved focus behavior for checkbox, radio, and switch components to enhance user experience by preventing unnecessary focus events.
- **Bug Fixes**
	- Resolved an issue where focus was incorrectly triggered multiple times on parent elements when interacting with checkbox, radio, and switch components.
- **Tests**
	- Added new test cases to verify correct focus behavior for checkbox, radio, and switch components upon interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->