### PR TITLE
fix(dropdown): unnecessary ref in dropdown

### DIFF
--- a/.changeset/soft-pugs-travel.md
+++ b/.changeset/soft-pugs-travel.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/dropdown": patch
+---
+
+fix unnecessary ref in dropdown (#4245)

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -164,18 +164,12 @@ export function useDropdown(props: UseDropdownProps): UseDropdownReturn {
     };
   };
 
-  const getMenuTriggerProps: PropGetter = (
-    originalProps = {},
-    _ref: Ref<any> | null | undefined = null,
-  ) => {
+  const getMenuTriggerProps: PropGetter = (originalProps = {}) => {
     // These props are not needed for the menu trigger since it is handled by the popover trigger.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {onPress, onPressStart, ...otherMenuTriggerProps} = menuTriggerProps;
 
-    return {
-      ...mergeProps(otherMenuTriggerProps, {isDisabled}, originalProps),
-      ref: mergeRefs(_ref, triggerRef),
-    };
+    return mergeProps(otherMenuTriggerProps, {isDisabled}, originalProps);
   };
 
   const getMenuProps = <T extends object>(
@@ -225,5 +219,5 @@ export type UseDropdownReturn = {
   disableAnimation: boolean;
   getPopoverProps: PropGetter;
   getMenuProps: <T extends object>(props?: Partial<MenuProps<T>>, ref?: Ref<any>) => MenuProps;
-  getMenuTriggerProps: (props?: any, ref?: Ref<any>) => any;
+  getMenuTriggerProps: (props?: any) => any;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4245

## 📝 Description

<!--- Add a brief description -->

In https://github.com/nextui-org/nextui/pull/4198, `forwardRef` has been removed from `PopoverTrigger` since the ref is not used there. The reported warning was caused by passing ref to PopoverTrigger, which no longer accepts. Since the ref will not be used, this PR is to avoid passing the unnecessary ref to PopoverTrigger.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the dropdown component by removing an unnecessary reference, improving functionality and performance.

- **New Features**
	- Simplified the `getMenuTriggerProps` method in the dropdown component for easier usage and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->