### PR TITLE
fix(system-rsc): extendVariants typescript type

### DIFF
--- a/.changeset/twelve-ducks-thank.md
+++ b/.changeset/twelve-ducks-thank.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/system-rsc": minor
+---
+
+Fix data type returned by the extendVariants function (#4269)

--- a/.changeset/twelve-ducks-thank.md
+++ b/.changeset/twelve-ducks-thank.md
@@ -1,5 +1,5 @@
 ---
-"@nextui-org/system-rsc": minor
+"@nextui-org/system-rsc": patch
 ---
 
 Fix data type returned by the extendVariants function (#4269)

--- a/packages/core/system-rsc/src/extend-variants.d.ts
+++ b/packages/core/system-rsc/src/extend-variants.d.ts
@@ -91,7 +91,7 @@ export type ExtendVariants = {
     },
     opts?: Options,
   ): ForwardRefRenderFunction<
-    ReactElement,
+    ReactElement<any>,
     {
       [key in keyof CP | keyof V]?:
         | (key extends keyof CP ? CP[key] : never)

--- a/packages/core/system-rsc/src/extend-variants.d.ts
+++ b/packages/core/system-rsc/src/extend-variants.d.ts
@@ -1,5 +1,11 @@
 import type {ClassValue, StringToBoolean, OmitUndefined, ClassProp} from "tailwind-variants";
-import type {ForwardRefRenderFunction, JSXElementConstructor, ReactElement} from "react";
+import type {
+  ForwardRefExoticComponent,
+  JSXElementConstructor,
+  PropsWithoutRef,
+  ReactElement,
+  RefAttributes,
+} from "react";
 
 type SlotsClassValue<S> = {
   [K in keyof S]?: ClassValue;
@@ -90,13 +96,13 @@ export type ExtendVariants = {
       slots?: S;
     },
     opts?: Options,
-  ): ForwardRefRenderFunction<
-    ReactElement<any>,
-    {
+  ): ForwardRefExoticComponent<
+    PropsWithoutRef<{
       [key in keyof CP | keyof V]?:
         | (key extends keyof CP ? CP[key] : never)
         | (key extends keyof V ? StringToBoolean<keyof V[key]> : never);
-    }
+    }> &
+      RefAttributes<ReactElement>
   >;
 };
 


### PR DESCRIPTION
Closes #4269

## 📝 Description

This request solves the problem of the data type returned by the `extendVariants` function.

## ⛳️ Current behavior (updates)

In the current implementation, the result of the `extendVariants` function is the `ForwardRefRenderFunction` data type.

## 🚀 New behavior

Because the resolution of the function is `forwardRef`, therefore it is necessary to return the `ForwardRefExoticComponent` data type.

## 💣 Is this a breaking change (Yes/No):

These changes work with `react/types` versions 18 and 19. And they don't break backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for components, improving clarity and type safety.
	- Updated `ExtendVariants` type to streamline props structure.
- **Bug Fixes**
	- Corrected the return type of the `extendVariants` function to ensure it meets expected standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->