### PR TITLE
fix: autofocus the input-otp when auto-focus prop is passed

### DIFF
--- a/.changeset/smooth-trainers-walk.md
+++ b/.changeset/smooth-trainers-walk.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input-otp": patch
+---
+
+Fixing the autofocus functionality in input-otp component(#4250)

--- a/packages/components/input-otp/__tests__/input-otp.test.tsx
+++ b/packages/components/input-otp/__tests__/input-otp.test.tsx
@@ -168,6 +168,21 @@ describe("InputOtp Component", () => {
     expect(onComplete).toHaveBeenCalledTimes(2);
     expect(onComplete).toHaveBeenCalledWith("1234");
   });
+
+  it("should autofocus when autofocus prop is passed.", async () => {
+    // eslint-disable-next-line jsx-a11y/no-autofocus
+    render(<InputOtp autoFocus length={4} />);
+    const segments = screen.getAllByRole("presentation");
+
+    expect(segments[0]).toHaveAttribute("data-focus", "true");
+  });
+
+  it("should not autofocus when autofocus prop is not passed.", async () => {
+    render(<InputOtp length={4} />);
+    const segments = screen.getAllByRole("presentation");
+
+    expect(segments[0]).not.toHaveAttribute("data-focus", "true");
+  });
 });
 
 describe("InputOtp with react-hook-form", () => {

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -230,6 +230,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
         ref: inputRef,
         name: name,
         value: value,
+        autoFocus: originalProps.autoFocus,
         onChange: setValue,
         onBlur: chain(focusProps.onBlur, props?.onBlur),
         onComplete: onComplete,


### PR DESCRIPTION
Closes #4250

## 📝 Description

Fixes the autofocus functionality in input-otp component## ⛳️ Current behavior (updates)

## Current behavior


https://github.com/user-attachments/assets/bddd90c6-d83f-4ecc-bf7d-4037ed92dd87



## 🚀 New behavior


https://github.com/user-attachments/assets/d77c19bc-cbc3-4dd4-9f5a-31eed5d3c40d



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
