### PR TITLE
fix: fixing the non selectable issue

### DIFF
--- a/.changeset/eighty-fireants-give.md
+++ b/.changeset/eighty-fireants-give.md
@@ -1,0 +1,7 @@
+---
+"@nextui-org/checkbox": patch
+"@nextui-org/switch": patch
+"@nextui-org/radio": patch
+---
+
+Fixing the non touchable components issue(#4252)

--- a/apps/docs/content/components/checkbox/custom-implementation.raw.jsx
+++ b/apps/docs/content/components/checkbox/custom-implementation.raw.jsx
@@ -1,4 +1,4 @@
-import {useCheckbox, Chip, VisuallyHidden, tv} from "@nextui-org/react";
+import {useCheckbox, Chip, tv} from "@nextui-org/react";
 
 export const CheckIcon = (props) => {
   return (
@@ -50,9 +50,7 @@ export default function App() {
 
   return (
     <label {...getBaseProps()}>
-      <VisuallyHidden>
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
       <Chip
         classNames={{
           base: styles.base(),

--- a/apps/docs/content/components/radio-group/custom-impl.raw.jsx
+++ b/apps/docs/content/components/radio-group/custom-impl.raw.jsx
@@ -1,4 +1,4 @@
-import {RadioGroup, useRadio, VisuallyHidden, cn} from "@nextui-org/react";
+import {RadioGroup, useRadio, cn} from "@nextui-org/react";
 
 export const CustomRadio = (props) => {
   const {
@@ -22,9 +22,7 @@ export const CustomRadio = (props) => {
         "data-[selected=true]:border-primary",
       )}
     >
-      <VisuallyHidden>
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
       <span {...getWrapperProps()}>
         <span {...getControlProps()} />
       </span>

--- a/apps/docs/content/components/radio-group/custom-impl.raw.tsx
+++ b/apps/docs/content/components/radio-group/custom-impl.raw.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {RadioGroup, useRadio, VisuallyHidden, RadioProps, cn} from "@nextui-org/react";
+import {RadioGroup, useRadio, RadioProps, cn} from "@nextui-org/react";
 
 export const CustomRadio = (props: RadioProps) => {
   const {
@@ -18,14 +18,12 @@ export const CustomRadio = (props: RadioProps) => {
     <Component
       {...getBaseProps()}
       className={cn(
-        "group inline-flex items-center justify-between hover:bg-content2 flex-row-reverse",
+        "relative group inline-flex items-center justify-between hover:bg-content2 flex-row-reverse",
         "max-w-[300px] cursor-pointer border-2 border-default rounded-lg gap-4 p-4",
         "data-[selected=true]:border-primary",
       )}
     >
-      <VisuallyHidden>
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
       <span {...getWrapperProps()}>
         <span {...getControlProps()} />
       </span>

--- a/apps/docs/content/components/switch/custom-impl.raw.jsx
+++ b/apps/docs/content/components/switch/custom-impl.raw.jsx
@@ -1,4 +1,4 @@
-import {VisuallyHidden, useSwitch} from "@nextui-org/react";
+import {useSwitch} from "@nextui-org/react";
 
 export const MoonIcon = (props) => {
   return (
@@ -45,9 +45,7 @@ const ThemeSwitch = (props) => {
   return (
     <div className="flex flex-col gap-2">
       <Component {...getBaseProps()}>
-        <VisuallyHidden>
-          <input {...getInputProps()} />
-        </VisuallyHidden>
+        <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
         <div
           {...getWrapperProps()}
           className={slots.wrapper({

--- a/apps/docs/content/components/switch/custom-impl.raw.tsx
+++ b/apps/docs/content/components/switch/custom-impl.raw.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {useSwitch, VisuallyHidden, SwitchProps} from "@nextui-org/react";
+import {useSwitch, SwitchProps} from "@nextui-org/react";
 
 export const MoonIcon = (props) => {
   return (
@@ -46,9 +46,7 @@ const ThemeSwitch = (props: SwitchProps) => {
   return (
     <div className="flex flex-col gap-2">
       <Component {...getBaseProps()}>
-        <VisuallyHidden>
-          <input {...getInputProps()} />
-        </VisuallyHidden>
+        <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
         <div
           {...getWrapperProps()}
           className={slots.wrapper({

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -90,6 +90,22 @@ describe("Checkbox", () => {
     expect(onFocus).toHaveBeenCalled();
   });
 
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <Checkbox data-testid="checkbox-test">Checkbox</Checkbox>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("checkbox-test");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {container} = render(
       <Checkbox isRequired validationBehavior="native">

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -1,5 +1,4 @@
 import {forwardRef} from "@nextui-org/system";
-import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {cloneElement, ReactElement} from "react";
 
 import {UseCheckboxProps, useCheckbox} from "./use-checkbox";
@@ -26,9 +25,7 @@ const Checkbox = forwardRef<"input", CheckboxProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden elementType="span">
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} />
       <span {...getWrapperProps()}>{clonedIcon}</span>
       {children && <span {...getLabelProps()}>{children}</span>}
     </Component>

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -142,6 +142,26 @@ describe("Radio", () => {
     expect(onFocus).toHaveBeenCalled();
   });
 
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <RadioGroup defaultValue="1" label="Options">
+          <Radio data-testid="radio-test-1" value="1">
+            Option 1
+          </Radio>
+        </RadioGroup>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("radio-test-1");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
   it("should have required attribute when isRequired with native validationBehavior", () => {
     const {getByRole, getAllByRole} = render(
       <RadioGroup isRequired label="Options" validationBehavior="native">

--- a/packages/components/radio/src/radio.tsx
+++ b/packages/components/radio/src/radio.tsx
@@ -1,5 +1,4 @@
 import {forwardRef} from "@nextui-org/system";
-import {VisuallyHidden} from "@react-aria/visually-hidden";
 
 import {UseRadioProps, useRadio} from "./use-radio";
 
@@ -21,9 +20,7 @@ const Radio = forwardRef<"input", RadioProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden elementType="span">
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} />
       <span {...getWrapperProps()}>
         <span {...getControlProps()} />
       </span>

--- a/packages/components/radio/stories/radio.stories.tsx
+++ b/packages/components/radio/stories/radio.stories.tsx
@@ -2,7 +2,6 @@ import type {ValidationResult} from "@react-types/shared";
 
 import React from "react";
 import {Meta} from "@storybook/react";
-import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {radio, button} from "@nextui-org/theme";
 import {clsx} from "@nextui-org/shared-utils";
 import {Form} from "@nextui-org/form";
@@ -421,15 +420,13 @@ const RadioCard = (props: RadioProps) => {
     <Component
       {...getBaseProps()}
       className={clsx(
-        "group inline-flex items-center justify-between hover:bg-content2 flex-row-reverse max-w-[300px] cursor-pointer border-2 border-default rounded-lg gap-4 p-4",
+        "relative group inline-flex items-center justify-between hover:bg-content2 flex-row-reverse max-w-[300px] cursor-pointer border-2 border-default rounded-lg gap-4 p-4",
         {
           "border-primary": isSelected,
         },
       )}
     >
-      <VisuallyHidden>
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
       <span {...getWrapperProps()}>
         <span {...getControlProps()} />
       </span>

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -184,6 +184,22 @@ describe("Switch", () => {
     expect(wrapper.getByTestId("start-icon")).toBeInTheDocument();
     expect(wrapper.getByTestId("end-icon")).toBeInTheDocument();
   });
+
+  it("should trigger focus on focusable parent once after click", async () => {
+    const onFocus = jest.fn();
+
+    const wrapper = render(
+      <div tabIndex={-1} onFocus={onFocus}>
+        <Switch data-testid="switch-test">Switch</Switch>
+      </div>,
+    );
+
+    const label = wrapper.getByTestId("switch-test");
+
+    await user.click(label);
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("Switch with React Hook Form", () => {

--- a/packages/components/switch/src/switch.tsx
+++ b/packages/components/switch/src/switch.tsx
@@ -1,4 +1,3 @@
-import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {cloneElement, ReactElement} from "react";
 import {forwardRef} from "@nextui-org/system";
 
@@ -35,9 +34,7 @@ const Switch = forwardRef<"input", SwitchProps>((props, ref) => {
 
   return (
     <Component {...getBaseProps()}>
-      <VisuallyHidden elementType="span">
-        <input {...getInputProps()} />
-      </VisuallyHidden>
+      <input {...getInputProps()} />
       <span {...getWrapperProps()}>
         {startContent && clonedStartContent}
         <span {...getThumbProps()}>{thumbIcon && clonedThumbIcon}</span>

--- a/packages/components/switch/stories/switch.stories.tsx
+++ b/packages/components/switch/stories/switch.stories.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import {Meta} from "@storybook/react";
 import {toggle} from "@nextui-org/theme";
-import {VisuallyHidden} from "@react-aria/visually-hidden";
 import {SunFilledIcon, MoonFilledIcon} from "@nextui-org/shared-icons";
 import {clsx} from "@nextui-org/shared-utils";
 import {button} from "@nextui-org/theme";
@@ -112,9 +111,7 @@ const CustomWithHooksTemplate = (args: SwitchProps) => {
   return (
     <div className="flex flex-col gap-2">
       <Component {...getBaseProps()}>
-        <VisuallyHidden>
-          <input {...getInputProps()} />
-        </VisuallyHidden>
+        <input {...getInputProps()} className="absolute inset-0 z-50 cursor-pointer opacity-0" />
         <div
           {...getWrapperProps()}
           className={slots.wrapper({


### PR DESCRIPTION
- Closes #4252
- Closes #4260

## 📝 Description

* The pr reverts https://github.com/nextui-org/nextui/pull/4220
* There will be issue in touch due to usePress update. The usePress update prevents the default behavior of the touch to tackle the chromium bug ([ref](https://github.com/adobe/react-spectrum/blob/1d5def8a5fc533649a0fabbef0420c2d84978d05/packages/%40react-aria/interactions/src/usePress.ts#L528-L533)). Due to this the touch events were not triggering.
* The pr makes changes to fix the above issue. (the aprroach is similar to one I am planning to use in the rating component)

## ⛳️ Current behavior (updates)

* Multiselect on table not functioning
* Parent was receiving more than one click.

## 🚀 New behavior

* Fixed: Multiselect on table not functioning
* Fixed: Parent was receiving more than one click.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced touch responsiveness for Checkbox, Switch, and Radio components.
  
- **Bug Fixes**
  - Improved accessibility by removing the `VisuallyHidden` component from Checkbox, Switch, and Radio implementations.

- **Tests**
  - Added new test cases to verify focus behavior for Checkbox, Switch, and Radio components.

- **Documentation**
  - Updated stories for Checkbox, Switch, and Radio components to reflect recent changes and improve usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->