### PR TITLE
Export useDisclosure with  `@nextui-org/drawer`

### DIFF
--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -7,6 +7,7 @@ export type {DrawerProps} from "./drawer";
 
 // export hooks
 export {useDrawer} from "./use-drawer";
+export {useDisclosure} from "@nextui-org/use-disclosure";
 
 // export component
 export {Drawer};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Export useDisclosure with `@nextui-org/drawer`

## ⛳️ Current behavior (updates)

the useDisclosure can currently be only imported from `@nextui-org/modal` or `@nextui-org/use-disclosure`

## 🚀 New behavior

useDisclosure is now exported with `@nextui-org/drawer` so it becomes completely independent from other components like the `nextui-org/modal`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `useDisclosure` hook for enhanced functionality in the drawer component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->