### PR TITLE
chore(drawer): export drawer children props

### DIFF
--- a/.changeset/forty-ducks-brake.md
+++ b/.changeset/forty-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/drawer": patch
+---
+
+Export useDisclosure and Drawer children props from `@nextui-org/drawer`

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -20,10 +20,11 @@ export type {
   ModalBodyProps as DrawerBodyProps,
   ModalFooterProps as DrawerFooterProps,
   UseDisclosureProps,
-}
+};
 
 // export hooks
 export {useDrawer} from "./use-drawer";
+export {useDisclosure} from "@nextui-org/use-disclosure";
 
 // export component
 export {Drawer};

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -7,7 +7,6 @@ import {
   ModalHeaderProps,
   ModalBodyProps,
   ModalFooterProps,
-  UseDisclosureProps,
 } from "@nextui-org/modal";
 
 import Drawer from "./drawer";
@@ -19,7 +18,6 @@ export type {
   ModalHeaderProps as DrawerHeaderProps,
   ModalBodyProps as DrawerBodyProps,
   ModalFooterProps as DrawerFooterProps,
-  UseDisclosureProps,
 };
 
 // export hooks

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -1,9 +1,26 @@
-import {ModalHeader, ModalBody, ModalFooter, ModalContent} from "@nextui-org/modal";
+import {
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalContent,
+  ModalContentProps,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
+  UseDisclosureProps,
+} from "@nextui-org/modal";
 
 import Drawer from "./drawer";
 
 // export types
 export type {DrawerProps} from "./drawer";
+export type {
+  ModalContentProps as DrawerContentProps,
+  ModalHeaderProps as DrawerHeaderProps,
+  ModalBodyProps as DrawerBodyProps,
+  ModalFooterProps as DrawerFooterProps,
+  UseDisclosureProps,
+}
 
 // export hooks
 export {useDrawer} from "./use-drawer";

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -24,7 +24,6 @@ export type {
 
 // export hooks
 export {useDrawer} from "./use-drawer";
-export {useDisclosure} from "@nextui-org/use-disclosure";
 
 // export component
 export {Drawer};

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -3,10 +3,10 @@ import {
   ModalBody,
   ModalFooter,
   ModalContent,
-  ModalContentProps,
-  ModalHeaderProps,
-  ModalBodyProps,
-  ModalFooterProps,
+  type ModalContentProps,
+  type ModalHeaderProps,
+  type ModalBodyProps,
+  type ModalFooterProps,
 } from "@nextui-org/modal";
 
 import Drawer from "./drawer";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Export DrawerContentProps, DrawerHeaderProps, DrawerBodyProps, DrawerFooterProps and UseDisclosureProps from `@nextui-org/drawer`

## ⛳️ Current behavior (updates)

The drawer children props aren't exported

## 🚀 New behavior

the drawer children props are exported

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for the Drawer component, including new props for content, header, body, and footer.
	- Introduced a new `useDisclosure` hook to improve modal functionalities.
- **Improvements**
	- Clearer usage of types with updated aliases for better integration with the Drawer component.
	- Enhanced accessibility of children properties for the Drawer component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->