### PR TITLE
fix(shared-utils): process?.env will not transform to env by transcompiler

### DIFF
--- a/.changeset/clever-teachers-live.md
+++ b/.changeset/clever-teachers-live.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/shared-utils": patch
+---
+
+fix process is not defined

--- a/packages/utilities/shared-utils/src/console.ts
+++ b/packages/utilities/shared-utils/src/console.ts
@@ -8,7 +8,7 @@ export function warn(message: string, component?: string, ...args: any[]) {
   if (warningStack[log]) return;
   warningStack[log] = true;
 
-  if (process?.env?.NODE_ENV !== "production") {
+  if (process.env.NODE_ENV !== "production") {
     // eslint-disable-next-line no-console
     return console.warn(log, args);
   }


### PR DESCRIPTION
When `warn` message such as button `onClick` deprecated warn, throw error when there is no global process var, transcompiler will not transform `process?.env` to env string with `?` in it.

## 📝 Description
The `warn` method cause page error because `process` is not defined.

## ⛳️ Current behavior (updates)
Page break render

## 🚀 New behavior
Page correct render

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the warning function to ensure it raises an error if the process object is undefined, improving stability in various environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->