### PR TITLE
fix(deps): bump `@nextui-org/theme` in peerDependencies

### DIFF
--- a/.changeset/famous-avocados-run.md
+++ b/.changeset/famous-avocados-run.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/switch": patch
+---
+
+bump `@nextui-org/theme` in peerDependencies

--- a/.changeset/famous-avocados-run.md
+++ b/.changeset/famous-avocados-run.md
@@ -1,5 +1,7 @@
 ---
+"@nextui-org/checkbox": patch
 "@nextui-org/switch": patch
+"@nextui-org/radio": patch
 ---
 
 bump `@nextui-org/theme` in peerDependencies

--- a/packages/components/checkbox/package.json
+++ b/packages/components/checkbox/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "@nextui-org/system": ">=2.4.0",
-    "@nextui-org/theme": ">=2.4.0",
+    "@nextui-org/theme": ">=2.4.3",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
   },

--- a/packages/components/radio/package.json
+++ b/packages/components/radio/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "@nextui-org/theme": ">=2.4.0",
+    "@nextui-org/theme": ">=2.4.3",
     "@nextui-org/system": ">=2.4.0"
   },
   "dependencies": {

--- a/packages/components/switch/package.json
+++ b/packages/components/switch/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0",
-    "@nextui-org/theme": ">=2.4.0",
+    "@nextui-org/theme": ">=2.4.3",
     "@nextui-org/system": ">=2.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4332

## 📝 Description

In PR https://github.com/nextui-org/nextui/pull/4311, a new slot `hiddenInput` has been added to checkbox, radio, toggle in theme package. Therefore, the corresponding `peerDependencies` should be also updated so that users can upgrade `@nextui-org/theme` package automatically.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

when users run `nextui upgrade --all`, `@nextui-org/theme` is not upgraded because of the peerDependencies.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated the peer dependency for the theme package to ensure compatibility.

- **Bug Fixes**
	- Adjusted version constraints for the theme package to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->