### PR TITLE
fix(input-otp): filter disallowed characters from value prop

### DIFF
--- a/.changeset/silent-jars-grow.md
+++ b/.changeset/silent-jars-grow.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input-otp": patch
+---
+
+Change ensures that the input value does not accept any disallowed characters when the value prop contains them(#4329)

--- a/.changeset/silent-jars-grow.md
+++ b/.changeset/silent-jars-grow.md
@@ -2,4 +2,4 @@
 "@nextui-org/input-otp": patch
 ---
 
-Change ensures that the input value does not accept any disallowed characters when the value prop contains them(#4329)
+Change ensures that the input value does not accept any disallowed characters when the value prop contains them (#4329)

--- a/packages/components/input-otp/__tests__/input-otp.test.tsx
+++ b/packages/components/input-otp/__tests__/input-otp.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 
 import * as React from "react";
 import {render, renderHook, screen} from "@testing-library/react";
-import {useForm} from "react-hook-form";
+import {Controller, useForm} from "react-hook-form";
 import userEvent, {UserEvent} from "@testing-library/user-event";
 
 import {InputOtp} from "../src";
@@ -249,5 +249,39 @@ describe("InputOtp with react-hook-form", () => {
     await user.click(button);
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should work correctly wiht react-hook-form controller", async () => {
+    const {result} = renderHook(() =>
+      useForm({
+        defaultValues: {
+          withController: "",
+        },
+      }),
+    );
+
+    const {control} = result.current;
+
+    render(
+      <form>
+        <Controller
+          control={control}
+          name="withController"
+          render={({field}) => <InputOtp length={4} {...field} data-testid="input-otp" />}
+        />
+      </form>,
+    );
+
+    const inputOtp = screen.getByTestId("input-otp");
+    const input = inputOtp.querySelector("input");
+
+    if (!input) {
+      throw new Error("Input not found");
+    }
+
+    await user.click(input);
+    await user.type(input, "1nj23aa4");
+
+    expect(input).toHaveAttribute("value", "1234");
   });
 });

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -119,6 +119,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
     pasteTransformer,
     containerClassName,
     noScriptCSSFallback,
+    onChange,
     ...otherProps
   } = props;
 
@@ -209,6 +210,14 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
           }),
           filterDOMProps(props),
         ),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+          const val = e.target?.value;
+          const regex = new RegExp(allowedKeys);
+
+          if (regex.test(val)) {
+            onChange?.(e);
+          }
+        },
       };
     },
     [baseDomRef, slots, baseStyles, isDisabled, isInvalid, isRequired, isReadOnly, value, length],

--- a/packages/components/input-otp/stories/input-otp.stories.tsx
+++ b/packages/components/input-otp/stories/input-otp.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {Meta} from "@storybook/react";
 import {button, inputOtp} from "@nextui-org/theme";
-import {useForm} from "react-hook-form";
+import {Controller, useForm} from "react-hook-form";
 import {ValidationResult} from "@react-types/shared";
 import {Button} from "@nextui-org/button";
 import {Form} from "@nextui-org/form";
@@ -177,6 +177,49 @@ const WithReactHookFormTemplate = (args) => {
   );
 };
 
+const WithReactHookFormControllerTemplate = (args) => {
+  const {
+    handleSubmit,
+    control,
+    formState: {errors},
+  } = useForm({
+    defaultValues: {
+      otp: "",
+    },
+  });
+
+  const onSubmit = (data) => {
+    alert(JSON.stringify(data));
+  };
+
+  return (
+    <form className="flex flex-col gap-4 w-full max-w-[300px]" onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        control={control}
+        name="otp"
+        render={({field}) => (
+          <InputOtp
+            {...field}
+            errorMessage={errors.otp && errors.otp.message}
+            isInvalid={!!errors.otp}
+            {...args}
+          />
+        )}
+        rules={{
+          required: "OTP is required",
+          minLength: {
+            value: 4,
+            message: "Please enter a valid OTP",
+          },
+        }}
+      />
+      <Button className="max-w-fit" type="submit" variant="flat">
+        Verify OTP
+      </Button>
+    </form>
+  );
+};
+
 const ServerValidationTemplate = (args) => {
   const [serverErrors, setServerErrors] = React.useState({});
 
@@ -331,6 +374,14 @@ export const AllowedKeys = {
 
 export const WithReactHookForm = {
   render: WithReactHookFormTemplate,
+  args: {
+    ...defaultProps,
+    length: 4,
+  },
+};
+
+export const WithReactHookFormController = {
+  render: WithReactHookFormControllerTemplate,
   args: {
     ...defaultProps,
     length: 4,


### PR DESCRIPTION
Closes #4329

## 📝 Description

Change ensures that the input value does not accept any disallowed characters when the value prop contains them.

## ⛳️ Current behavior (updates)

https://github.com/user-attachments/assets/45cb3e05-908f-46d2-8c94-a83ca8acac3e

## 🚀 New behavior
* Disallowed characters typed will be avoided. 

https://github.com/user-attachments/assets/5f5dbd8c-cbbd-4ec3-8345-67b3459190a7


## 💣 Is this a breaking change (Yes/No): No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced input integrity for the OTP component by restricting disallowed characters.
  - Integrated `react-hook-form` functionality for improved form handling of the OTP input.

- **Bug Fixes**
  - Improved validation logic to ensure only allowed characters are accepted in the input.

- **Tests**
  - Added a new test case to verify that the input correctly reflects allowed characters when using `react-hook-form`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->