### PR TITLE
fix(docs): horizontal scroll triggering intersection observer

### DIFF
--- a/apps/docs/components/docs/components/codeblock.tsx
+++ b/apps/docs/components/docs/components/codeblock.tsx
@@ -99,6 +99,10 @@ const CodeBlockHighlight = ({
       ref={intersectionRef}
       style={{
         height: isVisible ? "auto" : `${height}px`,
+        // due to display: contents on the scrollable child element, this div will also scroll
+        // this causes the intersection observer to trigger if scrolled far enough horizontally
+        // set the width to fit-content to prevent this div from going off screen
+        width: "fit-content",
       }}
     >
       {isVisible ? (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- `Codeblock` disappears when out of view for performance reasons
- horizontal scrolling in `Codeblock` triggers this as well due to weird `display: contents` behavior
- fix by setting `width: fit-content` so `Codeblock` intersection observer ref remains in view when scrolled horizontally

## ⛳️ Current behavior (updates)

white border added to wrapper for reference

https://github.com/user-attachments/assets/a0b371d6-e17f-4c8a-b1d4-51dcd7ccac3a



## 🚀 New behavior

white border added to wrapper for reference

https://github.com/user-attachments/assets/78a515bf-f150-4d8e-a905-141ec60e7b82



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

I have no idea why `display: contents` is used here. Was added in [this commit](https://github.com/nextui-org/nextui/pull/3922/commits/ab1aab9cdd187aceafb6ccc8bab9bd7f98a3a391).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of code blocks with improved highlighting for inserted and deleted lines.
  
- **Bug Fixes**
	- Resolved scrolling issues by adjusting the width of the outer `div` to fit content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->