### PR TITLE
docs(blog): v2.6.0 link typo 

### DIFF
--- a/apps/docs/content/blog/v2.6.0.mdx
+++ b/apps/docs/content/blog/v2.6.0.mdx
@@ -87,7 +87,7 @@ NextUI version **v2.6.0** comes with 4 new components **Form**, **Drawer**, **In
 
 ## Form Component
 
-Built on [React Aria's Form](https://react-spectrum.adobe.com/react-aria/forms.html#forms) component, the [Form](/docs/components/forms) component provides accessible form handling with built-in submission, validation and error management.
+Built on [React Aria's Form](https://react-spectrum.adobe.com/react-aria/forms.html#forms) component, the [Form](/docs/components/form) component provides accessible form handling with built-in submission, validation and error management.
 
 <Spacer y={4} />
 
@@ -313,7 +313,7 @@ function Example() {
 - **Form Libraries Support**: Supports popular form libraries like `react-hook-form` and `formik`
 - **Accessibility**: Built-in accessibility features including ARIA attributes and keyboard navigation
 
-Check out our [Forms documentation](/docs/components/forms) for a deep dive into all the features and capabilities.
+Check out our [Forms documentation](/docs/components/form) for a deep dive into all the features and capabilities.
 
 <Spacer y={4} />
 
@@ -566,7 +566,7 @@ declare module "@react-types/shared" {
 - **Improved Base Path Support**: Better handling of base paths through the new `useHref` prop in `NextUIProvider`
 - **Framework-specific Optimizations**: Built-in support for Next.js (both App and Pages Router), React Router, Remix, and TanStack Router
 
-See the [Routing documentation](/docs/guides/routing) for more details.
+See the [Routing documentation](/docs/guide/routing) for more details.
 
 <Spacer y={4} />
 


### PR DESCRIPTION
Closes # 

## 📝 Description

- similar to #4339 
- link in blog has a typo

## ⛳️ Current behavior (updates)
- https://nextui.org/blog/v2.6.0#form-component
- https://nextui.org/blog/v2.6.0#router-improvements

![form-typo](https://github.com/user-attachments/assets/4a634e0e-90f4-4d1b-b281-f653073b55e9)
![route-link-typo](https://github.com/user-attachments/assets/f7482606-63e9-47cb-99c2-76988eb3f5be)


## 🚀 New behavior
link should work

## 💣 Is this a breaking change (Yes/No):
No


## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced four new components: Form, Drawer, Input OTP, and Alert.
	- Added a `use-theme` hook for runtime theme management.
	- Enhanced Select, Autocomplete, and Listbox components with virtualization for better performance with large datasets.
	- Implemented draggable support for modals.

- **Bug Fixes**
	- Numerous bug fixes and improvements for better functionality and performance.

- **Documentation**
	- Improved clarity and usability of documentation to enhance the developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->