### PR TITLE
fix(input): label placement with file input type

### DIFF
--- a/.changeset/chilly-rules-marry.md
+++ b/.changeset/chilly-rules-marry.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+label placement with file input type (#4364)

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -13,7 +13,7 @@ import {useFocusRing} from "@react-aria/focus";
 import {input} from "@nextui-org/theme";
 import {useDOMRef, filterDOMProps} from "@nextui-org/react-utils";
 import {useFocusWithin, useHover, usePress} from "@react-aria/interactions";
-import {clsx, dataAttr, isEmpty, objectToDeps, safeAriaLabel, warn} from "@nextui-org/shared-utils";
+import {clsx, dataAttr, isEmpty, objectToDeps, safeAriaLabel} from "@nextui-org/shared-utils";
 import {useControlledState} from "@react-stately/utils";
 import {useMemo, Ref, useCallback, useState} from "react";
 import {chain, mergeProps} from "@react-aria/utils";
@@ -228,19 +228,6 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const isInvalid = validationState === "invalid" || isAriaInvalid;
 
   const labelPlacement = useMemo<InputVariantProps["labelPlacement"]>(() => {
-    if (isFileTypeInput) {
-      // if `labelPlacement` is not defined, choose `outside` instead
-      // since the default value `inside` is not supported in file input
-      if (!originalProps.labelPlacement) return "outside";
-
-      // throw a warning if `labelPlacement` is `inside`
-      // and change it to `outside`
-      if (originalProps.labelPlacement === "inside") {
-        warn("Input with file type doesn't support inside label. Converting to outside ...");
-
-        return "outside";
-      }
-    }
     if ((!originalProps.labelPlacement || originalProps.labelPlacement === "inside") && !label) {
       return "outside";
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4364

## 📝 Description

<!--- Add a brief description -->

Not sure what was the reason why `inside` is not supported. Probably this logic was added before changing `data-filled` & `data-filled-within`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

When using `labelPlacement=inside`, it throws `Input with file type doesn't support inside label. Converting to outside ...`

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/73b507f1-0c83-4db6-bd57-a6949bca84ec)

![image](https://github.com/user-attachments/assets/cdaf1d93-6965-4230-bf0f-4fa646bcf335)

![image](https://github.com/user-attachments/assets/cd463026-71e3-4149-9ecf-5d47a3d75d28)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved label placement for file input types, enhancing visual alignment and usability.

- **Bug Fixes**
	- Simplified label placement logic for file inputs, eliminating unnecessary warnings and improving control flow.

- **Documentation**
	- Minor adjustments made to comments and documentation for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->