### PR TITLE
fix(listbox): listbox-section items prop in html

### DIFF
--- a/.changeset/angry-boxes-wonder.md
+++ b/.changeset/angry-boxes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/listbox": patch
+---
+
+fix listbox section items prop in html element (#4277)

--- a/packages/components/listbox/src/listbox-section.tsx
+++ b/packages/components/listbox/src/listbox-section.tsx
@@ -51,6 +51,9 @@ const ListboxSection = forwardRef<"li", ListboxSectionProps>(
       // the title props is already inside the rendered prop
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       title,
+      // removed items from props to avoid show in html element
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      items,
       ...otherProps
     },
     _,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4277

## 📝 Description
Items props for ListBoxSection was shared to component in otherProps doing that items render in HTML. Same as before was fix for title i added to props list for prevent spread to component.
<!--- Add a brief description -->

## ⛳️ Current behavior (updates)
Items and object are printed in HTML component
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/10042e7d-5c8d-445f-8235-6d5cfd7fb0c0" />
## 🚀 New behavior
Only correct props are printed
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/952a005a-72d8-4d62-8ed2-ba6e20d99f5b" />

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):
No
<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the rendering and management of items in the listbox component.
  
- **New Features**
	- Improved functionality of the listbox by removing unnecessary properties to enhance user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->