### PR TITLE
fix(theme): menu overflow use clip

### DIFF
--- a/.changeset/old-peas-cheat.md
+++ b/.changeset/old-peas-cheat.md
@@ -2,4 +2,4 @@
 "@nextui-org/theme": patch
 ---
 
-menu base use overflow-clip to fix listbox section sticky
+menu base use overflow-clip to fix listbox section sticky (#4335)

--- a/.changeset/old-peas-cheat.md
+++ b/.changeset/old-peas-cheat.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+menu base use overflow-clip to fix listbox section sticky

--- a/packages/core/theme/src/components/menu.ts
+++ b/packages/core/theme/src/components/menu.ts
@@ -11,7 +11,7 @@ import {dataFocusVisibleClasses} from "../utils";
  */
 const menu = tv({
   slots: {
-    base: "w-full relative flex flex-col gap-1 p-1 overflow-hidden",
+    base: "w-full relative flex flex-col gap-1 p-1 overflow-clip",
     list: "w-full flex flex-col gap-0.5 outline-none",
     emptyContent: [
       "h-10",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4335


## 📝 Description

caused by #4105 
setting `overflow: hidden` on an ancestor of a `position: sticky` element will make that ancestor the scroll reference
use `overflow: clip` instead, which is fairly well supported at time of writing

## ⛳️ Current behavior (updates)

header is sticky but still scrolls

https://github.com/user-attachments/assets/8a08758b-15a1-4de4-88fb-e9dc3c556127



## 🚀 New behavior

header sticky works properly

https://github.com/user-attachments/assets/002754d9-998b-4757-832f-92d501c4971f



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

No tests as it's a scroll behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the sticky behavior of the menu component by modifying the overflow handling.

- **New Features**
	- Enhanced rendering and functionality of the menu component within the theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->