### PR TITLE
docs(switch): custom style example wrong margins

### DIFF
--- a/apps/docs/content/components/switch/custom-styles.raw.jsx
+++ b/apps/docs/content/components/switch/custom-styles.raw.jsx
@@ -14,10 +14,10 @@ export default function App() {
           "w-6 h-6 border-2 shadow-lg",
           "group-data-[hover=true]:border-primary",
           //selected
-          "group-data-[selected=true]:ml-6",
+          "group-data-[selected=true]:ms-6",
           // pressed
           "group-data-[pressed=true]:w-7",
-          "group-data-[selected]:group-data-[pressed]:ml-4",
+          "group-data-[selected]:group-data-[pressed]:ms-4",
         ),
       }}
     >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4352, kind of
Related: #3868

## 📝 Description

- example code for switch custom styles uses the wrong class for thumb position
- should be using `margin-inline-start` instead of `margin-left`
- default uses `margin-inline-start`, and mixing `margin-left` causes inconsistencies due to the order css definitions are loaded by `next`

## ⛳️ Current behavior (updates)

notice the little gap to the right of the thumb
this is because the `ml-6` is being overwritten by the default `ms-5`

![before](https://github.com/user-attachments/assets/bfb88f5c-aa1e-4cb8-9f37-0f6fab4dd647)



## 🚀 New behavior

![after](https://github.com/user-attachments/assets/9c8f6382-c5e3-4dc4-b5ac-0f6c45ed2527)


## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated styling for the `Switch` component to enhance support for right-to-left layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->