### PR TITLE
fix: clipboard get the different unicode whitespace

### DIFF
--- a/.changeset/rich-moles-compare.md
+++ b/.changeset/rich-moles-compare.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/use-clipboard": patch
+"@nextui-org/snippet": patch
+---
+
+Fix clipboard get different unicode whitespace (#4225)

--- a/.changeset/rich-moles-compare.md
+++ b/.changeset/rich-moles-compare.md
@@ -1,6 +1,5 @@
 ---
 "@nextui-org/use-clipboard": patch
-"@nextui-org/snippet": patch
 ---
 
 Fix clipboard get different unicode whitespace (#4225)

--- a/packages/components/snippet/stories/snippet.stories.tsx
+++ b/packages/components/snippet/stories/snippet.stories.tsx
@@ -92,32 +92,9 @@ export const MultiLine = {
   args: {
     ...defaultProps,
     children: [
-      // "npm install @nextui-org/react",
-      // "yarn add @nextui-org/react",
-      // "pnpm add @nextui-org/react",
-      `
-{
-  "name": "Next.js PWA",
-  "short_name": "NextPWA",
-  "description": "A Progressive Web App built with Next.js and React",
-  "start_url": "/",
-  "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#000000",
-  "icons": [
-    {
-      "src": "/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
-  ]
-}
-`,
+      "npm install @nextui-org/react",
+      "yarn add @nextui-org/react",
+      "pnpm add @nextui-org/react",
     ],
   },
 };

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -8,6 +8,11 @@ export interface UseClipboardProps {
   timeout?: number;
 }
 
+const transformValue = (text: string) => {
+  // Manually replace all &nbsp; to avoid get different unicode characters;
+  return text.replace(/[\u00A0]/g, " ");
+};
+
 /**
  * Copies the given text to the clipboard.
  * @param {number} timeout - timeout in ms, default 2000
@@ -33,16 +38,11 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
     [onClearTimeout, timeout],
   );
 
-  const transformWhitespace = useCallback((text: string) => {
-    // Manually replace all &nbsp; to avoid get different unicode characters;
-    return text.replace(/[\u00A0]/g, " ");
-  }, []);
-
   const copy = useCallback(
     (valueToCopy: any) => {
       if ("clipboard" in navigator) {
         const transformedValue =
-          typeof valueToCopy === "string" ? transformWhitespace(valueToCopy) : valueToCopy;
+          typeof valueToCopy === "string" ? transformValue(valueToCopy) : valueToCopy;
 
         navigator.clipboard
           .writeText(transformedValue)
@@ -52,7 +52,7 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
         setError(new Error("useClipboard: navigator.clipboard is not supported"));
       }
     },
-    [handleCopyResult, transformWhitespace],
+    [handleCopyResult],
   );
 
   const reset = useCallback(() => {

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -34,8 +34,8 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
   );
 
   const transformWhitespace = useCallback((text: string) => {
-    // Manually replace all whitespace to avoid get different unicode characters;
-    return text.replace(/\s/g, " ");
+    // Manually replace all &nbsp; to avoid get different unicode characters;
+    return text.replace(/[\u00A0]/g, " ");
   }, []);
 
   const copy = useCallback(

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -41,11 +41,11 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
   const copy = useCallback(
     (valueToCopy: any) => {
       if ("clipboard" in navigator) {
-        const decodedValue =
+        const transformedValue =
           typeof valueToCopy === "string" ? transformWhitespace(valueToCopy) : valueToCopy;
 
         navigator.clipboard
-          .writeText(decodedValue)
+          .writeText(transformedValue)
           .then(() => handleCopyResult(true))
           .catch((err) => setError(err));
       } else {

--- a/packages/hooks/use-clipboard/src/index.ts
+++ b/packages/hooks/use-clipboard/src/index.ts
@@ -33,18 +33,26 @@ export function useClipboard({timeout = 2000}: UseClipboardProps = {}) {
     [onClearTimeout, timeout],
   );
 
+  const transformWhitespace = useCallback((text: string) => {
+    // Manually replace all whitespace to avoid get different unicode characters;
+    return text.replace(/\s/g, " ");
+  }, []);
+
   const copy = useCallback(
     (valueToCopy: any) => {
       if ("clipboard" in navigator) {
+        const decodedValue =
+          typeof valueToCopy === "string" ? transformWhitespace(valueToCopy) : valueToCopy;
+
         navigator.clipboard
-          .writeText(valueToCopy)
+          .writeText(decodedValue)
           .then(() => handleCopyResult(true))
           .catch((err) => setError(err));
       } else {
         setError(new Error("useClipboard: navigator.clipboard is not supported"));
       }
     },
-    [handleCopyResult],
+    [handleCopyResult, transformWhitespace],
   );
 
   const reset = useCallback(() => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4225

## 📝 Description

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a utility function to normalize whitespace in clipboard operations.
	- Updated the snippet component to provide installation commands for the `@nextui-org/react` package.
- **Bug Fixes**
	- Resolved issues with clipboard handling of different Unicode whitespace characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->