### PR TITLE
fix: navbar state change

### DIFF
--- a/.changeset/smart-oranges-peel.md
+++ b/.changeset/smart-oranges-peel.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/navbar": patch
+---
+
+
+Resolving the issue preventing the navbar from opening(#4345)

--- a/packages/components/navbar/src/use-navbar.ts
+++ b/packages/components/navbar/src/use-navbar.ts
@@ -161,6 +161,11 @@ export function useNavbar(originalProps: UseNavbarProps) {
     ref: domRef,
     onResize: () => {
       const currentWidth = domRef.current?.offsetWidth;
+      const scrollWidth = window.innerWidth - document.documentElement.clientWidth;
+
+      if (currentWidth && currentWidth + scrollWidth == prevWidth.current) {
+        return;
+      }
 
       if (currentWidth !== prevWidth.current) {
         updateWidth();


### PR DESCRIPTION
Closes #4345 

## 📝 Description

The PR fixes the Navbar unable to open issue.
Root cause:
* It issue emerged when we added `usePreventScroll` and removed `react-rmeove-scroll`.
* The `usePreventScroll` internally adds the `overflow-hidden` and `paddingRight` of `{scrollBarWidth}` styles to prevent the scrolling behaviour. Due to this the width of the navbar base would be changed. Now, this causes the useResizeObserver to trigger which in-turn closes the Navbar menu.

The pr adds the changes to useResizeObserver callback so that it does not close the Navbar Menu.

## Current Behaviour

https://github.com/user-attachments/assets/6c95040a-3dd2-4936-951b-f76c8b94a073

## New Behaviour

https://github.com/user-attachments/assets/57c60984-747f-4829-96f9-cfa67634b2e3

## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue preventing the navbar from opening.

- **Improvements**
	- Enhanced responsiveness and behavior of the navbar during window resizing and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->