### PR TITLE
fix: virtual keyboard on mobile should be based on the allowed keys

### DIFF
--- a/.changeset/cyan-donkeys-swim.md
+++ b/.changeset/cyan-donkeys-swim.md
@@ -1,5 +1,6 @@
 ---
 "@nextui-org/input-otp": patch
+"@nextui-org/shared-utils": patch
 ---
 
 Fix virtual keyboard to display the keys based on allowedKeys(#4408)

--- a/.changeset/cyan-donkeys-swim.md
+++ b/.changeset/cyan-donkeys-swim.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input-otp": patch
+---
+
+Fix virtual keyboard to display the keys based on allowedKeys(#4408)

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -223,6 +223,12 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
     [baseDomRef, slots, baseStyles, isDisabled, isInvalid, isRequired, isReadOnly, value, length],
   );
 
+  const isNumeric = (pattern: string) => {
+    const numericPattern = /(^|\W)[0-9](\W|$)/;
+
+    return numericPattern.test(pattern) && !/[^\d\^$\[\]\(\)\*\+\-\.\|]/.test(pattern);
+  };
+
   const getInputOtpProps = useCallback(
     (props: Partial<OTPInputProps> = {}) => {
       const otpProps: Omit<OTPInputProps, "render" | "children"> & {
@@ -246,6 +252,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
         pushPasswordManagerStrategy,
         pasteTransformer,
         noScriptCSSFallback,
+        inputMode: isNumeric(allowedKeys) ? "numeric" : "text",
         containerClassName: slots.wrapper?.({class: clsx(classNames?.wrapper, containerClassName)}),
         ...props,
       };

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -120,6 +120,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
     containerClassName,
     noScriptCSSFallback,
     onChange,
+    inputMode,
     ...otherProps
   } = props;
 
@@ -237,16 +238,16 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
         minLength: minLength ?? length,
         textAlign,
         ref: inputRef,
-        name: name,
-        value: value,
+        name,
+        value,
         autoFocus,
         onChange: setValue,
         onBlur: chain(focusProps.onBlur, props?.onBlur),
-        onComplete: onComplete,
+        onComplete,
         pushPasswordManagerStrategy,
         pasteTransformer,
         noScriptCSSFallback,
-        inputMode: isPatternNumeric(allowedKeys) ? "numeric" : "text",
+        inputMode: inputMode ?? (isPatternNumeric(allowedKeys) ? "numeric" : "text"),
         containerClassName: slots.wrapper?.({class: clsx(classNames?.wrapper, containerClassName)}),
         ...props,
       };
@@ -254,6 +255,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
       return otpProps;
     },
     [
+      inputMode,
       isRequired,
       isDisabled,
       isReadOnly,

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -13,7 +13,7 @@ import {
 } from "@nextui-org/system";
 import {inputOtp} from "@nextui-org/theme";
 import {filterDOMProps, ReactRef, useDOMRef} from "@nextui-org/react-utils";
-import {clsx, dataAttr, objectToDeps} from "@nextui-org/shared-utils";
+import {clsx, dataAttr, objectToDeps, isPatternNumeric} from "@nextui-org/shared-utils";
 import {useCallback, useMemo} from "react";
 import {chain, mergeProps, useFormReset} from "@react-aria/utils";
 import {AriaTextFieldProps} from "@react-types/textfield";
@@ -223,12 +223,6 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
     [baseDomRef, slots, baseStyles, isDisabled, isInvalid, isRequired, isReadOnly, value, length],
   );
 
-  const isNumeric = (pattern: string) => {
-    const numericPattern = /(^|\W)[0-9](\W|$)/;
-
-    return numericPattern.test(pattern) && !/[^\d\^$\[\]\(\)\*\+\-\.\|]/.test(pattern);
-  };
-
   const getInputOtpProps = useCallback(
     (props: Partial<OTPInputProps> = {}) => {
       const otpProps: Omit<OTPInputProps, "render" | "children"> & {
@@ -252,7 +246,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
         pushPasswordManagerStrategy,
         pasteTransformer,
         noScriptCSSFallback,
-        inputMode: isNumeric(allowedKeys) ? "numeric" : "text",
+        inputMode: isPatternNumeric(allowedKeys) ? "numeric" : "text",
         containerClassName: slots.wrapper?.({class: clsx(classNames?.wrapper, containerClassName)}),
         ...props,
       };

--- a/packages/utilities/shared-utils/src/index.ts
+++ b/packages/utilities/shared-utils/src/index.ts
@@ -8,3 +8,4 @@ export * from "./numbers";
 export * from "./console";
 export * from "./types";
 export * from "./dates";
+export * from "./regex";

--- a/packages/utilities/shared-utils/src/regex.ts
+++ b/packages/utilities/shared-utils/src/regex.ts
@@ -1,0 +1,5 @@
+export const isPatternNumeric = (pattern: string) => {
+  const numericPattern = /(^|\W)[0-9](\W|$)/;
+
+  return numericPattern.test(pattern) && !/[^\d\^$\[\]\(\)\*\+\-\.\|]/.test(pattern);
+};


### PR DESCRIPTION
Closes #4408 

## 📝 Description

Fixing the virtual keyboard based on the allowedKeys.

## ⛳️ Current behavior (updates)

https://github.com/user-attachments/assets/3df95fa5-867b-49d4-93cc-0be8d0c30f9c

## 🚀 New behavior

https://github.com/user-attachments/assets/c4383de3-8806-4c51-8676-d1e33bacdc2e

## 💣 Is this a breaking change (Yes/No): No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced virtual keyboard functionality for the OTP input, displaying only allowed keys.
	- Improved input handling for numeric patterns in the OTP input component.

- **Bug Fixes**
	- Addressed issues with input validation and control for the virtual keyboard.

- **Documentation**
	- Updated exports to include a new regex utility for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->