### PR TITLE
fix(input-otp): form validation hook missing behavior prop

### DIFF
--- a/.changeset/nasty-dolls-tease.md
+++ b/.changeset/nasty-dolls-tease.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input-otp": patch
+---
+
+fixed isRequired not showing error when validationBehavior=native is not explicitly set

--- a/packages/components/input-otp/__tests__/input-otp.test.tsx
+++ b/packages/components/input-otp/__tests__/input-otp.test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {render, renderHook, screen} from "@testing-library/react";
 import {Controller, useForm} from "react-hook-form";
 import userEvent, {UserEvent} from "@testing-library/user-event";
+import {Form} from "@nextui-org/form";
 
 import {InputOtp} from "../src";
 
@@ -182,6 +183,45 @@ describe("InputOtp Component", () => {
     const segments = screen.getAllByRole("presentation");
 
     expect(segments[0]).not.toHaveAttribute("data-focus", "true");
+  });
+});
+
+describe("Validation", () => {
+  let user: UserEvent;
+
+  beforeAll(() => {
+    user = userEvent.setup();
+  });
+
+  it("supports isRequired when validationBehavior=native", async () => {
+    const {getByTestId} = render(
+      <Form validationBehavior="native">
+        <InputOtp isRequired data-testid="base" length={4} />
+        <button data-testid="submit" type="submit" />
+        <button data-testid="reset" type="reset" />
+      </Form>,
+    );
+
+    const inputOtpBase = getByTestId("base");
+
+    expect(inputOtpBase).toHaveAttribute("aria-required", "true");
+    expect(inputOtpBase).not.toHaveAttribute("data-invalid");
+
+    const submitButton = getByTestId("submit");
+
+    await user.click(submitButton);
+
+    expect(inputOtpBase).toHaveAttribute("data-invalid", "true");
+    const errorMessage = document.querySelector("[data-slot='error-message']");
+
+    expect(errorMessage).toBeInTheDocument();
+
+    const resetButton = getByTestId("reset");
+
+    await user.click(resetButton);
+
+    expect(inputOtpBase).not.toHaveAttribute("data-invalid");
+    expect(errorMessage).not.toBeInTheDocument();
   });
 });
 

--- a/packages/components/input-otp/src/use-input-otp.ts
+++ b/packages/components/input-otp/src/use-input-otp.ts
@@ -158,7 +158,7 @@ export function useInputOtp(originalProps: UseInputOtpProps) {
   });
 
   useFormReset(inputRef, value, setValue);
-  useFormValidation(props, validationState, inputRef);
+  useFormValidation({...props, validationBehavior}, validationState, inputRef);
 
   const {
     isInvalid: isAriaInvalid,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

- `validationBehavior` wasn't being passed properly to `useFormValidation` hook in `use-input-otp`
- this prevented the `useLayoutEffect` in `useFormValidation` from executing `validationState.updateValidation`

## ⛳️ Current behavior (updates)


https://github.com/user-attachments/assets/2a3fb3c1-8203-45bb-9c69-0e70fae8fccb



## 🚀 New behavior


https://github.com/user-attachments/assets/bbf26f5b-3212-43cf-9de8-e3c0affe8d38



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Addressed an issue with the `isRequired` property not displaying errors for the `InputOtp` component when using native validation.
  
- **Tests**
	- Introduced a new test suite for validation of the `InputOtp` component, ensuring correct behavior of required fields and error handling.
  
- **Chores**
	- Updated the validation logic in the `useInputOtp` function to improve how validation behavior is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->