### PR TITLE
fix(calendar): invalid prop ref supplied to React.Fragment

### DIFF
--- a/.changeset/chilled-files-serve.md
+++ b/.changeset/chilled-files-serve.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/calendar": patch
+---
+
+remove unnecessary fragment in calendar (#4358, #4068)

--- a/packages/components/calendar/src/calendar-base.tsx
+++ b/packages/components/calendar/src/calendar-base.tsx
@@ -152,11 +152,9 @@ export function CalendarBase(props: CalendarBaseProps) {
           data-slot="content"
         >
           <AnimatePresence custom={direction} initial={false} mode="popLayout">
-            <>
-              <MotionConfig transition={transition}>
-                <LazyMotion features={domAnimation}>{calendarContent}</LazyMotion>
-              </MotionConfig>
-            </>
+            <MotionConfig transition={transition}>
+              <LazyMotion features={domAnimation}>{calendarContent}</LazyMotion>
+            </MotionConfig>
           </AnimatePresence>
         </ResizablePanel>
       )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

- Closes #4358 
- Closes #4068 

## 📝 Description

In 2.3.0, `PopLayoutWrapper` was used to forward the ref. 

```tsx
const PopLayoutWrapper = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
  (props, ref) => {
    return <div ref={ref} {...props} />;
  },
);
```

At some point (couldn't trace when probably due to force push), it was changed to use React.Fragment, i.e. `<></>`. This is where the error is thrown.

In Ripple component, there is the same pattern (i.e. replace `PopLayoutWrapper` by `<></>`) and the fragment got removed in [this commit](https://github.com/nextui-org/nextui/commit/422770cc6bcdd1d4c51257654ab718f3c19d6cb2#diff-1406de614abf1c88f70eb8d86d1046e16a85a8d5ba3b057405d571097ca1f468). Hence, applying the same change to `calendar-base.tsx`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Sandbox provided by the user: https://codesandbox.io/p/devbox/friendly-diffie-55mxp5

![image](https://github.com/user-attachments/assets/bdc883fb-221a-4132-a46e-e67cd5a6500c)

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

I cloned the above sandbox and link to my local package for testing.

[pr4428-demo.webm](https://github.com/user-attachments/assets/8183be99-5284-45c4-8d02-f6d6c257fe66)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
