### PR TITLE
fix(docs): i18n version in date-related components

### DIFF
--- a/apps/docs/content/docs/components/date-input.mdx
+++ b/apps/docs/content/docs/components/date-input.mdx
@@ -129,9 +129,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -177,9 +177,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-picker.mdx
+++ b/apps/docs/content/docs/components/date-picker.mdx
@@ -144,9 +144,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -192,9 +192,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -214,9 +214,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -246,9 +246,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 

--- a/apps/docs/content/docs/components/date-range-picker.mdx
+++ b/apps/docs/content/docs/components/date-range-picker.mdx
@@ -161,9 +161,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -209,9 +209,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -231,9 +231,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -256,9 +256,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 
@@ -276,9 +276,9 @@ in multiple formats into `ZonedDateTime` objects.
 
 <PackageManagers
   commands={{
-    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
-    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.2",
+    npm: "npm install @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    yarn: "yarn add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
+    pnpm: "pnpm add @internationalized/date@3.6.0 @react-aria/i18n@3.12.4",
   }}
 />
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

currently production is using `@react-aria/i18n@3.12.4`. therefore, update the correct version so that users can use the exact same version as our codebase.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for the `DateInput`, `DatePicker`, and `DateRangePicker` components to reflect the latest version of the `@react-aria/i18n` package (3.12.4).
	- Enhanced descriptions of component features, props, and API details for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->