### PR TITLE
fix(drawer): use a top-level type-only import instead of inline type specifiers

### DIFF
--- a/.changeset/little-apricots-rhyme.md
+++ b/.changeset/little-apricots-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/drawer": patch
+---
+
+use top-level type-only import instead of inline type specifiers

--- a/packages/components/drawer/src/index.ts
+++ b/packages/components/drawer/src/index.ts
@@ -1,13 +1,11 @@
-import {
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  ModalContent,
-  type ModalContentProps,
-  type ModalHeaderProps,
-  type ModalBodyProps,
-  type ModalFooterProps,
+import type {
+  ModalContentProps,
+  ModalHeaderProps,
+  ModalBodyProps,
+  ModalFooterProps,
 } from "@nextui-org/modal";
+
+import {ModalHeader, ModalBody, ModalFooter, ModalContent} from "@nextui-org/modal";
 
 import Drawer from "./drawer";
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

![image](https://github.com/user-attachments/assets/0b5a3b72-ce0c-4ed7-97c2-e8e50bc901a9)

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in type imports for the drawer component package.
	- Introduced separate import statements for modal components, improving organization.

- **Bug Fixes**
	- Applied a patch for the `@nextui-org/drawer` package to refine import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->