### PR TITLE
fix(alert): mark description optional & revise styles when only children is provided

### DIFF
--- a/.changeset/neat-badgers-beam.md
+++ b/.changeset/neat-badgers-beam.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/alert": patch
+---
+
+mark description prop as optional (#4445)

--- a/.changeset/new-cups-tan.md
+++ b/.changeset/new-cups-tan.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/theme": patch
+---
+
+fix the alignment when only alert children is provided

--- a/packages/components/alert/src/use-alert.ts
+++ b/packages/components/alert/src/use-alert.ts
@@ -19,9 +19,9 @@ interface Props extends HTMLNextUIProps<"div"> {
    */
   title?: string;
   /**
-   * Main body of the alert message
+   * description of the alert message
    */
-  description: ReactNode;
+  description?: ReactNode;
   /**
    * Icon to be displayed in the alert - overrides the default icon
    */

--- a/packages/core/theme/src/components/alert.ts
+++ b/packages/core/theme/src/components/alert.ts
@@ -25,7 +25,8 @@ import {colorVariants} from "../utils";
 const alert = tv({
   slots: {
     base: "flex flex-grow flex-row w-full items-start py-3 px-4 gap-x-1",
-    mainWrapper: "h-full flex-grow min-h-10 ms-2 flex flex-col box-border items-start text-inherit",
+    mainWrapper:
+      "h-full flex-grow min-h-10 ms-2 flex flex-col box-border items-start text-inherit justify-center",
     title: "text-small w-full font-medium block text-inherit leading-5",
     description: "pl-[1px] text-small font-normal text-inherit",
     closeButton: "relative text-inherit translate-x-1 -translate-y-1",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4445 

## 📝 Description

<!--- Add a brief description -->

`description` is marked as required (from the earliest design). At some point (around 2 months ago), `description` is only shown when it is provided based on [alert.tsx#L66](https://github.com/nextui-org/nextui/blob/canary/packages/components/alert/src/alert.tsx#L66). Hence, it indicates that it should be optional.

Also, when no title & description are provided, says `<Alert>Hello</Alert>`, the children position is a bit off. This PR also fixes the styling to make it look more natural (see the screenshots below).

## ⛳️ Current behavior (updates)

![image](https://github.com/user-attachments/assets/df908571-f5ba-40d2-a286-ba84e58f4356)

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/b3947372-37c0-4e2a-a330-f1e0a703cff2)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information
