### PR TITLE
fix(autocomplete): validate prop not working after hovering

### DIFF
--- a/.changeset/ninety-lobsters-deliver.md
+++ b/.changeset/ninety-lobsters-deliver.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+fixed autocomplete validate prop not working after hovering when validation behavior is native

--- a/packages/components/autocomplete/__tests__/autocomplete.test.tsx
+++ b/packages/components/autocomplete/__tests__/autocomplete.test.tsx
@@ -739,6 +739,60 @@ describe("Autocomplete", () => {
         expect(input).not.toHaveAttribute("aria-describedby");
         expect(input.validity.valid).toBe(true);
       });
+
+      // this test is to cover a case where hovering over the combobox causes the validation from use-input to overwrite the validation from use-autocomplete if not handled properly
+      // this causes the first form submit after initial render to always succeed even if the validate function returns an error
+      it("should work with validate after hovering", async () => {
+        const onSubmit = jest.fn((e) => {
+          e.preventDefault();
+        });
+
+        const {getByTestId, findByRole} = render(
+          <Form validationBehavior="native" onSubmit={onSubmit}>
+            <AutocompleteExample
+              data-testid="combobox"
+              name="animal"
+              validate={(value) => {
+                if (!value?.selectedKey) {
+                  return "Please select an animal";
+                }
+              }}
+              validationBehavior="native"
+            />
+            <button data-testid="submit" type="submit">
+              Submit
+            </button>
+          </Form>,
+        );
+
+        const combobox = getByTestId("combobox") as HTMLInputElement;
+        const submit = getByTestId("submit");
+
+        expect(combobox).not.toHaveAttribute("aria-describedby");
+        expect(combobox.validity.valid).toBe(false);
+
+        await user.hover(combobox);
+        await user.click(submit);
+
+        expect(onSubmit).toHaveBeenCalledTimes(0);
+        expect(combobox).toHaveAttribute("aria-describedby");
+        expect(
+          document.getElementById(combobox.getAttribute("aria-describedby")!),
+        ).toHaveTextContent("Please select an animal");
+
+        await user.click(combobox);
+        await user.keyboard("pe");
+
+        const listbox = await findByRole("listbox");
+        const items = within(listbox).getAllByRole("option");
+
+        await user.click(items[0]);
+        expect(combobox).toHaveAttribute("aria-describedby");
+
+        await user.click(submit);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(combobox).not.toHaveAttribute("aria-describedby");
+      });
     });
 
     describe("validationBehavior=aria", () => {

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -433,12 +433,18 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       }),
     } as ButtonProps);
 
+  // prevent use-input's useFormValidation hook from overwriting use-autocomplete's useFormValidation hook when there are uncommitted validation errors
+  const hasUncommittedValidation =
+    validationBehavior === "native" &&
+    state.displayValidation.isInvalid === false &&
+    state.realtimeValidation.isInvalid === true;
+
   const getInputProps = () =>
     ({
       ...otherProps,
       ...inputProps,
       ...slotsProps.inputProps,
-      isInvalid,
+      isInvalid: hasUncommittedValidation ? undefined : isInvalid,
       validationBehavior,
       errorMessage:
         typeof errorMessage === "function"

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -434,6 +434,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
     } as ButtonProps);
 
   // prevent use-input's useFormValidation hook from overwriting use-autocomplete's useFormValidation hook when there are uncommitted validation errors
+  // see https://github.com/nextui-org/nextui/pull/4452
   const hasUncommittedValidation =
     validationBehavior === "native" &&
     state.displayValidation.isInvalid === false &&


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes eng-1790

## 📝 Description

- autocomplete has an `<input>` that has 2 `useFormValidation` hooks attached to it due to autocomplete's implementation using NextUI's own input
  - the 2 `useFormValidation` hooks are attached by autocomplete's `useComboBox` and input's `useTextField`
  - this works fine for most cases as the input's `useFormValidation` is controlled externally by autocomplete through `isInvalid` and `errorMessage`
- when using the `validate` prop's function for validation and `validationBehavior=native`, after initial render, autocomplete will be invalid but the errors do not show yet since nothing has been committed
- however, if the input is hovered, the input's `useFormValidation` will execute due to the `useHover` hook, which will cause it to overwrite the validation result of the `useFormValidation` hook from `useCombobox`
  - this overwrite happens because both `useFormValidation` hooks reference the same `<input>`
  - at this moment, the input has `isInvalid=false` and no validation errors yet
  - under these conditions, `useFormValidation` will run and set the `<input>` 's validity to `true` since its errors externally controlled but there are no errors yet
- if the form is submitted now, the submission will succeed before autocomplete's `useFormValidation` has a chance to update the `<input>` to the correct validation state
- the fix in this PR is a hack that works by setting input's `isInvalid` to `undefined` when there is uncommitted validation so input's `useFormValidation` does not overwrite that of autocomplete

sandbox: https://codesandbox.io/p/github/Peterl561/autocomplete-validate/main
1. have autocomplete in a `validationBehavior=native` form with a `validate` function 
2. hover over autocomplete after initial render (not clicking)
3. click form submit
4. observe that failed `validate` on autocomplete does not prevent submission
5. repeat steps 2-4 infinitely
  a. clicking submit without hovering autocomplete works
  b. clicking autocomplete (instead of only hovering) before submitting works

## ⛳️ Current behavior (updates)

when autocomplete first renders, repeatedly hovering the input prevent `validate` from working as expected

https://github.com/user-attachments/assets/248deaa5-54d7-4361-8698-d23b3408b1e2



## 🚀 New behavior

hovering autocomplete before submit does not interfere with `validate`

https://github.com/user-attachments/assets/f4977d85-9abb-42ae-8046-fa08961bc45b



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the validation behavior of the autocomplete component after user interaction.
  
- **Tests**
	- Added a new test case to verify the validation behavior of the autocomplete component when hovered over and submitted without a valid selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->