### PR TITLE
fix(docs): extra classname in form example

### DIFF
--- a/apps/docs/content/components/form/demo.raw.jsx
+++ b/apps/docs/content/components/form/demo.raw.jsx
@@ -58,7 +58,7 @@ export default function App() {
 
   return (
     <Form
-      className="w-full justify-center items-center w-full space-y-4"
+      className="w-full justify-center items-center space-y-4"
       validationBehavior="native"
       validationErrors={errors}
       onReset={() => setSubmitted(null)}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4464

## 📝 Description

<!--- Add a brief description -->

remove extra `w-full` in the example

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Simplified the `className` for the `Form` component by removing a redundant `w-full` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->