### PR TITLE
fix(dropdown): invalid dropdown menu position

### DIFF
--- a/.changeset/silly-hotels-stare.md
+++ b/.changeset/silly-hotels-stare.md
@@ -1,6 +1,5 @@
 ---
 "@nextui-org/dropdown": patch
-"@nextui-org/popover": patch
 ---
 
-Remove conversion logic in useOverlay that was transforming Placement type to PlacementAxis type.
+Remove conversion logic in useOverlay that was transforming Placement type to PlacementAxis type. (#4466)

--- a/.changeset/silly-hotels-stare.md
+++ b/.changeset/silly-hotels-stare.md
@@ -1,0 +1,6 @@
+---
+"@nextui-org/dropdown": patch
+"@nextui-org/popover": patch
+---
+
+Remove conversion logic in useOverlay that was transforming Placement type to PlacementAxis type.

--- a/packages/components/dropdown/src/use-dropdown.ts
+++ b/packages/components/dropdown/src/use-dropdown.ts
@@ -9,12 +9,11 @@ import {useMenuTrigger} from "@react-aria/menu";
 import {dropdown} from "@nextui-org/theme";
 import {clsx} from "@nextui-org/shared-utils";
 import {ReactRef, mergeRefs} from "@nextui-org/react-utils";
-import {ariaShouldCloseOnInteractOutside, toReactAriaPlacement} from "@nextui-org/aria-utils";
+import {ariaShouldCloseOnInteractOutside} from "@nextui-org/aria-utils";
 import {useMemo, useRef} from "react";
 import {mergeProps} from "@react-aria/utils";
 import {MenuProps} from "@nextui-org/menu";
 import {CollectionElement} from "@react-types/shared";
-import {useOverlayPosition} from "@react-aria/overlays";
 
 interface Props extends HTMLNextUIProps<"div"> {
   /**
@@ -99,10 +98,6 @@ export function useDropdown(props: UseDropdownProps): UseDropdownReturn {
     disableAnimation = globalContext?.disableAnimation ?? false,
     onClose,
     className,
-    containerPadding = 12,
-    offset = 7,
-    crossOffset = 0,
-    shouldFlip = true,
     ...otherProps
   } = props;
 
@@ -139,17 +134,6 @@ export function useDropdown(props: UseDropdownProps): UseDropdownReturn {
     [className],
   );
 
-  const {placement} = useOverlayPosition({
-    isOpen: state.isOpen,
-    targetRef: triggerRef,
-    overlayRef: popoverRef,
-    placement: toReactAriaPlacement(placementProp),
-    offset,
-    crossOffset,
-    shouldFlip,
-    containerPadding,
-  });
-
   const onMenuAction = (menuCloseOnSelect?: boolean) => {
     if (menuCloseOnSelect !== undefined && !menuCloseOnSelect) {
       return;
@@ -164,7 +148,7 @@ export function useDropdown(props: UseDropdownProps): UseDropdownReturn {
 
     return {
       state,
-      placement: placement || DEFAULT_PLACEMENT,
+      placement: placementProp,
       ref: popoverRef,
       disableAnimation,
       shouldBlockScroll,

--- a/packages/components/popover/src/popover.tsx
+++ b/packages/components/popover/src/popover.tsx
@@ -17,7 +17,6 @@ export interface PopoverProps extends UsePopoverProps {
 const Popover = forwardRef<"div", PopoverProps>((props, ref) => {
   const {children, ...otherProps} = props;
   const context = usePopover({...otherProps, ref});
-
   const [trigger, content] = Children.toArray(children);
 
   const overlay = <Overlay portalContainer={context.portalContainer}>{content}</Overlay>;

--- a/packages/components/popover/src/popover.tsx
+++ b/packages/components/popover/src/popover.tsx
@@ -17,6 +17,7 @@ export interface PopoverProps extends UsePopoverProps {
 const Popover = forwardRef<"div", PopoverProps>((props, ref) => {
   const {children, ...otherProps} = props;
   const context = usePopover({...otherProps, ref});
+
   const [trigger, content] = Children.toArray(children);
 
   const overlay = <Overlay portalContainer={context.portalContainer}>{content}</Overlay>;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4466 

## 📝 Description

<!--- Add a brief description -->

placementProps was converted to `PlacementAxis` type
using `toReactAriaPlacement` and `useOverlayPosition `

```ts
// react-aria/overlay

// ...

export type Axis = 'top' | 'bottom' | 'left' | 'right';
export type PlacementAxis = Axis | 'center';
```


> e.g.)
  bottom-end -> (toReactAriaPlacement) -> bottom right -> (useOverlayPosition) -> bottom
  bottom-start -> (toReactAriaPlacement) -> bottom left -> (useOverlayPosition) -> bottom
  top-start -> (toReactAriaPlacement) -> top left -> (useOverlayPosition) -> top



We want use the original placement instead of converting it to PlacementAxis.
So I delete the conversion logic.


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

https://github.com/user-attachments/assets/83c31444-8697-4759-b285-f3fdfe33fa2a




## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->


https://github.com/user-attachments/assets/4d5755f5-38b0-42b8-99e5-d00130e023c4



## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Update**
  - Patched `@nextui-org/dropdown` dependency

- **Improvements**
  - Simplified dropdown positioning logic
  - Removed complex overlay positioning calculations
  - Streamlined dropdown configuration options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->