### PR TITLE
refactor: remove cursor-hit in hiddenInputClasses

### DIFF
--- a/packages/core/theme/src/utils/classes.ts
+++ b/packages/core/theme/src/utils/classes.ts
@@ -69,9 +69,6 @@ export const collapseAdjacentVariantBorders = {
 };
 
 export const hiddenInputClasses = [
-  // Variables
-  "[--cursor-hit-x:8px]",
-
   // Font styles
   "font-inherit",
   "text-[100%]",
@@ -88,8 +85,7 @@ export const hiddenInputClasses = [
   // Positioning & Hit area
   "absolute",
   "top-0",
-  "start-[calc(var(--cursor-hit-x)*-1)]",
-  "w-[calc(100%+var(--cursor-hit-x)*2)]",
+  "w-full",
   "h-full",
 
   // Opacity and z-index


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4473 

## 📝 Description

<!--- Add a brief description -->

cursor hit will cause the overflow scrollbar to overflow abnormally under overflow-auto.

## ⛳️ Current behavior (updates)

![e536aaf5dfd9b25a1070ceb522563c9](https://github.com/user-attachments/assets/d5c88c9a-24f2-446e-840e-645ca88de756)
![a17df08f2e45bee6ba417e8e84af3b3](https://github.com/user-attachments/assets/8807cdb0-e9f1-4e1c-a7df-caeb97eec0b4)

![92ed33ce13fe750a8e4294c372f6ba3](https://github.com/user-attachments/assets/89e3e689-2a26-41d0-a11e-0c34da9b5461)
![d42eeffc83da567afcf10223e2062f9](https://github.com/user-attachments/assets/7dcbb87d-3853-4386-bfb1-d82e42ee6046)

## 🚀 New behavior

cancel hit area

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
