### PR TITLE
fix(input): use onPress for wrapper click focus

### DIFF
--- a/.changeset/friendly-hounds-walk.md
+++ b/.changeset/friendly-hounds-walk.md
@@ -2,4 +2,4 @@
 "@nextui-org/input": patch
 ---
 
-input use onPress for wrapper click focus (#4287)
+fixed input inconsistent focus behaviour on wrapper click (#4287)

--- a/.changeset/friendly-hounds-walk.md
+++ b/.changeset/friendly-hounds-walk.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/input": patch
+---
+
+input use onPress for wrapper click focus (#4287)

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -224,6 +224,33 @@ describe("Input", () => {
 
     expect(onClear).toHaveBeenCalledTimes(0);
   });
+
+  it("should focus input on click", async () => {
+    const {getByTestId} = render(<Input data-testid="input" />);
+
+    const input = getByTestId("input") as HTMLInputElement;
+    const innerWrapper = document.querySelector("[data-slot='inner-wrapper']") as HTMLDivElement;
+    const inputWrapper = document.querySelector("[data-slot='input-wrapper']") as HTMLDivElement;
+
+    const user = userEvent.setup();
+
+    expect(document.activeElement).not.toBe(input);
+
+    await user.click(input);
+    expect(document.activeElement).toBe(input);
+    input.blur();
+    expect(document.activeElement).not.toBe(input);
+
+    await user.click(innerWrapper);
+    expect(document.activeElement).toBe(input);
+    input.blur();
+    expect(document.activeElement).not.toBe(input);
+
+    await user.click(inputWrapper);
+    expect(document.activeElement).toBe(input);
+    input.blur();
+    expect(document.activeElement).not.toBe(input);
+  });
 });
 
 describe("Input with React Hook Form", () => {

--- a/packages/components/input/src/use-input.ts
+++ b/packages/components/input/src/use-input.ts
@@ -161,6 +161,12 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
     domRef.current?.focus();
   }, [setInputValue, onClear]);
 
+  const handleInputWrapperClick = useCallback(() => {
+    if (domRef.current) {
+      domRef.current?.focus();
+    }
+  }, [domRef.current]);
+
   // if we use `react-hook-form`, it will set the input value using the ref in register
   // i.e. setting ref.current.value to something which is uncontrolled
   // hence, sync the state with `ref.current.value`
@@ -223,6 +229,11 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
   const {pressProps: clearPressProps} = usePress({
     isDisabled: !!originalProps?.isDisabled || !!originalProps?.isReadOnly,
     onPress: handleClear,
+  });
+
+  const {pressProps: inputWrapperPressProps} = usePress({
+    isDisabled: !!originalProps?.isDisabled || !!originalProps?.isReadOnly,
+    onPress: handleInputWrapperClick,
   });
 
   const isInvalid = validationState === "invalid" || isAriaInvalid;
@@ -403,12 +414,7 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         className: slots.inputWrapper({
           class: clsx(classNames?.inputWrapper, isFilled ? "is-filled" : ""),
         }),
-        ...mergeProps(props, hoverProps),
-        onClick: (e) => {
-          if (domRef.current && e.currentTarget === e.target) {
-            domRef.current.focus();
-          }
-        },
+        ...mergeProps(props, hoverProps, inputWrapperPressProps),
         style: {
           cursor: "text",
           ...props.style,
@@ -432,11 +438,6 @@ export function useInput<T extends HTMLInputElement | HTMLTextAreaElement = HTML
         ...props,
         ref: innerWrapperRef,
         "data-slot": "inner-wrapper",
-        onClick: (e) => {
-          if (domRef.current && e.currentTarget === e.target) {
-            domRef.current.focus();
-          }
-        },
         className: slots.innerWrapper({
           class: clsx(classNames?.innerWrapper, props?.className),
         }),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4287
note that this bug occurs in docs due to the Overlay from NavbarMenu, which is another bug (see #4490)

## 📝 Description

- when Input wrappers are clicked, an `onClick` handler focuses the `<input>`
- this causes issues as it bypasses Overlay's ability to control focus (don't quote me on this)
- use `onPress` instead for consistency
- added a test for input click focus

## ⛳️ Current behavior (updates)

clicking on input (blue) will close listbox first due to Modal Overlay while clicking on wrapper (red) will immediately focus on input due to `onClick` ignoring Overlay

https://github.com/user-attachments/assets/a6d7c974-1f90-4cee-beb8-2a1cbed1164b



## 🚀 New behavior

with `onPress`, clicking wrapper (red) will behave the same as clicking input (blue)

https://github.com/user-attachments/assets/3258d2aa-acf7-41bd-b15b-31c4276f1481



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced input component interaction by ensuring consistent focus when clicking on input wrappers.
  - Improved user experience for input field interactions.

- **Tests**
  - Added test case to verify input focusing behavior when clicking the input or its wrappers.

- **Bug Fixes**
  - Resolved input focus management for consistent user interaction across different input wrapper scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->