### PR TITLE
fix(use-image): set status after hydrated

### DIFF
--- a/.changeset/fair-pigs-tap.md
+++ b/.changeset/fair-pigs-tap.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-image": patch
+---
+
+set status after hydrated

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -71,9 +71,7 @@ export function useImage(props: UseImageProps = {}) {
 
   const imageRef = useRef<HTMLImageElement | null>(isHydrated ? new Image() : null);
 
-  const [status, setStatus] = useState<Status>(() =>
-    isHydrated ? setImageAndGetInitialStatus(props, imageRef) : "pending",
-  );
+  const [status, setStatus] = useState<Status>("pending");
 
   useEffect(() => {
     if (!imageRef.current) return;
@@ -96,6 +94,12 @@ export function useImage(props: UseImageProps = {}) {
       imageRef.current = null;
     }
   };
+
+  useEffect(() => {
+    if (isHydrated) {
+      setStatus(setImageAndGetInitialStatus(props, imageRef));
+    }
+  }, [isHydrated]);
 
   /**
    * If user opts out of the fallback/placeholder

--- a/packages/hooks/use-image/src/index.ts
+++ b/packages/hooks/use-image/src/index.ts
@@ -6,6 +6,7 @@ import type {ImgHTMLAttributes, SyntheticEvent} from "react";
 
 import {useRef, useState, useEffect, MutableRefObject} from "react";
 import {useIsHydrated} from "@nextui-org/react-utils";
+import {useSafeLayoutEffect} from "@nextui-org/use-safe-layout-effect";
 
 type NativeImageProps = ImgHTMLAttributes<HTMLImageElement>;
 
@@ -95,7 +96,7 @@ export function useImage(props: UseImageProps = {}) {
     }
   };
 
-  useEffect(() => {
+  useSafeLayoutEffect(() => {
     if (isHydrated) {
       setStatus(setImageAndGetInitialStatus(props, imageRef));
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

follow-up of https://github.com/nextui-org/nextui/pull/4442

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

The status was not set after hydrated in previous version. Therefore, the image is not loaded even hydrated.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

Update the status once it's hydrated

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image hook initialization to correctly handle status management during component hydration.
  - Updated dependency `@nextui-org/use-image` to address potential rendering inconsistencies.

- **Chores**
  - Refined image loading state management to ensure more predictable component behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->