### PR TITLE
fix(navbar): hide overlay when menu is closed

### DIFF
--- a/.changeset/honest-waves-camp.md
+++ b/.changeset/honest-waves-camp.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/navbar": patch
+---
+
+fixed NavbarMenu applying Overlay while closed

--- a/packages/components/navbar/src/navbar-menu.tsx
+++ b/packages/components/navbar/src/navbar-menu.tsx
@@ -4,6 +4,7 @@ import {clsx, dataAttr} from "@nextui-org/shared-utils";
 import {AnimatePresence, HTMLMotionProps, LazyMotion, m} from "framer-motion";
 import {mergeProps} from "@react-aria/utils";
 import {Overlay} from "@react-aria/overlays";
+import React from "react";
 
 import {menuVariants} from "./navbar-menu-transitions";
 import {useNavbarContext} from "./navbar-context";
@@ -31,47 +32,54 @@ const NavbarMenu = forwardRef<"ul", NavbarMenuProps>((props, ref) => {
 
   const styles = clsx(classNames?.menu, className);
 
+  // only apply overlay when menu is open
+  const OverlayComponent = isMenuOpen ? Overlay : React.Fragment;
+
   const contents = disableAnimation ? (
-    <ul
-      ref={domRef}
-      className={slots.menu?.({class: styles})}
-      data-open={dataAttr(isMenuOpen)}
-      style={{
-        // @ts-expect-error
-        "--navbar-height": typeof height === "number" ? `${height}px` : height,
-      }}
-      {...otherProps}
-    >
-      {children}
-    </ul>
+    <OverlayComponent portalContainer={portalContainer}>
+      <ul
+        ref={domRef}
+        className={slots.menu?.({class: styles})}
+        data-open={dataAttr(isMenuOpen)}
+        style={{
+          // @ts-expect-error
+          "--navbar-height": typeof height === "number" ? `${height}px` : height,
+        }}
+        {...otherProps}
+      >
+        {children}
+      </ul>
+    </OverlayComponent>
   ) : (
     <AnimatePresence mode="wait">
       {isMenuOpen ? (
-        <LazyMotion features={domAnimation}>
-          <m.ul
-            ref={domRef}
-            layoutScroll
-            animate="enter"
-            className={slots.menu?.({class: styles})}
-            data-open={dataAttr(isMenuOpen)}
-            exit="exit"
-            initial="exit"
-            style={{
-              // @ts-expect-error
-              "--navbar-height": typeof height === "number" ? `${height}px` : height,
-              ...style,
-            }}
-            variants={menuVariants}
-            {...mergeProps(motionProps, otherProps)}
-          >
-            {children}
-          </m.ul>
-        </LazyMotion>
+        <Overlay portalContainer={portalContainer}>
+          <LazyMotion features={domAnimation}>
+            <m.ul
+              ref={domRef}
+              layoutScroll
+              animate="enter"
+              className={slots.menu?.({class: styles})}
+              data-open={dataAttr(isMenuOpen)}
+              exit="exit"
+              initial="exit"
+              style={{
+                // @ts-expect-error
+                "--navbar-height": typeof height === "number" ? `${height}px` : height,
+                ...style,
+              }}
+              variants={menuVariants}
+              {...mergeProps(motionProps, otherProps)}
+            >
+              {children}
+            </m.ul>
+          </LazyMotion>
+        </Overlay>
       ) : null}
     </AnimatePresence>
   );
 
-  return <Overlay portalContainer={portalContainer}>{contents}</Overlay>;
+  return contents;
 });
 
 NavbarMenu.displayName = "NextUI.NavbarMenu";


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes eng-1823

## 📝 Description

- Overlay is used to provide a focus scope for child components
  - this is useful for things like modals and popovers
  - should only be applied to the page when the child with focus scope is open
- NavbarMenu applies Overlay to page even though its closed
  - this causes other Overlay components like Select and Autocomplete to behave as if they are in a modal
- this PR makes it so Overlay is only applied by NavbarMenu when it is open

## ⛳️ Current behavior (updates)

Note that it takes 2 clicks: one to close current Select and one to open a different Select

https://github.com/user-attachments/assets/bbaf057d-ffce-4076-bf1b-5e654b798fbb




## 🚀 New behavior

1 click to close current Select and open a different Select

https://github.com/user-attachments/assets/1d58c904-73a3-47fa-91c7-f60c880802f9



## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
