### PR TITLE
fix(autocomplete): missing popover props except content

### DIFF
--- a/.changeset/seven-news-melt.md
+++ b/.changeset/seven-news-melt.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/autocomplete": patch
+---
+
+fix missing popover props except content (#4484)

--- a/packages/components/autocomplete/src/use-autocomplete.ts
+++ b/packages/components/autocomplete/src/use-autocomplete.ts
@@ -482,6 +482,7 @@ export function useAutocomplete<T extends object>(originalProps: UseAutocomplete
       triggerType: "listbox",
       ...popoverProps,
       classNames: {
+        ...slotsProps.popoverProps?.classNames,
         content: slots.popoverContent({
           class: clsx(
             classNames?.popoverContent,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4484

## 📝 Description

Currently when users pass `popoverProps` in Autocomplete, only `content` is passed. This PR is to include other popover props.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

![image](https://github.com/user-attachments/assets/8a3dd2d6-a79c-46ca-8cdc-522d771f4b90)

## 🚀 New behavior

![image](https://github.com/user-attachments/assets/b20801c5-3e63-4ffb-b942-2f208a5a5b49)

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with the `@nextui-org/autocomplete` package by adding missing popover properties
  - Improved popover styling capabilities by allowing additional class names to be applied

<!-- end of auto-generated comment: release notes by coderabbit.ai -->