### PR TITLE
fix(use-aria-link): onclick deprecation warning for Button as Link

### DIFF
--- a/.changeset/sixty-fireants-build.md
+++ b/.changeset/sixty-fireants-build.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/use-aria-link": patch
+---
+
+fix onclick deprecation warning for Button as Link (#4493)

--- a/packages/hooks/use-aria-link/src/index.ts
+++ b/packages/hooks/use-aria-link/src/index.ts
@@ -19,6 +19,8 @@ export interface AriaLinkOptions extends AriaLinkProps {
   "aria-current"?: DOMAttributes["aria-current"];
   /** Whether the link is disabled. */
   isDisabled?: boolean;
+  /** The role of the element */
+  role?: string;
   /**
    * The HTML element used to render the link, e.g. 'a', or 'span'.
    * @default 'a'
@@ -46,6 +48,7 @@ export function useAriaLink(props: AriaLinkOptions, ref: RefObject<FocusableElem
     onPressEnd,
     // @ts-ignore
     onClick: deprecatedOnClick,
+    role,
     isDisabled,
     ...otherProps
   } = props;
@@ -61,7 +64,7 @@ export function useAriaLink(props: AriaLinkOptions, ref: RefObject<FocusableElem
 
   let isMobile = isIOS() || isAndroid();
 
-  if (deprecatedOnClick && typeof deprecatedOnClick === "function") {
+  if (deprecatedOnClick && typeof deprecatedOnClick === "function" && role !== "button") {
     warn(
       "onClick is deprecated, please use onPress instead. See: https://github.com/nextui-org/nextui/issues/4292",
       "useLink",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4493

## 📝 Description

<!--- Add a brief description -->

Users receive `[Next UI] [useLink]: onClick is deprecated, please use onPress instead.` when using `<Button as={Link} href="/">`. The `onClick` was introduced from `usePress` internally. This `onClick` would pass to `Link` and trigger that warning. This PR is to handle this case by checking the `role`. If using as a polymorphic component, the role will be `button`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

Got `[Next UI] [useLink]: onClick is deprecated, please use onPress instead.` while not defining any `onClick`.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

No such warning when using `<Button as={Link} href="/">`

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved deprecation warning for the Button component when used as a Link
  - Improved handling of `onClick` event for different element roles

- **New Features**
  - Added optional `role` property to customize element behavior
  - Enhanced flexibility for link and button interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->