### PR TITLE
fix(avatar): title type in Avatar

### DIFF
--- a/.changeset/quick-peas-care.md
+++ b/.changeset/quick-peas-care.md
@@ -1,0 +1,5 @@
+---
+"@nextui-org/alert": patch
+---
+
+fix title type in Avatar (#4525)

--- a/apps/docs/content/docs/components/alert.mdx
+++ b/apps/docs/content/docs/components/alert.mdx
@@ -138,7 +138,7 @@ Alert has the following slots:
   data={[
     {
       attribute: "title",
-      type: "string",
+      type: "ReactNode",
       description: "The alert title",
       default: "-"
     },

--- a/packages/components/alert/src/alert.tsx
+++ b/packages/components/alert/src/alert.tsx
@@ -62,7 +62,7 @@ const Alert = forwardRef<"div", AlertProps>((props, ref) => {
         {customIcon || <IconComponent {...getAlertIconProps()} />}
       </div>
       <div {...getMainWrapperProps()}>
-        {title && <div {...getTitleProps()}>{title}</div>}
+        {!isEmpty(title) && <div {...getTitleProps()}>{title}</div>}
         {!isEmpty(description) && <div {...getDescriptionProps()}>{description}</div>}
         {children}
       </div>

--- a/packages/components/alert/src/use-alert.ts
+++ b/packages/components/alert/src/use-alert.ts
@@ -9,7 +9,7 @@ import {alert} from "@nextui-org/theme";
 import {useControlledState} from "@react-stately/utils";
 import {dataAttr, isEmpty, objectToDeps} from "@nextui-org/shared-utils";
 
-interface Props extends HTMLNextUIProps<"div"> {
+interface Props extends Omit<HTMLNextUIProps<"div">, "title"> {
   /**
    * Ref to the DOM node.
    */

--- a/packages/components/alert/src/use-alert.ts
+++ b/packages/components/alert/src/use-alert.ts
@@ -17,7 +17,7 @@ interface Props extends HTMLNextUIProps<"div"> {
   /**
    * title of the alert message
    */
-  title?: string;
+  title?: ReactNode;
   /**
    * description of the alert message
    */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes #4525

## 📝 Description

Change `title` type from `string` to `ReactNode`.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

This throws typing error.

```tsx
<Alert color="primary" title={<strong>Some content</strong>} />
```

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

![image](https://github.com/user-attachments/assets/4f4bb0b5-adae-4318-91fd-8b5198b9922a)


## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

No

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Alert component to support more flexible title and description props.
  - Allows rendering of complex React elements in Alert titles and descriptions.

- **Bug Fixes**
  - Improved title rendering logic to only display non-empty titles.

- **Documentation**
  - Updated Alert component documentation to reflect new prop types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->