### PR TITLE
refactor: remove unnecessary props types

### DIFF
--- a/.changeset/dirty-poets-cover.md
+++ b/.changeset/dirty-poets-cover.md
@@ -1,0 +1,9 @@
+---
+"@nextui-org/accordion": patch
+"@nextui-org/listbox": patch
+"@nextui-org/snippet": patch
+"@nextui-org/menu": patch
+"@nextui-org/user": patch
+---
+
+remove unnecessary types

--- a/.changeset/dirty-poets-cover.md
+++ b/.changeset/dirty-poets-cover.md
@@ -1,9 +1,0 @@
----
-"@nextui-org/accordion": patch
-"@nextui-org/listbox": patch
-"@nextui-org/snippet": patch
-"@nextui-org/menu": patch
-"@nextui-org/user": patch
----
-
-remove unnecessary types

--- a/apps/docs/content/docs/components/accordion.mdx
+++ b/apps/docs/content/docs/components/accordion.mdx
@@ -327,19 +327,19 @@ Here's an example of how to customize the accordion styles:
   data={[
     {
       attribute: "children",
-      type: "ReactNode | string",
+      type: "ReactNode",
       description: "The content of the component.",
       default: "-"
     },
     {
       attribute: "title",
-      type: "ReactNode | string",
+      type: "ReactNode",
       description: "The accordion item title.",
       default: "-"
     },
     {
       attribute: "subtitle",
-      type: "ReactNode | string",
+      type: "ReactNode",
       description: "The accordion item subtitle.",
       default: "-"
     },

--- a/apps/docs/content/docs/components/navbar.mdx
+++ b/apps/docs/content/docs/components/navbar.mdx
@@ -412,7 +412,7 @@ When the `NavbarItem` is active, it will have a `data-active` attribute. You can
   data={[
     {
       attribute: "icon",
-      type: "ReactNode | ((isOpen: boolean | undefined) => ReactNode | null)",
+      type: "ReactNode | ((isOpen: boolean | undefined) => ReactNode)",
       description: "The icon to render as the navbar menu toggle.",
       default: "-"
     },

--- a/packages/components/accordion/src/accordion-item.tsx
+++ b/packages/components/accordion/src/accordion-item.tsx
@@ -40,7 +40,7 @@ const AccordionItem = forwardRef<"button", AccordionItemProps>((props, ref) => {
 
   const willChange = useWillChange();
 
-  const indicatorContent = useMemo<ReactNode | null>(() => {
+  const indicatorContent = useMemo<ReactNode>(() => {
     if (typeof indicator === "function") {
       return indicator({indicator: <ChevronIcon />, isOpen, isDisabled});
     }

--- a/packages/components/accordion/src/base/accordion-item-base.tsx
+++ b/packages/components/accordion/src/base/accordion-item-base.tsx
@@ -33,15 +33,15 @@ export interface Props<T extends object = {}>
   /**
    * The content of the component.
    */
-  children?: ReactNode | null;
+  children?: ReactNode;
   /**
    * The accordion item title.
    */
-  title?: ReactNode | string;
+  title?: ReactNode;
   /**
    * The accordion item subtitle.
    */
-  subtitle?: ReactNode | string;
+  subtitle?: ReactNode;
   /**
    * The accordion item `expanded` indicator, it's usually an arrow icon.
    * If you pass a function, NextUI will expose the current indicator and the open status,

--- a/packages/components/listbox/src/base/listbox-item-base.tsx
+++ b/packages/components/listbox/src/base/listbox-item-base.tsx
@@ -25,15 +25,15 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"li", T>, "childre
   /**
    * The content of the component.
    */
-  children?: ReactNode | null;
+  children?: ReactNode;
   /**
    * The listbox item title.
    */
-  title?: ReactNode | string;
+  title?: ReactNode;
   /**
    * The listbox item subtitle.
    */
-  description?: ReactNode | string;
+  description?: ReactNode;
   /**
    * The listbox item start content.
    */

--- a/packages/components/listbox/src/listbox-item.tsx
+++ b/packages/components/listbox/src/listbox-item.tsx
@@ -29,7 +29,7 @@ const ListboxItem = (props: ListboxItemProps) => {
     getSelectedIconProps,
   } = useListboxItem(props);
 
-  const selectedContent = useMemo<ReactNode | null>(() => {
+  const selectedContent = useMemo<ReactNode>(() => {
     const defaultIcon = (
       <ListboxSelectedIcon disableAnimation={disableAnimation} isSelected={isSelected} />
     );

--- a/packages/components/menu/src/base/menu-item-base.tsx
+++ b/packages/components/menu/src/base/menu-item-base.tsx
@@ -25,19 +25,19 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"li", T>, "childre
   /**
    * The content of the component.
    */
-  children?: ReactNode | null;
+  children?: ReactNode;
   /**
    * The menu item title.
    */
-  title?: ReactNode | string;
+  title?: ReactNode;
   /**
    * The menu item subtitle.
    */
-  description?: ReactNode | string;
+  description?: ReactNode;
   /**
    * The menu item keyboard shortcut.
    */
-  shortcut?: ReactNode | string;
+  shortcut?: ReactNode;
   /**
    * The menu item start content.
    */

--- a/packages/components/menu/src/menu-item.tsx
+++ b/packages/components/menu/src/menu-item.tsx
@@ -32,7 +32,7 @@ const MenuItem = (props: MenuItemProps) => {
     getSelectedIconProps,
   } = useMenuItem(props);
 
-  const selectedContent = useMemo<ReactNode | null>(() => {
+  const selectedContent = useMemo<ReactNode>(() => {
     const defaultIcon = (
       <MenuSelectedIcon disableAnimation={disableAnimation} isSelected={isSelected} />
     );

--- a/packages/components/snippet/src/use-snippet.ts
+++ b/packages/components/snippet/src/use-snippet.ts
@@ -24,7 +24,7 @@ export interface UseSnippetProps extends Omit<HTMLNextUIProps, "onCopy">, Snippe
    * The content of the snippet.
    * if `string[]` is passed, it will be rendered as a multi-line snippet.
    */
-  children?: React.ReactNode | string | string[];
+  children?: React.ReactNode | string[];
   /**
    * The symbol to show before the snippet.
    * @default "$"

--- a/packages/components/tabs/src/base/tab-item-base.ts
+++ b/packages/components/tabs/src/base/tab-item-base.ts
@@ -4,11 +4,11 @@ interface Props<T extends object = {}> extends Omit<ItemProps<"button", T>, "chi
   /**
    * The content of the component.
    */
-  children?: ReactNode | null;
+  children?: ReactNode;
   /**
    * The title of the component.
    */
-  title?: ReactNode | null;
+  title?: ReactNode;
   /**
    *  A string representation of the item's contents. Use this when the title is not readable.
    *  This will be used as native `title` attribute.

--- a/packages/components/user/src/use-user.ts
+++ b/packages/components/user/src/use-user.ts
@@ -17,11 +17,11 @@ interface Props {
   /**
    * The user name.
    */
-  name: ReactNode | string;
+  name: ReactNode;
   /**
    * The user information, like email, phone, etc.
    */
-  description?: ReactNode | string;
+  description?: ReactNode;
   /**
    * Whether the user can be focused.
    * @default false


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

<!--- Add a brief description -->

Given that `ReactNode` already unions `string` and `null`, we don't need to union them again.

```tsx
type ReactNode =
    | ReactElement
    | string
    | number
    | ReactFragment
    | ReactPortal
    | boolean
    | null
    | undefined
    | DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES[keyof DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_REACT_NODES];
```


## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated type definitions for various components to improve type safety
	- Refined prop types for Accordion, Navbar, Listbox, Menu, Snippet, Tabs, and User components
	- Removed string and null options from several component properties
	- Enforced stricter React node type requirements across multiple components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->